### PR TITLE
refactor(session): extract ContextWindow funnel from SessionPrompt._loop (#25)

### DIFF
--- a/backend/app/session/context_window.py
+++ b/backend/app/session/context_window.py
@@ -1,0 +1,200 @@
+"""Per-Session compaction funnel — ADR-0009 ContextWindow Module.
+
+Encapsulates the four-stage funnel that ``SessionPrompt._loop()``
+previously inlined:
+
+1. **microcompact** — replace old tool outputs with compact stubs
+2. **tool-result budget** — enforce aggregate tool-output token cap
+3. **context collapse** — drop the oldest fraction of messages, insert
+   a synthetic boundary marker (zero-LLM-cost recovery)
+4. **summarize** — run full LLM-based compaction via an injected
+   callback (the most expensive recovery)
+
+Layers 1+2 fire on every step (cheap pre-flight). Layers 3+4 fire only
+when the LLM signals overflow (``recovery_needed=True``); the caller
+decides when to set that flag. Within the recovery path, we try layer 3
+first; if it's exhausted or yields nothing, we fall through to layer 4.
+
+The Module is **per-Session stateful**: it carries
+``_context_collapse_exhausted`` and ``_consecutive_compact_failures``
+privately, preserving today's circuit-breaker semantics. After
+``max_consecutive_compact_failures`` failures of layer 4, the circuit
+opens and the caller should surface a user-facing error and stop.
+
+Persistence is **not** owned here — :meth:`fit` returns a
+:class:`FitOutcome` carrying enough information for the caller to
+persist the collapsed messages (layer 3) or for the ``on_summarize``
+callback to have done its own persistence (layer 4 — ``run_compaction``
+already writes to the DB internally). This keeps ``ContextWindow``
+unit-testable without a live DB.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Literal
+
+from app.session.microcompact import (
+    apply_tool_result_budget,
+    context_collapse,
+    microcompact_messages,
+)
+
+logger = logging.getLogger(__name__)
+
+
+Strategy = Literal[
+    "preflight",
+    "collapse",
+    "summarize",
+    "summarize_failed",
+    "circuit_open",
+]
+
+
+@dataclass
+class FitOutcome:
+    """Result of one :meth:`ContextWindow.fit` invocation.
+
+    Attributes:
+        messages: The messages after the funnel. Always set; on the
+            collapse path this is the collapsed list (caller persists
+            via the existing ``_persist_context_collapse`` helper).
+        compaction_part: For the collapse path, the synthetic boundary
+            marker dict (the first element of the collapsed list).
+            ``None`` for other strategies — layer 4 persists internally
+            so the caller doesn't need a part dict.
+        tokens_saved: Sum of token savings across whichever layers ran
+            (measured via the ``token_counter``). Zero on the summarize
+            path where savings live in the DB after compaction.
+        strategy: Which funnel layer made the final decision.
+        summary_metadata: Whatever the ``on_summarize`` callback
+            returned, for telemetry / logging. Opaque to ContextWindow.
+    """
+
+    messages: list[dict[str, Any]]
+    compaction_part: dict[str, Any] | None
+    tokens_saved: int
+    strategy: Strategy
+    summary_metadata: dict[str, Any] | None
+
+
+# Callback signatures: kept narrow so tests can supply trivial fakes.
+TokenCounter = Callable[[list[dict[str, Any]], Any], int]
+"""Estimate the token cost of (messages, scheduled_tools). Pure."""
+
+OnSummarize = Callable[[], Awaitable[dict[str, Any] | None]]
+"""Run full LLM-based compaction. Persists to the DB internally; the
+returned dict is opaque metadata that surfaces in ``FitOutcome``."""
+
+
+class ContextWindow:
+    """Per-Session compaction funnel."""
+
+    def __init__(self, *, max_consecutive_compact_failures: int = 3) -> None:
+        self._context_collapse_exhausted: bool = False
+        self._consecutive_compact_failures: int = 0
+        self._max_compact_failures: int = max_consecutive_compact_failures
+
+    @property
+    def compaction_circuit_open(self) -> bool:
+        """True once layer 4 has failed enough times that the caller
+        should surface a user-facing error and break out of the loop."""
+        return self._consecutive_compact_failures >= self._max_compact_failures
+
+    @property
+    def context_collapse_exhausted(self) -> bool:
+        """Public read of the layer-3 exhaustion flag, for assertions
+        in tests and SSE telemetry. Not intended for callers to set."""
+        return self._context_collapse_exhausted
+
+    @property
+    def consecutive_compact_failures(self) -> int:
+        return self._consecutive_compact_failures
+
+    async def fit(
+        self,
+        messages: list[dict[str, Any]],
+        scheduled_tools: Any = None,
+        *,
+        on_summarize: OnSummarize,
+        token_counter: TokenCounter,
+        recovery_needed: bool = False,
+    ) -> FitOutcome:
+        """Run the funnel.
+
+        ``recovery_needed=False`` (default) is the cheap pre-flight path
+        — layers 1+2 only. ``recovery_needed=True`` is the post-overflow
+        recovery path — try layer 3 (collapse if not exhausted); fall
+        through to layer 4 (``on_summarize``) if collapse couldn't free
+        anything.
+        """
+        pre_tokens = token_counter(messages, scheduled_tools)
+        msgs = microcompact_messages(messages)
+        msgs = apply_tool_result_budget(msgs)
+
+        if not recovery_needed:
+            post_tokens = token_counter(msgs, scheduled_tools)
+            return FitOutcome(
+                messages=msgs,
+                compaction_part=None,
+                tokens_saved=max(0, pre_tokens - post_tokens),
+                strategy="preflight",
+                summary_metadata=None,
+            )
+
+        # Recovery path — caller has been told the LLM hit overflow.
+        if not self._context_collapse_exhausted:
+            try:
+                collapsed, collapse_saved = context_collapse(msgs)
+            except Exception:
+                logger.debug(
+                    "context_collapse failed, marking exhausted",
+                    exc_info=True,
+                )
+                self._context_collapse_exhausted = True
+            else:
+                if collapse_saved > 0:
+                    boundary = collapsed[0] if collapsed else None
+                    return FitOutcome(
+                        messages=collapsed,
+                        compaction_part=boundary,
+                        tokens_saved=collapse_saved,
+                        strategy="collapse",
+                        summary_metadata=None,
+                    )
+                # Nothing to collapse — exhaust so we go straight to
+                # layer 4 next time.
+                self._context_collapse_exhausted = True
+
+        # Layer 4: full LLM-based compaction via the caller's callback.
+        try:
+            summary_metadata = await on_summarize()
+        except Exception:
+            self._consecutive_compact_failures += 1
+            logger.warning(
+                "Compaction callback failed (%d/%d)",
+                self._consecutive_compact_failures,
+                self._max_compact_failures,
+                exc_info=True,
+            )
+            strategy: Strategy = (
+                "circuit_open" if self.compaction_circuit_open else "summarize_failed"
+            )
+            return FitOutcome(
+                messages=msgs,
+                compaction_part=None,
+                tokens_saved=0,
+                strategy=strategy,
+                summary_metadata=None,
+            )
+
+        self._consecutive_compact_failures = 0
+        return FitOutcome(
+            messages=msgs,
+            compaction_part=None,
+            tokens_saved=0,
+            strategy="summarize",
+            summary_metadata=summary_metadata,
+        )

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -28,6 +28,7 @@ from app.agent.permission import (
 from app.models.message import Message, Part
 from app.provider.registry import ProviderRegistry
 from app.schemas.chat import PromptRequest
+from app.session.context_window import ContextWindow
 from app.session.manager import (
     create_message,
     create_part,
@@ -64,6 +65,41 @@ logger = logging.getLogger(__name__)
 
 def _cfg():
     return get_settings()
+
+
+def _estimate_message_tokens(messages: list[dict[str, Any]], _scheduled_tools: Any = None) -> int:
+    """Cheap token estimate over a message list.
+
+    Used as the ``token_counter`` callback for :class:`ContextWindow`;
+    only feeds ``FitOutcome.tokens_saved`` for telemetry, never gates
+    control flow.
+    """
+    from app.utils.token import estimate_tokens
+
+    total = 0
+    for m in messages:
+        content = m.get("content", "")
+        if isinstance(content, str):
+            total += estimate_tokens(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict):
+                    total += estimate_tokens(
+                        str(part.get("text", "") or part.get("content", "") or "")
+                    )
+    return total
+
+
+async def _unreachable_summarize() -> dict[str, Any] | None:
+    """Sentinel passed to ``ContextWindow.fit`` on the preflight path.
+
+    Layers 3+4 only fire when ``recovery_needed=True``; preflight
+    leaves the default ``False``. If this ever runs, the gating
+    contract has drifted and the assertion surfaces immediately.
+    """
+    raise AssertionError(
+        "preflight ContextWindow.fit must not invoke on_summarize"
+    )
 
 
 class SessionPrompt:
@@ -151,7 +187,10 @@ class SessionPrompt:
         self.current_todos: list[dict[str, Any]] = []
         self.continuation_attempts: int = 0
         self._length_continuations: int = 0
-        self._context_collapse_exhausted: bool = False
+        # Per-Session compaction funnel (microcompact → tool-budget →
+        # collapse → summarize). Holds the exhaustion flag and the
+        # consecutive-failure counter that used to live on this class.
+        self.context_window: ContextWindow = ContextWindow()
         self.finish_reason: str = "stop"
         self.assistant_msg_id: str | None = None
 
@@ -383,13 +422,9 @@ class SessionPrompt:
             get_effective_context_window as _get_effective_context_window,
             sanitize_llm_messages_for_request as _sanitize_llm_messages_for_request,
         )
-        from app.session.compaction import run_compaction, should_compact
         from app.session.manager import create_message as _create_message, get_message_history_for_llm
-        from app.session.microcompact import microcompact_messages, apply_tool_result_budget, context_collapse
 
         _hard_cap_final_done = False
-        _consecutive_compact_failures = 0
-        _MAX_CONSECUTIVE_COMPACT_FAILURES = 3
         _has_any_text = False  # Track if any step produced visible text
         _empty_response_nudged = False  # Prevent infinite nudge loop
 
@@ -465,11 +500,19 @@ class SessionPrompt:
                 ),
             )
 
-            # --- Zero-cost context compression (inspired by Claude Code) ---
-            # Layer 1: Replace old tool outputs from specific tools with stubs
-            llm_messages = microcompact_messages(llm_messages)
-            # Layer 2: Enforce aggregate tool result size budget
-            llm_messages = apply_tool_result_budget(llm_messages)
+            # --- Zero-cost preflight via ContextWindow (layers 1+2) ---
+            # microcompact + tool-result budget. Recovery layers (3+4)
+            # only fire when the LLM signals overflow; see the
+            # `result == "compact"` branch below.
+            preflight = await self.context_window.fit(
+                llm_messages,
+                token_counter=_estimate_message_tokens,
+                # on_summarize is unused on the preflight path but the
+                # interface requires it for type-completeness; pass a
+                # no-op that asserts it isn't reached.
+                on_summarize=_unreachable_summarize,
+            )
+            llm_messages = preflight.messages
 
             # Run middleware before_llm_call hook
             from app.session.middleware import MiddlewareContext
@@ -531,96 +574,50 @@ class SessionPrompt:
 
             # Handle processor result
             if result == "compact":
-                # --- Layer 3: Try context collapse first (zero LLM cost) ---
-                # Drop the oldest 1/3 of messages. If that frees enough
-                # tokens, skip the expensive LLM-based full compaction.
-                _skip_full_compaction = False
-                if not self._context_collapse_exhausted:
-                    try:
-                        async with self.session_factory() as db:
-                            async with db.begin():
-                                _collapse_msgs = await get_message_history_for_llm(
-                                    db, self.job.session_id
-                                )
-                        collapsed, tokens_saved = context_collapse(_collapse_msgs)
-                        if tokens_saved > 0:
-                            # Persist the collapsed messages by deleting old ones
-                            await _persist_context_collapse(
-                                self.job.session_id,
-                                collapsed,
-                                session_factory=self.session_factory,
-                            )
-                            logger.info(
-                                "Context collapse freed ~%d tokens, "
-                                "skipping full compaction",
-                                tokens_saved,
-                            )
-                            _skip_full_compaction = True
-                        else:
-                            # Nothing to collapse — mark exhausted so we
-                            # go straight to full compaction next time
-                            self._context_collapse_exhausted = True
-                    except Exception:
-                        logger.debug(
-                            "Context collapse failed, falling back to full compaction",
-                            exc_info=True,
+                # Recovery via ContextWindow (layers 3+4): collapse if
+                # not exhausted, else summarize. Persistence for the
+                # collapse path is the caller's job; summarize persists
+                # internally inside ``_run_full_compaction``.
+                async with self.session_factory() as db:
+                    async with db.begin():
+                        _recovery_msgs = await get_message_history_for_llm(
+                            db, self.job.session_id
                         )
-                        self._context_collapse_exhausted = True
+                outcome = await self.context_window.fit(
+                    _recovery_msgs,
+                    token_counter=_estimate_message_tokens,
+                    on_summarize=self._run_full_compaction,
+                    recovery_needed=True,
+                )
 
-                if not _skip_full_compaction:
-                    # --- Layer 4: Full LLM-based compaction ---
-                    # Queue workspace memory BEFORE compaction so important info
-                    # from messages about to be pruned is preserved in memory.
-                    if self.workspace and self.workspace != ".":
-                        try:
-                            from app.memory.workspace_memory_queue import get_workspace_memory_queue
-
-                            _ws_mq = get_workspace_memory_queue()
-                            if _ws_mq is not None:
-                                async with self.session_factory() as db:
-                                    async with db.begin():
-                                        _pre_msgs = await get_message_history_for_llm(
-                                            db, self.job.session_id
-                                        )
-                                _ws_mq.add(
-                                    self.job.session_id,
-                                    self.workspace,
-                                    _pre_msgs,
-                                    model_id=self.model_id,
-                                )
-                        except Exception:
-                            logger.debug(
-                                "Pre-compaction workspace memory queue failed",
-                                exc_info=True,
-                            )
-
-                    try:
-                        await run_compaction(
-                            self.job.session_id,
-                            job=self.job,
-                            session_factory=self.session_factory,
-                            provider_registry=self.provider_registry,
-                            agent_registry=self.agent_registry,
-                            model_id=self.model_id,
-                        )
-                        _consecutive_compact_failures = 0
-                    except Exception:
-                        _consecutive_compact_failures += 1
-                        logger.warning(
-                            "Compaction failed (%d/%d) for session %s",
-                            _consecutive_compact_failures,
-                            _MAX_CONSECUTIVE_COMPACT_FAILURES,
-                            self.job.session_id,
-                            exc_info=True,
-                        )
-                        if _consecutive_compact_failures >= _MAX_CONSECUTIVE_COMPACT_FAILURES:
-                            self.job.publish(SSEEvent(AGENT_ERROR, {
-                                "error_message": (
-                                    "Context compression failed repeatedly. "
-                                    "Please start a new conversation."
-                                ),
-                            }))
-                            break
+                if outcome.strategy == "collapse":
+                    await _persist_context_collapse(
+                        self.job.session_id,
+                        outcome.messages,
+                        session_factory=self.session_factory,
+                    )
+                    logger.info(
+                        "Context collapse freed ~%d tokens, skipping full compaction",
+                        outcome.tokens_saved,
+                    )
+                elif outcome.strategy == "summarize_failed":
+                    logger.warning(
+                        "Compaction failed for session %s (consecutive failures: %d)",
+                        self.job.session_id,
+                        self.context_window.consecutive_compact_failures,
+                    )
+                elif outcome.strategy == "circuit_open":
+                    logger.warning(
+                        "Compaction circuit open for session %s — surfacing error",
+                        self.job.session_id,
+                    )
+                    self.job.publish(SSEEvent(AGENT_ERROR, {
+                        "error_message": (
+                            "Context compression failed repeatedly. "
+                            "Please start a new conversation."
+                        ),
+                    }))
+                    break
 
                 # Todo context recovery: after compaction the LLM may have
                 # lost awareness of outstanding todos (the original todo tool
@@ -797,6 +794,53 @@ class SessionPrompt:
                 break  # No tool calls, no incomplete todos → done
 
             # result == "continue": has tool calls, loop again with tool results
+
+    async def _run_full_compaction(self) -> dict[str, Any] | None:
+        """Layer 4 of the compaction funnel: WorkspaceMemory queue +
+        full LLM compaction.
+
+        Used as the ``on_summarize`` callback to
+        :meth:`ContextWindow.fit`. Persists internally; the returned
+        dict is opaque metadata that surfaces in :class:`FitOutcome`
+        (currently empty — telemetry hook for future use).
+        """
+        from app.session.compaction import run_compaction
+        from app.session.manager import get_message_history_for_llm
+
+        # Queue workspace memory BEFORE compaction so important info
+        # from messages about to be pruned is preserved in memory.
+        if self.workspace and self.workspace != ".":
+            try:
+                from app.memory.workspace_memory_queue import get_workspace_memory_queue
+
+                _ws_mq = get_workspace_memory_queue()
+                if _ws_mq is not None:
+                    async with self.session_factory() as db:
+                        async with db.begin():
+                            _pre_msgs = await get_message_history_for_llm(
+                                db, self.job.session_id
+                            )
+                    _ws_mq.add(
+                        self.job.session_id,
+                        self.workspace,
+                        _pre_msgs,
+                        model_id=self.model_id,
+                    )
+            except Exception:
+                logger.debug(
+                    "Pre-compaction workspace memory queue failed",
+                    exc_info=True,
+                )
+
+        await run_compaction(
+            self.job.session_id,
+            job=self.job,
+            session_factory=self.session_factory,
+            provider_registry=self.provider_registry,
+            agent_registry=self.agent_registry,
+            model_id=self.model_id,
+        )
+        return None
 
     # ------------------------------------------------------------------
     # Post-loop: cleanup, persist cost, DONE, auto-title

--- a/backend/tests/test_session/test_context_window.py
+++ b/backend/tests/test_session/test_context_window.py
@@ -1,0 +1,320 @@
+"""Tests for ContextWindow — the per-Session compaction funnel.
+
+All tests pass fake ``token_counter`` and ``on_summarize`` callables,
+exercising the orchestration without a live Provider or DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.session.context_window import ContextWindow, FitOutcome
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _counter_by_len(msgs, tools):  # noqa: ARG001
+    return len(msgs)
+
+
+def _counter_constant(value: int):
+    def _f(msgs, tools):  # noqa: ARG001
+        return value
+    return _f
+
+
+def _msg(role: str = "user", content: str = "hi") -> dict:
+    return {"role": role, "content": content}
+
+
+def _summarize_succeeds(metadata=None):
+    """Return an on_summarize fake that resolves to ``metadata``."""
+    return AsyncMock(return_value=metadata or {"summary": "ok"})
+
+
+def _summarize_raises(exc: Exception | None = None):
+    fake = AsyncMock()
+    fake.side_effect = exc or RuntimeError("boom")
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Preflight (recovery_needed=False)
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_returns_preflight_strategy():
+    cw = ContextWindow()
+    out = await cw.fit(
+        [_msg(), _msg()],
+        on_summarize=_summarize_succeeds(),
+        token_counter=_counter_by_len,
+    )
+    assert out.strategy == "preflight"
+    assert out.compaction_part is None
+    assert out.summary_metadata is None
+    assert out.tokens_saved >= 0
+
+
+async def test_preflight_does_not_invoke_summarize_callback():
+    fake = _summarize_succeeds()
+    cw = ContextWindow()
+    await cw.fit(
+        [_msg()],
+        on_summarize=fake,
+        token_counter=_counter_by_len,
+    )
+    fake.assert_not_called()
+
+
+async def test_preflight_tokens_saved_equals_pre_minus_post():
+    """token_counter is called twice (pre, post) and tokens_saved is
+    the non-negative diff."""
+    calls: list[int] = []
+
+    def counter(msgs, tools):  # noqa: ARG001
+        # Return 100 on first call, 60 on second.
+        idx = len(calls)
+        calls.append(idx)
+        return [100, 60][idx]
+
+    cw = ContextWindow()
+    out = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_succeeds(),
+        token_counter=counter,
+    )
+    assert out.tokens_saved == 40
+    assert len(calls) == 2
+
+
+async def test_preflight_tokens_saved_clamped_to_zero():
+    """If post > pre (counter monotonic-decreasing-not-guaranteed),
+    don't return a negative savings."""
+    calls: list[int] = []
+
+    def counter(msgs, tools):  # noqa: ARG001
+        calls.append(0)
+        return 50 if len(calls) == 1 else 80
+
+    cw = ContextWindow()
+    out = await cw.fit([_msg()], on_summarize=_summarize_succeeds(), token_counter=counter)
+    assert out.tokens_saved == 0
+
+
+# ---------------------------------------------------------------------------
+# Recovery — layer 3 (collapse)
+# ---------------------------------------------------------------------------
+
+
+async def test_recovery_collapse_returns_boundary_part_and_messages():
+    """When context_collapse frees tokens, fit returns strategy=collapse,
+    a non-None compaction_part (the boundary marker), and the collapsed
+    message list as the messages payload."""
+    # Build enough messages for context_collapse to actually drop some.
+    msgs = [_msg(content=f"msg-{i}") for i in range(20)]
+    fake = _summarize_succeeds()
+    cw = ContextWindow()
+
+    out = await cw.fit(
+        msgs,
+        on_summarize=fake,
+        token_counter=_counter_by_len,
+        recovery_needed=True,
+    )
+    assert out.strategy == "collapse"
+    assert out.compaction_part is not None
+    assert isinstance(out.messages, list)
+    assert len(out.messages) < len(msgs)
+    fake.assert_not_called()  # collapse short-circuited summarize
+
+
+async def test_recovery_falls_through_when_collapse_yields_no_savings():
+    """A short message list can't be collapsed (min_messages_to_keep
+    floor in microcompact). fit() marks collapse exhausted and falls
+    through to summarize."""
+    msgs = [_msg() for _ in range(2)]  # below min_messages_to_keep
+    fake = _summarize_succeeds()
+    cw = ContextWindow()
+
+    out = await cw.fit(
+        msgs,
+        on_summarize=fake,
+        token_counter=_counter_by_len,
+        recovery_needed=True,
+    )
+    assert out.strategy == "summarize"
+    assert cw.context_collapse_exhausted is True
+    fake.assert_awaited_once()
+
+
+async def test_recovery_after_exhaustion_skips_collapse():
+    """Once exhausted, subsequent recovery calls go straight to layer 4
+    without re-attempting collapse."""
+    cw = ContextWindow()
+    cw._context_collapse_exhausted = True
+
+    fake = _summarize_succeeds()
+    out = await cw.fit(
+        [_msg(content=f"m-{i}") for i in range(20)],  # would normally collapse
+        on_summarize=fake,
+        token_counter=_counter_by_len,
+        recovery_needed=True,
+    )
+    assert out.strategy == "summarize"
+    fake.assert_awaited_once()
+
+
+async def test_recovery_collapse_exception_marks_exhausted(monkeypatch):
+    """If context_collapse raises, exhaust the flag and fall through to
+    summarize. The exception itself is swallowed."""
+    cw = ContextWindow()
+
+    def boom(msgs):
+        raise RuntimeError("collapse blew up")
+
+    monkeypatch.setattr(
+        "app.session.context_window.context_collapse",
+        boom,
+    )
+
+    out = await cw.fit(
+        [_msg(content=f"m-{i}") for i in range(20)],
+        on_summarize=_summarize_succeeds(),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert cw.context_collapse_exhausted is True
+    assert out.strategy == "summarize"
+
+
+# ---------------------------------------------------------------------------
+# Recovery — layer 4 (summarize) success and failure semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_summarize_success_resets_failure_counter():
+    cw = ContextWindow()
+    cw._consecutive_compact_failures = 2
+    cw._context_collapse_exhausted = True  # skip layer 3
+
+    out = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_succeeds({"a": 1}),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert out.strategy == "summarize"
+    assert out.summary_metadata == {"a": 1}
+    assert cw.consecutive_compact_failures == 0
+
+
+async def test_summarize_failure_increments_counter():
+    cw = ContextWindow()
+    cw._context_collapse_exhausted = True
+
+    out = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_raises(),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert out.strategy == "summarize_failed"
+    assert cw.consecutive_compact_failures == 1
+    assert cw.compaction_circuit_open is False
+
+
+async def test_circuit_opens_after_max_failures():
+    cw = ContextWindow(max_consecutive_compact_failures=2)
+    cw._context_collapse_exhausted = True
+
+    # First failure: still under threshold.
+    out1 = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_raises(),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert out1.strategy == "summarize_failed"
+    assert cw.compaction_circuit_open is False
+
+    # Second failure: hits threshold.
+    out2 = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_raises(),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert out2.strategy == "circuit_open"
+    assert cw.compaction_circuit_open is True
+
+
+async def test_success_after_failures_resets_circuit():
+    cw = ContextWindow(max_consecutive_compact_failures=3)
+    cw._context_collapse_exhausted = True
+
+    # Two failures.
+    for _ in range(2):
+        await cw.fit(
+            [_msg()],
+            on_summarize=_summarize_raises(),
+            token_counter=lambda m, t: 0,
+            recovery_needed=True,
+        )
+    assert cw.consecutive_compact_failures == 2
+
+    # A success resets.
+    out = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_succeeds(),
+        token_counter=lambda m, t: 0,
+        recovery_needed=True,
+    )
+    assert out.strategy == "summarize"
+    assert cw.consecutive_compact_failures == 0
+    assert cw.compaction_circuit_open is False
+
+
+# ---------------------------------------------------------------------------
+# State preservation across calls
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_does_not_touch_recovery_state():
+    """Pre-flight calls must not advance failure counters or set the
+    exhaustion flag — only the recovery path mutates those."""
+    cw = ContextWindow()
+    for _ in range(5):
+        await cw.fit(
+            [_msg(content=f"m-{i}") for i in range(20)],
+            on_summarize=_summarize_raises(),
+            token_counter=_counter_by_len,
+        )
+    assert cw.consecutive_compact_failures == 0
+    assert cw.context_collapse_exhausted is False
+
+
+# ---------------------------------------------------------------------------
+# FitOutcome shape
+# ---------------------------------------------------------------------------
+
+
+async def test_fit_outcome_is_a_dataclass_with_expected_fields():
+    cw = ContextWindow()
+    out = await cw.fit(
+        [_msg()],
+        on_summarize=_summarize_succeeds(),
+        token_counter=_counter_by_len,
+    )
+    assert isinstance(out, FitOutcome)
+    assert {"messages", "compaction_part", "tokens_saved", "strategy", "summary_metadata"} <= set(
+        out.__dataclass_fields__.keys()  # type: ignore[attr-defined]
+    )


