### PR TITLE
docs(v2): ADR-0011 + README rewrite for macOS-only pivot (v2 PR 7/8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/openyak/openyak/stargazers"><img src="https://img.shields.io/github/stars/openyak/openyak?style=flat-square" alt="GitHub Stars" /></a>
   <a href="https://github.com/openyak/openyak/blob/main/LICENSE"><img src="https://img.shields.io/github/license/openyak/openyak?style=flat-square" alt="License" /></a>
   <a href="https://github.com/openyak/openyak/releases/latest"><img src="https://img.shields.io/github/v/release/openyak/openyak?style=flat-square" alt="Latest Release" /></a>
-  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square" alt="Platform: macOS | Windows | Linux" />
+  <img src="https://img.shields.io/badge/platform-macOS-blue?style=flat-square" alt="Platform: macOS" />
   <a href="https://github.com/openyak/openyak/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs Welcome" /></a>
 </p>
 
@@ -28,8 +28,8 @@ OpenYak is built for real work, not just one-off chat prompts.
 
 - **Work from your actual files.** Upload DOCX, XLSX, PPTX, PDFs, CSVs, and local project context, then ask for briefs, tables, follow-ups, plans, and reusable artifacts.
 - **Keep the workflow in one thread.** Start with analysis, continue into a RACI, ask for a follow-up email, and preserve context across long conversations.
-- **Choose your model path.** Use free models, bring your own API key, connect a ChatGPT subscription, or run local models through [Ollama](https://ollama.com).
-- **Stay local by default.** Files, conversations, memory, and generated artifacts are stored on your device. Cloud model calls go directly to the model provider you choose.
+- **Run models locally on macOS.** OpenYak v2 is built around [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) for Apple Silicon — install once with Homebrew or pip, then point OpenYak at `http://localhost:8000/v1`. For any other inference server, use the Custom Endpoint mode.
+- **Stay local by default.** Files, conversations, memory, and generated artifacts are stored on your device. There is no managed account and no hosted proxy — model calls go straight to whatever endpoint you point OpenYak at.
 - **Use it from another device.** Remote access lets you scan a QR code and send tasks to your desktop through a secure tunnel.
 
 ## What It Feels Like
@@ -97,21 +97,20 @@ Professional workflows include failure states. Upload errors and missing inputs 
 
 | Platform | Architecture | Formats |
 |----------|--------------|---------|
-| macOS | Apple Silicon / Intel | `.dmg`, `.app` |
-| Windows | x64 | `.exe` installer |
-| Linux | x64 | `.deb`, `.rpm` |
+| macOS | Apple Silicon | `.dmg`, `.app` |
 
 > [Download the latest release](https://github.com/openyak/openyak/releases/latest) or visit [open-yak.com/download](https://open-yak.com/download/).
 >
-> Linux users can also read [LINUX.md](LINUX.md) for requirements and troubleshooting.
+> v2.0.0 is **macOS-only** (Apple Silicon). Windows and Linux builds were dropped — see [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md) for the rationale. v1.x binaries for those platforms remain on the [releases page](https://github.com/openyak/openyak/releases) but are no longer updated.
 
 ## Get Started
 
-1. **Install OpenYak** for your platform.
-2. **Connect a model** using free cloud models, your own API key, ChatGPT subscription, or local Ollama.
-3. **Start a new conversation** and attach a real file.
-4. **Ask for a deliverable**, not just a summary: brief, action plan, RACI, email, table, or artifact.
-5. **Review the result** in the chat and artifact panel, then continue in the same thread.
+1. **Install OpenYak** from the latest macOS release.
+2. **Install [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX)** — `brew install raullenchai/rapid-mlx/rapid-mlx` or `pip install rapid-mlx`, then run `rapid-mlx serve <model>` in a terminal. Or skip this step and use the Custom Endpoint mode to point at any other OpenAI-compatible server.
+3. **Open Settings → Providers** and confirm OpenYak detects your local endpoint at `http://localhost:8000/v1`.
+4. **Start a new conversation** and attach a real file.
+5. **Ask for a deliverable**, not just a summary: brief, action plan, RACI, email, table, or artifact.
+6. **Review the result** in the chat and artifact panel, then continue in the same thread.
 
 Example prompt:
 
@@ -123,27 +122,12 @@ Finally, write a follow-up email I can send to the team directly.
 
 ## Supported Providers
 
-### Cloud and Subscription
+OpenYak v2 ships with two model-access modes. There is no managed account, no hosted proxy, and no built-in catalog of cloud providers — see [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md) for why.
 
-| Provider | Access | Notes |
-|----------|--------|-------|
-| OpenRouter | Built-in | Free models and premium models |
-| OpenAI | BYOK | Bring your own API key |
-| Anthropic | BYOK | Bring your own API key |
-| Google | BYOK | Gemini models |
-| DeepSeek | BYOK | Direct provider key |
-| Groq | BYOK | Fast hosted inference |
-| Mistral | BYOK | Direct provider key |
-| xAI | BYOK | Grok models |
-| Qwen | BYOK | Direct provider key |
-| Kimi | BYOK | Moonshot models |
-| MiniMax | BYOK | Direct provider key |
-| Zhipu | BYOK | Direct provider key |
-| ChatGPT | Subscription | Use an existing ChatGPT Plus, Pro, Team, or Enterprise plan when available |
-
-### Local
-
-Run any model available through [Ollama](https://ollama.com). Local models are auto-detected and can be used without an internet connection.
+| Mode | Notes |
+|------|-------|
+| Rapid-MLX (Local) | Recommended runtime on Apple Silicon. Install via Homebrew or pip; OpenYak detects the CLI and connects to `http://localhost:8000/v1`. |
+| Custom Endpoint | Any OpenAI-compatible base URL — vLLM, llama.cpp server, an Ollama instance you manage yourself, a self-hosted gateway, or a colleague's MLX rig on the network. |
 
 ## Core Capabilities
 
@@ -153,7 +137,7 @@ Run any model available through [Ollama](https://ollama.com). Local models are a
 - **Long-context work:** continue from analysis to planning to follow-up without starting over.
 - **Remote access:** connect from mobile through QR code and Cloudflare Tunnel.
 - **Automations:** schedule recurring cleanup, reporting, and file workflows.
-- **Privacy controls:** local storage, BYOK options, and local model support.
+- **Privacy controls:** local storage, no managed account, and local-first model serving via Rapid-MLX.
 
 ## For Developers
 
@@ -180,25 +164,37 @@ This starts the backend on port `8000` and the frontend on port `3000`. For deep
 <details>
 <summary>Does my data leave my machine?</summary>
 
-Files, conversations, memory, and generated artifacts are stored locally. If you use a cloud model, the prompt and relevant context are sent directly to the model provider you selected. You can also use local Ollama models for offline work.
+Files, conversations, memory, and generated artifacts are stored locally. v2 has no managed account and no hosted proxy — model calls go directly to whatever endpoint you configure (Rapid-MLX on `localhost`, or whatever Custom Endpoint URL you point at). If you point at a remote endpoint, the prompt and relevant context obviously go there.
 </details>
 
 <details>
 <summary>Do I need an OpenYak account?</summary>
 
-No. OpenYak is designed to work without a required OpenYak account. You can use free models, bring provider keys, connect a subscription, or run local models depending on your setup.
+No. v2 removed managed accounts entirely. The only thing you need is an OpenAI-compatible model endpoint to point OpenYak at — by default, that means installing Rapid-MLX locally.
+</details>
+
+<details>
+<summary>What happened to the OpenYak free tier / hosted proxy?</summary>
+
+The hosted proxy at `api.open-yak.com` is being shut down 30 days after the v2.0.0 release. Existing v1 users will get an in-app notice and an email with migration instructions. v2 is local-first only — see [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md) for the rationale.
+</details>
+
+<details>
+<summary>What about Windows and Linux?</summary>
+
+v2 is macOS-only (Apple Silicon). v1.x binaries for Windows and Linux remain on the [releases page](https://github.com/openyak/openyak/releases) but are no longer updated. The pivot reasoning is in [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md).
 </details>
 
 <details>
 <summary>How is OpenYak different from ChatGPT or Claude.ai?</summary>
 
-OpenYak runs on your desktop and is designed around local files, artifacts, tools, and workflow continuity. Web chat products are great assistants; OpenYak is closer to a local workbench for files and repeatable office tasks.
+OpenYak runs on your Mac and is designed around local files, artifacts, tools, and workflow continuity. Web chat products are great assistants; OpenYak is closer to a local workbench for files and repeatable office tasks.
 </details>
 
 <details>
 <summary>Can I use it offline?</summary>
 
-Yes. Install Ollama, download a model, and OpenYak can run locally without cloud model calls.
+Yes. Install Rapid-MLX, pull a model with `rapid-mlx serve <model>`, and OpenYak runs entirely offline.
 </details>
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/openyak/openyak/stargazers"><img src="https://img.shields.io/github/stars/openyak/openyak?style=flat-square" alt="GitHub Stars" /></a>
   <a href="https://github.com/openyak/openyak/blob/main/LICENSE"><img src="https://img.shields.io/github/license/openyak/openyak?style=flat-square" alt="License" /></a>
   <a href="https://github.com/openyak/openyak/releases/latest"><img src="https://img.shields.io/github/v/release/openyak/openyak?style=flat-square" alt="Latest Release" /></a>
-  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square" alt="Platform: macOS | Windows | Linux" />
+  <img src="https://img.shields.io/badge/platform-macOS-blue?style=flat-square" alt="Platform: macOS" />
   <a href="https://github.com/openyak/openyak/pulls"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs Welcome" /></a>
 </p>
 
@@ -28,8 +28,8 @@ OpenYak 不是只用来问一句话的聊天框，而是为真实办公动线设
 
 - **直接处理真实文件。** 上传 DOCX、XLSX、PPTX、PDF、CSV 和本地项目上下文，生成 brief、表格、follow-up、计划和可复用 artifact。
 - **同一个线程走完整流程。** 先分析文件，再继续生成 RACI、follow-up 邮件、会议 agenda，不需要反复重讲背景。
-- **自由选择模型。** 使用免费模型、自带 API Key、接入 ChatGPT 订阅，或通过 [Ollama](https://ollama.com) 完全本地运行。
-- **默认本地优先。** 文件、对话、记忆和生成结果都存储在本机。使用云端模型时，只会直接请求你选择的模型提供商。
+- **在 macOS 本地运行模型。** OpenYak v2 围绕 Apple Silicon 上的 [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) 构建——通过 Homebrew 或 pip 安装一次，然后让 OpenYak 指向 `http://localhost:8000/v1`。需要其他推理服务，使用 Custom Endpoint 模式。
+- **默认本地优先。** 文件、对话、记忆和生成结果都存储在本机。v2 没有托管账户、没有云端代理——模型调用直接发给你配置的端点。
 - **可以从手机访问桌面 AI。** 开启远程访问后扫码连接，通过安全 tunnel 把任务发给桌面端执行。
 
 ## 它解决什么问题
@@ -97,21 +97,20 @@ OpenYak 可以在同一个线程里综合多份文件，并在右侧 artifact pa
 
 | 平台 | 架构 | 格式 |
 |------|------|------|
-| macOS | Apple Silicon / Intel | `.dmg`, `.app` |
-| Windows | x64 | `.exe` 安装包 |
-| Linux | x64 | `.deb`, `.rpm` |
+| macOS | Apple Silicon | `.dmg`, `.app` |
 
 > [下载最新版本](https://github.com/openyak/openyak/releases/latest) 或访问 [open-yak.com/download](https://open-yak.com/download/)。
 >
-> Linux 用户可以查看 [LINUX.md](LINUX.md) 了解依赖、安装和排障说明。
+> v2.0.0 **仅支持 macOS（Apple Silicon）**。Windows 和 Linux 构建已被取消——背景见 [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md)。这两个平台的 v1.x 安装包仍保留在 [releases 页](https://github.com/openyak/openyak/releases) 但不再更新。
 
 ## 快速开始
 
-1. **安装 OpenYak。** 下载适合你系统的安装包。
-2. **连接模型。** 使用免费云端模型、自带 API Key、接入 ChatGPT 订阅，或连接本地 Ollama。
-3. **新建会话并上传真实文件。**
-4. **直接说你要的交付物。** 比如 brief、行动计划、RACI、邮件、表格或 artifact。
-5. **检查结果并继续追问。** 在同一个线程里继续从分析推进到执行。
+1. **安装 OpenYak。** 下载最新的 macOS 版本。
+2. **安装 [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX)。** `brew install raullenchai/rapid-mlx/rapid-mlx` 或 `pip install rapid-mlx`，然后在终端运行 `rapid-mlx serve <模型>`。或者跳过这一步，使用 Custom Endpoint 模式指向其他 OpenAI 兼容服务。
+3. **打开 设置 → Providers** 并确认 OpenYak 检测到本地端点 `http://localhost:8000/v1`。
+4. **新建会话并上传真实文件。**
+5. **直接说你要的交付物。** 比如 brief、行动计划、RACI、邮件、表格或 artifact。
+6. **检查结果并继续追问。** 在同一个线程里继续从分析推进到执行。
 
 示例 prompt：
 
@@ -123,27 +122,12 @@ OpenYak 可以在同一个线程里综合多份文件，并在右侧 artifact pa
 
 ## 支持的模型提供商
 
-### 云端与订阅
+OpenYak v2 提供两种模型接入方式。没有托管账户、没有云端代理、不内置任何云服务商目录——背景见 [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md)。
 
-| 提供商 | 接入方式 | 说明 |
-|--------|----------|------|
-| OpenRouter | 内置 | 免费模型和高级模型 |
-| OpenAI | BYOK | 使用自己的 API Key |
-| Anthropic | BYOK | 使用自己的 API Key |
-| Google | BYOK | Gemini 模型 |
-| DeepSeek | BYOK | 直连提供商密钥 |
-| Groq | BYOK | 高速托管推理 |
-| Mistral | BYOK | 直连提供商密钥 |
-| xAI | BYOK | Grok 模型 |
-| Qwen | BYOK | 直连提供商密钥 |
-| Kimi | BYOK | Moonshot 模型 |
-| MiniMax | BYOK | 直连提供商密钥 |
-| 智谱 | BYOK | 直连提供商密钥 |
-| ChatGPT | 订阅 | 在可用时使用现有 ChatGPT Plus、Pro、Team 或 Enterprise 方案 |
-
-### 本地模型
-
-通过 [Ollama](https://ollama.com) 运行任意本地模型。OpenYak 会自动检测本地模型，也可以在无网络环境下工作。
+| 模式 | 说明 |
+|------|------|
+| Rapid-MLX（本地） | Apple Silicon 上的推荐运行时。通过 Homebrew 或 pip 安装；OpenYak 自动检测 CLI 并连接 `http://localhost:8000/v1`。 |
+| Custom Endpoint | 任何 OpenAI 兼容的 base URL——vLLM、llama.cpp server、自管理的 Ollama 实例、自建网关，或局域网内同事的 MLX 主机。 |
 
 ## 核心能力
 
@@ -153,7 +137,7 @@ OpenYak 可以在同一个线程里综合多份文件，并在右侧 artifact pa
 - **长上下文任务：** 从分析到计划再到 follow-up，不需要重新开始。
 - **远程访问：** 通过二维码和 Cloudflare Tunnel 从手机连接桌面端。
 - **自动化任务：** 定时清理、报告、文件整理和重复工作流。
-- **隐私控制：** 本地存储、BYOK、自带订阅和本地模型支持。
+- **隐私控制：** 本地存储、无托管账户，通过 Rapid-MLX 实现本地优先的模型服务。
 
 ## 开发者
 
@@ -180,25 +164,37 @@ npm run dev:all
 <details>
 <summary>我的数据会离开本机吗？</summary>
 
-文件、对话、记忆和生成的 artifact 都存储在本机。使用云端模型时，prompt 和相关上下文会直接发送给你选择的模型提供商。你也可以使用 Ollama 本地模型进行离线工作。
+文件、对话、记忆和生成的 artifact 都存储在本机。v2 没有托管账户和云端代理——模型调用直接发到你配置的端点（默认是本机的 Rapid-MLX，或你设置的任意 Custom Endpoint URL）。如果你指向一个远程端点，prompt 和上下文当然会发送过去。
 </details>
 
 <details>
 <summary>需要 OpenYak 账号吗？</summary>
 
-不需要。OpenYak 不强制要求注册账号。你可以使用免费模型、自带 provider key、连接订阅，或使用本地模型。
+不需要。v2 完全移除了托管账户。你只需要一个 OpenAI 兼容的模型端点供 OpenYak 接入——默认就是本地安装的 Rapid-MLX。
+</details>
+
+<details>
+<summary>之前的 OpenYak 免费额度 / 云端代理怎么处理？</summary>
+
+`api.open-yak.com` 上的托管代理将在 v2.0.0 发布后 30 天关闭。现有 v1 用户会收到应用内通知和包含迁移说明的邮件。v2 仅本地优先——背景见 [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md)。
+</details>
+
+<details>
+<summary>Windows 和 Linux 怎么办？</summary>
+
+v2 仅支持 macOS（Apple Silicon）。Windows 和 Linux 的 v1.x 安装包仍保留在 [releases 页](https://github.com/openyak/openyak/releases) 但不再更新。背景见 [ADR-0011](docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md)。
 </details>
 
 <details>
 <summary>和 ChatGPT 或 Claude.ai 有什么区别？</summary>
 
-OpenYak 运行在你的桌面上，围绕本地文件、artifact、工具和连续工作流设计。网页版聊天助手很适合问答，OpenYak 更像一个可以处理文件和重复办公任务的本地工作台。
+OpenYak 运行在你的 Mac 上，围绕本地文件、artifact、工具和连续工作流设计。网页版聊天助手很适合问答，OpenYak 更像一个可以处理文件和重复办公任务的本地工作台。
 </details>
 
 <details>
 <summary>可以离线使用吗？</summary>
 
-可以。安装 Ollama 并下载模型后，OpenYak 可以在不调用云端模型的情况下本地运行。
+可以。安装 Rapid-MLX，用 `rapid-mlx serve <模型>` 拉起一个模型，OpenYak 即可完全离线运行。
 </details>
 
 <details>

--- a/docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md
+++ b/docs/adr/0011-v2-macos-only-rapid-mlx-pivot.md
@@ -1,0 +1,60 @@
+# v2: pivot OpenYak to macOS-only, drop hosted backends, recommend Rapid-MLX as the local runtime
+
+## Context
+
+OpenYak v1 shipped as a cross-platform desktop app (macOS / Windows / Linux) that fanned out across five model-access modes:
+
+1. **OpenYak Account** — managed proxy at `api.open-yak.com` with weekly free quota and paid credits (the SaaS).
+2. **BYOK** — direct keys to 21 catalog providers (OpenAI, Anthropic, Google, Groq, DeepSeek, Mistral, xAI, Together, DeepInfra, Cerebras, Cohere, Perplexity, Fireworks, Azure, Qwen, Kimi, MiniMax, Zhipu, SiliconFlow, Xiaomi, OpenRouter).
+3. **ChatGPT Subscription** — OAuth login with a ChatGPT Plus/Pro/Team account, OpenAI's Codex token-exchange flow.
+4. **Ollama** — bundled binary downloader + lifecycle manager + model library browser.
+5. **Local API + Custom Endpoint** — generic OpenAI-compatible base URL.
+
+Each lane added surface area: a settings panel, a registry adapter, telemetry plumbing, an i18n block, error-recovery copy, and at least one issue category. The five-lane fan-out also forced product copy to read like a comparison matrix instead of a recommendation: "free credits OR your own keys OR your subscription OR a local model OR a custom URL." Users who installed OpenYak to *try local models* still had to navigate around four cloud-shaped affordances first.
+
+A handful of harder-to-quantify pressures pushed us to consolidate now rather than later:
+
+- **Operational cost of `api.open-yak.com`.** The hosted proxy required token refresh plumbing, abuse-rate guards, weekly quota accounting, an OAuth flow, and an EC2 deploy pipeline. Per `feedback_proxy_deploy_full_app_sync.md` we had a 25-day prod incident from piecemeal scp; per the launch-history memos the SaaS framing ("we hold your tokens") was the consistent sore point at HN + Product Hunt feedback rounds.
+- **macOS is where the local-model story actually wins.** Apple Silicon has unified memory; MLX-based runtimes (Rapid-MLX in particular) get throughput on a MacBook that Windows + Linux equivalents need a discrete GPU to match. Bundling Ollama on Linux laptops without a GPU was, in practice, false advertising.
+- **Maintenance honesty.** A two-person team cannot keep 21 BYOK adapters, three OAuth flows, an Ollama lifecycle manager, *and* three platform installers continuously green. v1 spent more PRs on "fix provider X catalog drift" than on the local-model UX we want to be known for.
+
+## Decision
+
+Cut OpenYak v2 as a **macOS-only, local-first desktop app** with exactly two model-access modes:
+
+1. **Rapid-MLX (Local)** — the rebrand of the existing `local` provider, oriented around the user installing the [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) CLI (`brew install raullenchai/rapid-mlx/rapid-mlx` or `pip install rapid-mlx`) and pointing OpenYak at `http://localhost:8000/v1`.
+2. **Custom Endpoint** — generic OpenAI-compatible base URL for power users who want to point at any other inference server (vLLM, llama.cpp server, a self-hosted gateway, a colleague's MLX rig, etc.).
+
+Everything else is removed:
+
+- OpenYak Account / `api.open-yak.com` proxy mode → cut (PR 1, [#79](https://github.com/openyak/openyak/pull/79)). SaaS server scheduled for shutdown 30 days after v2.0.0 release.
+- ChatGPT Subscription → cut (PR 2, [#77](https://github.com/openyak/openyak/pull/77)).
+- BYOK + 21-provider catalog → cut (PR 3, [#78](https://github.com/openyak/openyak/pull/78)). `OpenRouterProvider` class is retained as a test fixture only.
+- Ollama → cut (PR 4, [#76](https://github.com/openyak/openyak/pull/76)). Users who want Ollama can still point Custom Endpoint at `http://localhost:11434/v1`; we just no longer manage the binary.
+- Windows + Linux builds → cut (PR 6, [#75](https://github.com/openyak/openyak/pull/75)).
+
+Rapid-MLX is **not bundled** as a Tauri sidecar in the v2.0.0 cut. PR 5 ([#80](https://github.com/openyak/openyak/pull/80)) only adds `GET /api/config/rapid-mlx/status` (probes `which rapid-mlx`) and a "please install Rapid-MLX" hint in the settings panel. Sidecar bundling is deferred — see "Considered options" below.
+
+## Consequences
+
+**What gets simpler.** The provider registry collapses to two modes and the settings page collapses to one card. Three OAuth flows (OpenYak email/code, ChatGPT Codex, Google login for the proxy) are gone. The 21-provider catalog with its per-provider key validation, masking, masked-display, error copy, and i18n keys is gone. Ollama's binary downloader, port allocator, lifecycle manager, model library browser, and update flow are gone. macOS-only means we drop a Tauri Windows installer + a Linux AppImage matrix from CI plus all per-platform branches in the codebase.
+
+**What gets harder.** A user who pulls v2.0.0 onto a Mac with no Rapid-MLX installed sees an "install this" hint instead of a working chat box. We accept that step in exchange for not pretending the local-model UX works without a local model server. The Custom Endpoint mode is the escape hatch for users who want a different runtime.
+
+**SaaS shutdown.** `api.open-yak.com` gets a 30-day EOL announcement at release time and is taken down on day 30. v1 users who depended on the free weekly quota or paid credits will be migrated to direct billing instructions for the underlying providers (mailing list captured in `reference_release_email.md`). v1 binaries continue to function until the SaaS endpoint goes away.
+
+**Cross-platform users.** v1 binaries for Windows + Linux remain downloadable from the [v1.x releases page](https://github.com/openyak/openyak/releases) but stop receiving updates. CHANGELOG and the v2.0.0 release notes will call this out explicitly so users can pin v1.x if they need cross-platform support.
+
+**ECS deploy footprint.** Per `feedback_ecs_release_deploy.md` and `reference_release_packaging.md`, the open-yak.com ECS service still needs the standard "replace all platform artifacts + verify before/after" treatment for the v2.0.0 cut, and the latest.json file is still uploaded last so cross-region downloads see consistent state. After the SaaS shutdown the ECS service downsizes to artifact serving only (no proxy backend).
+
+## Considered options
+
+**Bundle Rapid-MLX as a Tauri sidecar via PyInstaller.** Tempting because it would make `dmg → first launch → working chat` the golden path with no install step. Rejected for v2.0.0 because: Rapid-MLX is a Python package (~200MB once you pull in `mlx`, `mlx_lm`, transformers tokenizers, etc.) and PyInstaller bundling pushes our DMG from ~80MB to ~500MB+. Ship-quality codesigning + notarization on a 500MB DMG with embedded Python is a non-trivial second engineering project. The user-installed CLI path works today and lets the user upgrade Rapid-MLX independently of OpenYak releases. We can revisit sidecar bundling in v2.x once the user-install path has produced data on how often that step actually trips users.
+
+**Bundle Rapid-MLX runtime *and* spawn `rapid-mlx serve` from the backend.** Rejected for the same DMG-size reason, plus the lifecycle complexity (port allocation, model-download progress, OOM handling, restart on crash) is a meaningful chunk of work that the existing Custom Endpoint pattern already lets users solve for themselves with `rapid-mlx serve <model>` in a terminal.
+
+**Keep BYOK as a "pro" mode behind an advanced toggle.** Rejected: the maintenance cost of catalog drift is the same whether the entry point is hidden or surfaced. If we want a hosted-key story back later, we can add it back as a single OpenRouter-backed mode (one provider, one catalog, no fan-out) rather than restoring all 21.
+
+**Cross-platform v2 with macOS-only Rapid-MLX recommendation.** Rejected: the value of the macOS pivot is not just the recommended runtime — it's also the freed CI matrix, the dropped Windows-specific code paths (cloudflared subprocess differences, NSVisualEffectView vs none, codesign vs Authenticode), and the honesty of saying out loud that Apple Silicon is where local models work best in 2026. Cross-platform v2 would have kept all of that complexity for a story that, on Windows + Linux without a discrete GPU, doesn't actually deliver.
+
+**Skip the SaaS shutdown announcement and just turn off `api.open-yak.com`.** Rejected: existing users have credit balances and weekly quotas they were promised. 30 days plus an in-app announcement plus an email blast (per `reference_release_email.md`) is the minimum honest treatment. The shutdown date and migration instructions are part of the v2.0.0 release notes, not a follow-up.


### PR DESCRIPTION
## Summary
- **ADR-0011** records the v2 architectural cut: macOS-only, Rapid-MLX as the recommended local runtime, Custom Endpoint as the escape hatch, everything else (OpenYak Account / BYOK / ChatGPT Sub / Ollama / Win+Linux) removed. Includes the SaaS shutdown timeline and the explicit reasoning for *not* bundling Rapid-MLX as a sidecar in v2.0.0.
- **README.md** + **README.zh-CN.md** rewritten to match: macOS-only platform badge, two-mode provider table, install-Rapid-MLX in Get Started, FAQ entries about the SaaS EOL + Windows/Linux v1.x fallback, and pointers to ADR-0011 for the rationale.

LINUX.md is intentionally left in place; deletion belongs in PR 8 cleanup so the docs PR stays scoped to architectural records and user-facing READMEs.

## Test plan
- [x] ADR-0011 follows the existing `docs/adr/00NN-...md` style (compare 0006, 0007, 0010)
- [x] Both READMEs render with the new platform badge + provider table
- [ ] Verify the ADR link from the README resolves on the merged commit