### PR TITLE
fix: remove vestigial transcribe_audio calls

### DIFF
--- a/backend/app/channels/feishu.py
+++ b/backend/app/channels/feishu.py
@@ -1583,11 +1583,6 @@ class FeishuChannel(BaseChannel):
                 if file_path:
                     media_paths.append(file_path)
 
-                if msg_type == "audio" and file_path:
-                    transcription = await self.transcribe_audio(file_path)
-                    if transcription:
-                        content_text = f"[transcription: {transcription}]"
-
                 content_parts.append(content_text)
 
             elif msg_type in (

--- a/backend/app/channels/matrix.py
+++ b/backend/app/channels/matrix.py
@@ -870,13 +870,7 @@ class MatrixChannel(BaseChannel):
         if isinstance(body := getattr(event, "body", None), str) and body.strip():
             parts.append(body.strip())
 
-        if attachment and attachment.get("type") == "audio":
-            transcription = await self.transcribe_audio(attachment["path"])
-            if transcription:
-                parts.append(f"[transcription: {transcription}]")
-            else:
-                parts.append(marker)
-        elif marker:
+        if marker:
             parts.append(marker)
 
         await self._start_typing_keepalive(room.room_id)

--- a/backend/app/channels/weixin.py
+++ b/backend/app/channels/weixin.py
@@ -673,12 +673,8 @@ class WeixinChannel(BaseChannel):
                         has_top_level_downloadable_media = True
                     file_path = await self._download_media_item(voice_item, "voice")
                     if file_path:
-                        transcription = await self.transcribe_audio(file_path)
-                        if transcription:
-                            content_parts.append(f"[voice] {transcription}")
-                        else:
-                            content_parts.append(f"[voice]\n[Audio: source: {file_path}]")
                         media_paths.append(file_path)
+                        content_parts.append(f"[voice: {file_path}]")
                     else:
                         content_parts.append("[voice]")
 
@@ -735,12 +731,8 @@ class WeixinChannel(BaseChannel):
                     voice_item = ref_media_item.get("voice_item") or {}
                     file_path = await self._download_media_item(voice_item, "voice")
                     if file_path:
-                        transcription = await self.transcribe_audio(file_path)
-                        if transcription:
-                            content_parts.append(f"[voice] {transcription}")
-                        else:
-                            content_parts.append(f"[voice]\n[Audio: source: {file_path}]")
                         media_paths.append(file_path)
+                        content_parts.append(f"[voice: {file_path}]")
                 elif ref_type == ITEM_FILE:
                     file_item = ref_media_item.get("file_item") or {}
                     file_name = file_item.get("file_name", "unknown")

--- a/backend/app/channels/whatsapp.py
+++ b/backend/app/channels/whatsapp.py
@@ -255,16 +255,11 @@ class WhatsAppChannel(BaseChannel):
             # Extract media paths (images/documents/videos downloaded by the bridge)
             media_paths = data.get("media") or []
 
-            # Handle voice transcription if it's a voice message
-            if content == "[Voice Message]":
+            is_voice_message = content == "[Voice Message]"
+            # Keep voice messages as downloaded media plus a placeholder in content.
+            if is_voice_message:
                 if media_paths:
-                    logger.info("Transcribing voice message from %s...", sender_id)
-                    transcription = await self.transcribe_audio(media_paths[0])
-                    if transcription:
-                        content = transcription
-                        logger.info("Transcribed voice from %s: %s...", sender_id, transcription[:50])
-                    else:
-                        content = "[Voice Message: Transcription failed]"
+                    content = ""
                 else:
                     content = "[Voice Message: Audio not available]"
 
@@ -272,7 +267,12 @@ class WhatsAppChannel(BaseChannel):
             if media_paths:
                 for p in media_paths:
                     mime, _ = mimetypes.guess_type(p)
-                    media_type = "image" if mime and mime.startswith("image/") else "file"
+                    if is_voice_message or (mime and mime.startswith("audio/")):
+                        media_type = "audio"
+                    elif mime and mime.startswith("image/"):
+                        media_type = "image"
+                    else:
+                        media_type = "file"
                     media_tag = f"[{media_type}: {p}]"
                     content = f"{content}\n{media_tag}" if content else media_tag
 


### PR DESCRIPTION
Fixes #70

## Summary

Removed vestigial `transcribe_audio` callsites from Matrix, WhatsApp, Feishu, and Weixin channels.

`transcribe_audio` is not implemented anywhere in the codebase, so voice/audio inbound handling now keeps the existing path-only placeholder content instead of attempting transcription.

## Verification

- `Select-String -Path "app/channels/*.py" -Pattern "transcribe_audio"` returns no results
- `python -m compileall app/channels/` passes
- `python -m pytest` was attempted locally on Windows:
  - 806 passed, 21 skipped
  - 4 failed due to Windows/local environment constraints unrelated to this change:
    - cloudflared remote recovery returned 500 instead of 200
    - executable-bit assertion for extracted tgz binary
    - bash subprocess could not find `python`
    - symlink creation requires elevated privileges