### PR TITLE
chore(macos-only): tighten build scripts (v2 PR 8/8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev:backend": "cd backend && ./venv/bin/python -m uvicorn app.main:create_app --factory --reload --reload-dir app --host 0.0.0.0 --port 8000",
     "dev:all": "node scripts/dev-all.mjs",
     "dev:desktop": "node scripts/dev-desktop.mjs",
-    "build:frontend": "cd frontend && cross-env DESKTOP_BUILD=true NEXT_PUBLIC_DESKTOP_BUILD=true npm run build",
-    "build:backend": "cd backend && node -e \"const p=process.platform==='win32'?'venv/Scripts/pyinstaller':'venv/bin/pyinstaller';require('child_process').execSync(p+' openyak.spec --noconfirm',{stdio:'inherit'})\"",
+    "build:frontend": "cd frontend && DESKTOP_BUILD=true NEXT_PUBLIC_DESKTOP_BUILD=true npm run build",
+    "build:backend": "cd backend && ./venv/bin/pyinstaller openyak.spec --noconfirm",
     "sync:desktop-meta": "node scripts/sync-desktop-meta.mjs",
     "build:desktop": "npm run sync:desktop-meta && cd desktop-tauri && cargo tauri build",
     "preflight": "npm run preflight:ui",
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "concurrently": "^9.1.0",
-    "cross-env": "^7.0.3",
     "esbuild": "^0.27.3",
     "typescript": "^5.7.0",
     "wait-on": "^8.0.0"

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -20,7 +20,7 @@
 import { existsSync, statSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { argv, env, exit, platform } from "node:process";
+import { argv, env, exit } from "node:process";
 import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -32,7 +32,7 @@ if (!existsSync(dist)) {
 }
 
 const internal = join(dist, "_internal");
-const exeName = platform === "win32" ? "openyak-backend.exe" : "openyak-backend";
+const exeName = "openyak-backend";
 
 /**
  * Each entry describes one required asset. `kind` is "file" | "dir"


### PR DESCRIPTION
## Summary
Tightens build scripts now that v2 is macOS-only:
- `package.json::build:backend` drops the `process.platform === 'win32'` ternary that picked between `venv/Scripts/pyinstaller` and `venv/bin/pyinstaller`. macOS-only repo → POSIX path is the only path.
- `package.json::build:frontend` drops `cross-env`; macOS shells handle inline env vars natively. `cross-env` removed from `devDependencies`.
- `scripts/verify-bundle.mjs` drops the `.exe` suffix ternary on `exeName`.

Net diff: -5 / +4 across 2 files.

## What's deferred
The larger post-merge orphan-removal sweep (dead `#[cfg(target_os = ...)]` branches, `download_node.py`'s Win/Linux platform tables, BYOK/proxy/ChatGPT/Ollama test fixtures left behind by partial PR merges, etc.) is **intentionally deferred** to a follow-up PR that branches off the *merged* v2 — so it can clean up real post-merge state instead of speculating about which other PR did what. Trying to do that pre-merge across 6 stacked branches produces either overlap or work on imaginary state.

## Test plan
- [ ] After all PRs merge: `npm run build:backend` works on a clean macOS Apple Silicon checkout
- [ ] After all PRs merge: `npm run build:frontend` produces a desktop bundle
- [ ] After all PRs merge: `node scripts/verify-bundle.mjs backend/dist/openyak-backend` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)