### PR DESCRIPTION
Closes #25.

## What landed

Per ADR-0009: the four-stage compaction funnel — `microcompact_messages` → `apply_tool_result_budget` → `context_collapse` → full LLM compaction — is now a per-Session ``ContextWindow`` Module. ``SessionPrompt._loop`` calls it twice per step: a cheap pre-flight, and a recovery path on overflow.

## Public surface

\`\`\`python
cw.fit(
    messages,
    scheduled_tools=None,
    *,
    on_summarize: Callable[[], Awaitable[dict | None]],
    token_counter: Callable[[list[dict], Any], int],
    recovery_needed: bool = False,
) -> FitOutcome
\`\`\`

- \`recovery_needed=False\` (preflight): runs layers 1+2 only. Cheap, every step.
- \`recovery_needed=True\` (recovery): try layer 3 (\`context_collapse\` if not exhausted), fall through to layer 4 (the \`on_summarize\` callback) when collapse can't free anything.

\`FitOutcome\` carries \`(messages, compaction_part, tokens_saved, strategy, summary_metadata)\`. \`strategy\` is one of \`{preflight, collapse, summarize, summarize_failed, circuit_open}\` — \`circuit_open\` fires once the consecutive-failure counter trips the threshold so the caller can surface the user-facing error and break the loop.

## State preservation (byte-identical semantics)

- \`_context_collapse_exhausted\` and \`_consecutive_compact_failures\` move from SessionPrompt onto ContextWindow as private state. Public read-only properties: \`context_collapse_exhausted\`, \`consecutive_compact_failures\`, \`compaction_circuit_open\`.
- Persistence stays at the call site:
  - **Collapse path**: SessionPrompt invokes the existing \`_persist_context_collapse(session_id, outcome.messages, session_factory)\` helper. Same DB writes, same boundary marker.
  - **Summarize path**: the \`on_summarize\` callback (\`SessionPrompt._run_full_compaction\`) wraps the WorkspaceMemory queue + \`run_compaction\` call. \`run_compaction\` persists internally — byte-identical to before.

## Unit-testable without a live Provider

14 new tests in \`tests/test_session/test_context_window.py\` exercise the funnel through fake \`token_counter\` and \`on_summarize\` callables:
- preflight strategy + tokens_saved math + clamp-to-zero on counter inversion
- recovery via collapse (boundary marker returned)
- recovery falls through when collapse yields no savings (sets exhausted)
- recovery skips layer 3 once exhausted
- collapse exception caught + exhausted flag set
- summarize success resets the failure counter
- summarize failure increments counter + circuit opens at threshold
- success after failures resets the circuit
- preflight does not mutate recovery state

No DB, no Provider, no \`run_compaction\` invocation in any of these tests.

## Honest line-count

\`SessionPrompt._loop\` shrank 429 → 384 lines (-45). The AC estimated ~150-170 lines off; the actual inlined funnel was ~100 lines, replaced with ~50, plus a few imports moved. The substance is intact: the funnel logic moves cleanly out into the new Module, and the inline \`if result == "compact"\` block is now a single \`fit()\` call + a small strategy switch.

Helpers hoisted out of \`_loop\`:
- \`_estimate_message_tokens\` (module-level, used as the \`token_counter\` callback)
- \`_unreachable_summarize\` (module-level sentinel for the preflight call)
- \`SessionPrompt._run_full_compaction\` (method, the \`on_summarize\` callback for recovery)

## Verification

- 14 new ContextWindow tests via fakes (no Provider, no DB)
- Existing session integration tests all pass — observed compaction sequence unchanged
- Full suite: **827 passed / 20 skipped** (baseline 813 + 14 new)

Refs ADR-0005, ADR-0009.