### PR TITLE
Sidebar live spinner + native finish notification for background sessions (#120, phase 3)

### DIFF
--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/Users/wangzhangwu/openyak/frontend/node_modules

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/wangzhangwu/openyak/frontend/node_modules

--- a/frontend/src/components/chat/chat-view.tsx
+++ b/frontend/src/components/chat/chat-view.tsx
@@ -82,6 +82,7 @@ export function ChatView({ sessionId }: ChatViewProps) {
   // the background so the user can come back to it later.
   useEffect(() => {
     useChatStore.getState().ensureSession(sessionId);
+    useChatStore.getState().setFocusedSession(sessionId);
     useArtifactStore.getState().clearAll();
     useActivityStore.getState().close();
     useWorkspaceStore.getState().resetForSession();
@@ -110,6 +111,16 @@ export function ChatView({ sessionId }: ChatViewProps) {
         );
       }
     }).catch(() => {});
+
+    return () => {
+      // Only clear focus if we are still the focused session on unmount —
+      // a fast route swap to another ChatView would otherwise wipe the
+      // other view's focus claim on its way in.
+      const cur = useChatStore.getState().focusedSessionId;
+      if (cur === sessionId) {
+        useChatStore.getState().setFocusedSession(null);
+      }
+    };
   }, [sessionId]);
 
   // Copy last assistant message to clipboard

--- a/frontend/src/components/chat/landing.tsx
+++ b/frontend/src/components/chat/landing.tsx
@@ -82,13 +82,10 @@ export function Landing({ directoryParam = null }: LandingProps) {
   }, []);
 
   useEffect(() => {
-    // Always reset the draft bucket on Landing mount — leftover frozen state
-    // from a previous send (kept around to bridge the navigation gap) gets
-    // wiped here so the next chat starts clean.
-    useChatStore.getState().resetSession(null);
-    // Respect ?directory=... (used by "Add new project"); otherwise start unrestricted.
+    const chat = useChatStore.getState();
+    chat.resetSession(null);
+    chat.setFocusedSession(null);
     useSettingsStore.getState().setWorkspaceDirectory(directoryParam || null);
-    // Close right-side panels when landing page mounts (new chat / after delete)
     useArtifactStore.getState().clearAll();
     useActivityStore.getState().close();
   }, [directoryParam]);

