### PR TITLE
[codex] fix long session message scroll

### DIFF
--- a/frontend/src/components/messages/message-list.tsx
+++ b/frontend/src/components/messages/message-list.tsx
@@ -116,6 +116,8 @@ export function MessageList({
   const { scrollRef, scrollElementRef, bottomRef, isAtBottom, scrollToBottom } = useScrollAnchor();
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const [unreadCount, setUnreadCount] = useState(0);
+  const [canFetchOlderMessages, setCanFetchOlderMessages] = useState(false);
+  const anchoredSessionRef = useRef<string | undefined>(undefined);
 
   // Keep StreamingMessage visible briefly after generation finishes so the
   // DB-fetched AssistantMessageGroup has time to render. Without this,
@@ -144,11 +146,31 @@ export function MessageList({
     }
   }, [messages.length, showStreamingFallback]);
 
+  useEffect(() => {
+    if (anchoredSessionRef.current === sessionId) return;
+    anchoredSessionRef.current = sessionId;
+    setCanFetchOlderMessages(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (canFetchOlderMessages || isLoading || messages.length === 0) return;
+    if (sessionId && messages.some((message) => message.session_id !== sessionId)) return;
+
+    const frame = requestAnimationFrame(() => {
+      const container = scrollElementRef.current;
+      if (!container) return;
+      container.scrollTop = container.scrollHeight;
+      setCanFetchOlderMessages(true);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [canFetchOlderMessages, isLoading, messages, scrollElementRef, sessionId]);
+
   // Reverse infinite scroll: observe top sentinel to load older messages
   useEffect(() => {
     const sentinel = topSentinelRef.current;
     const container = scrollElementRef.current;
-    if (!sentinel || !container || !hasPreviousPage || isFetchingPreviousPage) return;
+    if (!sentinel || !container || !canFetchOlderMessages || !hasPreviousPage || isFetchingPreviousPage) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -167,7 +189,7 @@ export function MessageList({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage, scrollElementRef]);
+  }, [canFetchOlderMessages, hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage, scrollElementRef]);
 
   // Track known message IDs to distinguish historical vs new messages.
   // Messages present on first render (or first data load) are "old" — skip animation.
@@ -255,7 +277,11 @@ export function MessageList({
     // to avoid a jarring skeleton → content transition during page navigation
     if (isGenerating || !!streamId) {
       return (
-        <div ref={scrollRef} className="relative flex-1 overflow-y-auto overscroll-contain scrollbar-auto">
+        <div
+          ref={scrollRef}
+          data-testid="message-list-scroller"
+          className="relative flex-1 overflow-y-auto overscroll-contain scrollbar-auto"
+        >
           {/* Show optimistic user bubble during loading so it doesn't flash
               away between navigation and message fetch completion */}
           {pendingUserText && (
@@ -323,7 +349,11 @@ export function MessageList({
 
   return (
     <div className="relative flex-1 overflow-hidden">
-      <div ref={scrollRef} className="h-full overflow-y-auto overscroll-contain scrollbar-auto">
+      <div
+        ref={scrollRef}
+        data-testid="message-list-scroller"
+        className="h-full overflow-y-auto overscroll-contain scrollbar-auto"
+      >
         {/* Top sentinel for reverse infinite scroll */}
         <div ref={topSentinelRef} className="h-px" />
         {isFetchingPreviousPage && (

--- a/frontend/tests/ui/fixtures/openyak-api.ts
+++ b/frontend/tests/ui/fixtures/openyak-api.ts
@@ -696,27 +696,27 @@ const longConversationMessages = Array.from({ length: 60 }, (_, index) => {
       "session-long",
       `user-${turn}`,
       "user",
-      index >= 56
+      `Long user turn ${turn}: ${index >= 56
         ? [
             "Before I send this to the board, can you sanity-check whether the vendor renewal risk should stay yellow or move to red?",
             "Can you use the same context to draft the final decision paragraph for the pre-read?",
             "Please make the last paragraph sound like an operator wrote it, not like a generic summary.",
             "Now give me the final version with the launch decision, owners, deadlines, and open risks in one place.",
           ][index - 56]
-        : prompt,
+        : prompt}`,
     ),
     textMessage(
       "session-long",
       `assistant-${turn}`,
       "assistant",
-      index >= 56
+      `Long assistant turn ${turn}: ${index >= 56
         ? [
             "Keep vendor renewal at yellow unless Legal misses the notice-window confirmation. It becomes red only if the renewal date is inside the freeze period or if the DPA language cannot be confirmed before procurement approval.",
             "Recommended decision: approve the launch for the board packet, conditional on Finance confirming the contractor exit date, Product closing the onboarding checklist, and Legal locking the renewal notice window before final approval.",
             "Here is a more operator-style close: We can move forward, but only with named owners on the three unresolved items. Finance owns run-rate, Product owns onboarding completion, and Legal owns renewal timing.",
             "Final version: launch is approved with conditions. Product closes enterprise onboarding gaps by Wednesday, Finance confirms the support contractor run-rate by Friday, Legal locks the vendor renewal window before procurement approval, and CS sends account-owner guidance after those three checks are complete.",
           ][index - 56]
-        : reply,
+        : reply}`,
       { input: 48000 + index * 700, output: 180, reasoning: 12, cache_read: 0, cache_write: 0 },
     ),
   ];

--- a/frontend/tests/ui/openyak-conversation-scale.spec.ts
+++ b/frontend/tests/ui/openyak-conversation-scale.spec.ts
@@ -66,7 +66,7 @@ test.describe("OpenYak conversation scale and compaction GUI workflows", () => {
     await expect(page.getByText("Long assistant turn 060")).toBeVisible();
     await expect(page.getByText("Long user turn 001")).toHaveCount(0);
 
-    const scroller = page.locator(".scrollbar-auto").first();
+    const scroller = page.getByTestId("message-list-scroller");
     await scroller.hover();
     await page.mouse.wheel(0, -12000);
 


### PR DESCRIPTION
## Summary
- anchor long Session message lists to the latest page before enabling reverse infinite scroll
- add a stable test id for the real Message list scroller
- label long-conversation fixture turns so the GUI regression checks the actual tail message

## Root Cause
The top sentinel for reverse infinite scroll could be observed during the initial long-Session mount, before the latest page was anchored at the bottom. That allowed older pages to prepend immediately and left the viewport pinned in the middle/older history, hiding the recent Messages even though they existed in the data/export path.

## User Impact
Long Sessions now open on the most recent Messages first, and users can still scroll upward to load older Messages intentionally.

## Validation
- `npm run test:ui:headless -- openyak-conversation-scale.spec.ts --project=chromium`
- `npm run lint`
- `git diff --check -- frontend/src/components/messages/message-list.tsx frontend/tests/ui/fixtures/openyak-api.ts frontend/tests/ui/openyak-conversation-scale.spec.ts`