--- a/frontend/src/components/layout/session-item.tsx
+++ b/frontend/src/components/layout/session-item.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Archive, MessageCircle, Pin, PinOff } from "lucide-react";
+import { Archive, Loader2, MessageCircle, Pin, PinOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
 import { API, queryKeys } from "@/lib/constants";
@@ -322,9 +322,9 @@ export const SessionItem = memo(function SessionItem({
                     {title}
                   </span>
                   {isLive && (
-                    <span
+                    <Loader2
                       aria-label={t('sessionIsGenerating', { defaultValue: 'Generating in background' })}
-                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--brand-primary)] animate-pulse"
+                      className="h-3 w-3 shrink-0 animate-spin text-[var(--brand-primary)]"
                     />
                   )}
                 </p>

--- a/frontend/src/components/layout/session-item.tsx
+++ b/frontend/src/components/layout/session-item.tsx
@@ -11,6 +11,7 @@ import { api } from "@/lib/api";
 import { API, queryKeys } from "@/lib/constants";
 import { getChatRoute } from "@/lib/routes";
 import { useDebouncedPrefetch } from "@/hooks/use-debounced-prefetch";
+import { useChatSession } from "@/stores/chat-store";
 import type { PaginatedMessages } from "@/types/message";
 import {
   ContextMenu,
@@ -70,6 +71,10 @@ export const SessionItem = memo(function SessionItem({
     : rawTitle;
   const relativeTime = getRelativeTimeLabel(session.time_updated);
   const channelBadge = session.slug ? getChannelBadge(session.slug) : null;
+  // Live status badge: shows whenever this session has an in-flight stream
+  // attached, including ones the user navigated away from.
+  const liveBucket = useChatSession(session.id);
+  const isLive = liveBucket.isGenerating || liveBucket.isCompacting;
   const hasDirectory = !!session.directory && session.directory !== ".";
   const deeplink = `openyak://chat?sessionId=${encodeURIComponent(session.id)}`;
   const pinLabel = session.is_pinned
@@ -316,6 +321,12 @@ export const SessionItem = memo(function SessionItem({
                   >
                     {title}
                   </span>
+                  {isLive && (
+                    <span
+                      aria-label={t('sessionIsGenerating', { defaultValue: 'Generating in background' })}
+                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--brand-primary)] animate-pulse"
+                    />
+                  )}
                 </p>
                 {snippet && (
                   <p className="mt-0.5 truncate text-ui-2xs leading-4 text-[var(--text-tertiary)]">

--- a/frontend/src/components/providers/stream-registry-hydration.tsx
+++ b/frontend/src/components/providers/stream-registry-hydration.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import { API } from "@/lib/constants";
+import { getChatRoute } from "@/lib/routes";
 import { useChatStore } from "@/stores/chat-store";
 import { startStream, isStreamActive } from "@/lib/session-stream-registry";
+import { NAVIGATE_TO_SESSION_EVENT, type NavigateToSessionDetail } from "@/lib/background-notify";
 
 /**
  * On app boot, ask the backend which generations are still running and
@@ -16,6 +19,8 @@ import { startStream, isStreamActive } from "@/lib/session-stream-registry";
  * client missed while the registry was empty.
  */
 export function StreamRegistryHydration() {
+  const router = useRouter();
+
   useEffect(() => {
     let cancelled = false;
 
@@ -42,6 +47,20 @@ export function StreamRegistryHydration() {
       cancelled = true;
     };
   }, []);
+
+  // Soft-route to a session when the user clicks a background-finish
+  // notification. The notification handler dispatches a CustomEvent so the
+  // module-level registry stays decoupled from React, and we pick it up
+  // here where the Next router is available.
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<NavigateToSessionDetail>).detail;
+      if (!detail?.sessionId) return;
+      router.push(getChatRoute(detail.sessionId));
+    };
+    window.addEventListener(NAVIGATE_TO_SESSION_EVENT, handler);
+    return () => window.removeEventListener(NAVIGATE_TO_SESSION_EVENT, handler);
+  }, [router]);
 
   return null;
 }

--- a/frontend/src/lib/background-notify.ts
+++ b/frontend/src/lib/background-notify.ts
@@ -12,11 +12,19 @@
  * "in the background" — this helper does not check focus state.
  */
 
-let permissionRequestInFlight: Promise<NotificationPermission> | null = null;
+/**
+ * Custom event the registry dispatches when a notification is clicked.
+ * A top-level component (currently `StreamRegistryHydration`) listens for
+ * it and routes via the Next.js router so we do soft navigation instead of
+ * a full reload (which would tear down the in-memory stream registry).
+ */
+export const NAVIGATE_TO_SESSION_EVENT = "openyak:navigate-to-session";
 
-function getRoute(sessionId: string): string {
-  return `/c/${sessionId}`;
+export interface NavigateToSessionDetail {
+  sessionId: string;
 }
+
+let permissionRequestInFlight: Promise<NotificationPermission> | null = null;
 
 async function ensurePermission(): Promise<NotificationPermission> {
   if (typeof window === "undefined" || !("Notification" in window)) return "denied";
@@ -48,11 +56,11 @@ export async function notifyBackgroundFinish({ sessionId, title, body, kind }: N
     n.onclick = () => {
       try {
         window.focus();
-        if (typeof window !== "undefined") {
-          // history.pushState avoids a full reload — Next.js App Router picks
-          // it up via the popstate listener and renders the chat in place.
-          window.location.assign(getRoute(sessionId));
-        }
+        window.dispatchEvent(
+          new CustomEvent<NavigateToSessionDetail>(NAVIGATE_TO_SESSION_EVENT, {
+            detail: { sessionId },
+          }),
+        );
       } finally {
         n.close();
       }

--- a/frontend/src/lib/background-notify.ts
+++ b/frontend/src/lib/background-notify.ts
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * Fire a native notification when a session finishes in the background.
+ *
+ * Uses the web Notification API (works in Tauri webview, mobile browser,
+ * and desktop Chrome alike — no Rust plugin needed). Permission is
+ * requested lazily on the first background completion so users never see
+ * the prompt for foreground-only usage.
+ *
+ * The caller is responsible for deciding whether the session was actually
+ * "in the background" — this helper does not check focus state.
+ */
+
+let permissionRequestInFlight: Promise<NotificationPermission> | null = null;
+
+function getRoute(sessionId: string): string {
+  return `/c/${sessionId}`;
+}
+
+async function ensurePermission(): Promise<NotificationPermission> {
+  if (typeof window === "undefined" || !("Notification" in window)) return "denied";
+  if (Notification.permission !== "default") return Notification.permission;
+  if (!permissionRequestInFlight) {
+    permissionRequestInFlight = Notification.requestPermission().finally(() => {
+      permissionRequestInFlight = null;
+    });
+  }
+  return permissionRequestInFlight;
+}
+
+interface NotifyOptions {
+  sessionId: string;
+  title: string;
+  body: string;
+  /** "done" | "error" — used for the tag so a later update replaces, not stacks. */
+  kind: "done" | "error";
+}
+
+export async function notifyBackgroundFinish({ sessionId, title, body, kind }: NotifyOptions): Promise<void> {
+  const perm = await ensurePermission();
+  if (perm !== "granted") return;
+  try {
+    const n = new Notification(title, {
+      body,
+      tag: `openyak-${kind}-${sessionId}`,
+    });
+    n.onclick = () => {
+      try {
+        window.focus();
+        if (typeof window !== "undefined") {
+          // history.pushState avoids a full reload — Next.js App Router picks
+          // it up via the popstate listener and renders the chat in place.
+          window.location.assign(getRoute(sessionId));
+        }
+      } finally {
+        n.close();
+      }
+    };
+  } catch {
+    // Notifications can throw if the browser blocks them post-grant
+    // (e.g. user revoked, or quota exceeded). Best-effort.
+  }
+}

--- a/frontend/src/lib/session-stream-registry.ts
+++ b/frontend/src/lib/session-stream-registry.ts
@@ -8,6 +8,7 @@ import { isRemoteMode } from "@/lib/remote-connection";
 import { desktopAPI } from "@/lib/tauri-api";
 import { api } from "@/lib/api";
 import { SSE_EVENTS } from "@/types/streaming";
+import { notifyBackgroundFinish } from "@/lib/background-notify";
 import { useChatStore } from "@/stores/chat-store";
 import { useConnectionStore } from "@/stores/connection-store";
 import { useArtifactStore } from "@/stores/artifact-store";
@@ -624,6 +625,7 @@ export async function startStream(sessionId: string, streamId: string): Promise<
       qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
       qc.invalidateQueries({ queryKey: queryKeys.sessions.detail(sessionId) });
     }
+    maybeNotifyFinish(sessionId, "done");
     stopStream(sessionId);
   });
 
@@ -650,6 +652,7 @@ export async function startStream(sessionId: string, streamId: string): Promise<
       }, 500);
       qc.invalidateQueries({ queryKey: queryKeys.sessions.detail(sessionId) });
     }
+    maybeNotifyFinish(sessionId, "error", message);
     stopStream(sessionId);
   };
   client.on(SSE_EVENTS.AGENT_ERROR, handleAgentError);
@@ -727,6 +730,28 @@ function ensureGlobalListeners(): void {
 
 function store_isGenerating(sessionId: string): boolean {
   return useChatStore.getState().sessions[sessionId]?.isGenerating ?? false;
+}
+
+/**
+ * Fire a native notification when a session finishes, unless the user is
+ * currently looking at that session in the foreground — in that case the
+ * normal UI is the notification.
+ */
+function maybeNotifyFinish(sessionId: string, kind: "done" | "error", errorMessage?: string): void {
+  const focusedSessionId = useChatStore.getState().focusedSessionId;
+  if (focusedSessionId === sessionId && typeof document !== "undefined" && !document.hidden) {
+    return;
+  }
+  const qc = queryClientRef;
+  const session = qc?.getQueryData<SessionResponse>(queryKeys.sessions.detail(sessionId));
+  const sessionTitle = session?.title?.trim() || "Background task";
+  const title = kind === "done"
+    ? `${sessionTitle} finished`
+    : `${sessionTitle} stopped`;
+  const body = kind === "done"
+    ? "Click to open the conversation."
+    : (errorMessage ?? "Click to open the conversation.");
+  void notifyBackgroundFinish({ sessionId, title, body, kind });
 }
 
 /** Cleanup, for tests / hot reload. Not used in production app code. */

--- a/frontend/src/stores/chat-store.ts
+++ b/frontend/src/stores/chat-store.ts
@@ -108,11 +108,18 @@ interface ChatStore {
    * startGeneration with a fresh sessionId it gets promoted into `sessions`.
    */
   draftSession: ChatSessionState | null;
+  /**
+   * The session the user is currently viewing. Null = Landing or any
+   * non-chat screen. The session stream registry uses this to decide
+   * whether a completed background generation deserves a notification.
+   */
+  focusedSessionId: string | null;
 
   // ─── Bucket lifecycle ───
   ensureSession: (sessionId: string) => void;
   removeSession: (sessionId: string) => void;
   resetSession: (sessionId: string | null) => void;
+  setFocusedSession: (sessionId: string | null) => void;
   /** Clear everything — only for logout / catastrophic reset. */
   resetAll: () => void;
 
@@ -187,12 +194,15 @@ function mutateBucket(
 export const useChatStore = create<ChatStore>((set) => ({
   sessions: {},
   draftSession: null,
+  focusedSessionId: null,
 
   ensureSession: (sessionId) =>
     set((s) => {
       if (s.sessions[sessionId]) return s;
       return { sessions: { ...s.sessions, [sessionId]: EMPTY_SESSION_STATE } };
     }),
+
+  setFocusedSession: (sessionId) => set({ focusedSessionId: sessionId }),
 
   removeSession: (sessionId) => {
     clearSeenStepFinishIds(sessionId);

--- a/frontend/src/stores/chat-store.ts
+++ b/frontend/src/stores/chat-store.ts
@@ -221,7 +221,7 @@ export const useChatStore = create<ChatStore>((set) => ({
 
   resetAll: () => {
     SEEN_STEP_FINISH_IDS.clear();
-    set({ sessions: {}, draftSession: null });
+    set({ sessions: {}, draftSession: null, focusedSessionId: null });
   },
 
   beginSending: (sessionId, text, attachments) =>


### PR DESCRIPTION
Closes phase 3 of #120. Stacks on top of #121 which already landed.

(This is a clean rebase replacement for #123 — same code, no leftover merge-commit weirdness from the original stacked-PR branch.)

## What this adds

### Sidebar live spinner
Each session row in the sidebar shows a small spinning `Loader2` whenever `sessions[id].isGenerating || isCompacting`. Driven directly off the keyed bucket — no polling. Lights up as soon as the SSE stream produces its first event, goes dark on DONE. Same affordance Codex and Claude Code Desktop use.

### Native finish notification
When a background generation finishes (DONE) or errors out (AGENT_ERROR), the registry fires a native notification via the standard web `Notification` API:

- Works in Tauri's WKWebView / WebView2 / WebKitGTK and in the remote-mobile / web case — no Rust plugin needed.
- Permission is requested **lazily**, only on the first background completion. Foreground-only users never see a prompt.
- Suppressed when the user is currently viewing the finished session AND the window is visible.
- Clicking the notification dispatches a \`CustomEvent\` that \`StreamRegistryHydration\` picks up and routes via Next.js's router — soft nav, no full reload. (Reviewer caught the original \`window.location.assign\` which would tear down the in-memory registry.)

### Plumbing
- \`focusedSessionId: string | null\` on \`chat-store\` + \`setFocusedSession\` action. ChatView sets it on mount; Landing clears it; ChatView clears on unmount only if it's still the focused session (avoids fast-route-swap wiping the new view's claim).
- \`resetAll\` also clears \`focusedSessionId\` so a logout doesn't leave a stale id.
- \`frontend/src/lib/background-notify.ts\` — 70-line helper, all of the permission and click handling.

## Verification

- \`next build\` passes.
- \`tsc --noEmit\` clean.
- **End-to-end smoke test in Chrome against a real backend (Rapid-MLX, qwen3.5-4b):**
  - Sidebar spinner appears on a session that's mid-stream, **persists when you navigate to any other chat** (proving the bucket-keyed selector picks up live state without the active route).
  - Patched \`window.Notification\` to spy on construction; sent a fast prompt in session D, immediately switched to session A; when D finished in background the spy recorded \`new Notification("Background task finished", { body: "Click to open the conversation.", tag: "openyak-done-<D.session_id>" })\`.