### PR TITLE
Echo reasoning_content for thinking-mode providers (fixes #126)

### DIFF
--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -261,7 +261,12 @@ async def _phase2_summarize(
 
     async with session_factory() as db:
         async with db.begin():
-            llm_messages = await get_message_history_for_llm(db, session_id)
+            llm_messages = await get_message_history_for_llm(
+                db,
+                session_id,
+                provider_id=provider.id,
+                model_id=model_id,
+            )
 
     if not llm_messages:
         return None

--- a/backend/app/session/manager.py
+++ b/backend/app/session/manager.py
@@ -393,14 +393,66 @@ async def get_messages(
     return list(result.scalars().all())
 
 
+# Providers that use a reasoning passback protocol OTHER than DeepSeek's
+# OpenAI-compat `reasoning_content` field. Echoing reasoning back as
+# `reasoning_content` would be wasted context at best and rejected at worst, so
+# skip them here and let each one's native code path handle reasoning:
+#   - openrouter: `reasoning` / `reasoning_details` (signed blocks)
+#   - anthropic: native API, signed `thinking_blocks`
+#   - google:    native Gemini API, `thought` parts
+#   - openai / azure / openai-subscription: o-series reasoning lives server-side
+#     and is never returned in chat completions; nothing to echo
+# Every other openai-compat provider (deepseek, kimi, qwen, zhipu, groq,
+# mistral, xai, together, deepinfra, cerebras, cohere, perplexity, fireworks,
+# minimax, siliconflow, xiaomi, ollama, rapid-mlx, generic BYOK, etc.) returns
+# reasoning via `reasoning_content`; for any thinking-mode model the spec says
+# (and DeepSeek v4 / Kimi K2 / Qwen3 actively require) the prior turn must
+# echo it back on multi-turn tool-call follow-ups.
+_REASONING_CONTENT_SKIP_PROVIDERS: frozenset[str] = frozenset({
+    "openrouter",
+    "anthropic",
+    "google",
+    "openai",
+    "openai-subscription",
+    "azure",
+})
+
+# Models that explicitly REJECT `reasoning_content` on input. Echoing back 400s.
+# Currently only DeepSeek's legacy R1 line (`deepseek-reasoner`); list extends
+# easily if more turn up.
+_REASONING_CONTENT_REJECT_MODEL_PREFIXES: tuple[str, ...] = (
+    "deepseek-reasoner",
+)
+
+
+def _provider_uses_reasoning_content(provider_id: str | None, model_id: str | None) -> bool:
+    """Decide whether to echo prior `reasoning_content` to the active provider."""
+    if not provider_id or provider_id in _REASONING_CONTENT_SKIP_PROVIDERS:
+        return False
+    if model_id and model_id.startswith(_REASONING_CONTENT_REJECT_MODEL_PREFIXES):
+        return False
+    return True
+
+
 async def get_message_history_for_llm(
     db: AsyncSession,
     session_id: str,
+    *,
+    provider_id: str | None = None,
+    model_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Load message history formatted for LLM consumption.
 
     Converts stored messages/parts into the OpenAI message format:
     [{role: "user", content: "..."}, {role: "assistant", content: "..."}, ...]
+
+    For openai-compat-family providers that use DeepSeek's `reasoning_content`
+    convention, the prior assistant turn's accumulated reasoning is re-attached
+    as ``reasoning_content`` so thinking-mode multi-turn follow-ups (DeepSeek
+    v4 / Kimi K2 / Qwen3 / etc.) do not 400. Providers with their own reasoning
+    protocol (OpenRouter / Anthropic / Gemini / native OpenAI) and the legacy
+    `deepseek-reasoner` R1 model are skipped — see
+    ``_provider_uses_reasoning_content``.
     """
     messages = await get_messages(db, session_id)
     llm_messages = []
@@ -425,6 +477,8 @@ async def get_message_history_for_llm(
 
     if compaction_anchor:
         messages = messages[compaction_anchor:]
+
+    echo_reasoning = _provider_uses_reasoning_content(provider_id, model_id)
 
     max_assistant_text_chars = 40_000
     max_tool_output_chars = 20_000
@@ -468,8 +522,9 @@ async def get_message_history_for_llm(
                 llm_messages.append({"role": "user", "content": content})
 
         elif role == "assistant":
-            # Collect assistant text and tool calls
+            # Collect assistant text, reasoning, and tool calls
             text_parts = []
+            reasoning_parts: list[str] = []
             tool_calls = []
             tool_results = []
 
@@ -479,6 +534,8 @@ async def get_message_history_for_llm(
 
                 if part_type == "text":
                     text_parts.append(part_data.get("text", ""))
+                elif part_type == "reasoning":
+                    reasoning_parts.append(part_data.get("text", ""))
                 elif part_type == "tool":
                     tool_name = part_data.get("tool", "")
                     call_id = part_data.get("call_id", "")
@@ -536,6 +593,10 @@ async def get_message_history_for_llm(
                 }
                 if tool_calls:
                     assistant_msg["tool_calls"] = tool_calls
+                if echo_reasoning and reasoning_parts:
+                    reasoning_text = "\n".join(r for r in reasoning_parts if r)
+                    if reasoning_text:
+                        assistant_msg["reasoning_content"] = reasoning_text
                 llm_messages.append(assistant_msg)
 
             # Append tool results

--- a/backend/app/session/manager.py
+++ b/backend/app/session/manager.py
@@ -418,18 +418,19 @@ _REASONING_CONTENT_SKIP_PROVIDERS: frozenset[str] = frozenset({
 })
 
 # Models that explicitly REJECT `reasoning_content` on input. Echoing back 400s.
-# Currently only DeepSeek's legacy R1 line (`deepseek-reasoner`); list extends
-# easily if more turn up.
-_REASONING_CONTENT_REJECT_MODEL_PREFIXES: tuple[str, ...] = (
+# Currently only DeepSeek's legacy R1 (`deepseek-reasoner`). Use exact match —
+# a hypothetical future `deepseek-reasoner-v2` could revert to the v4 echo rule
+# and we don't want a prefix match to silently strip it.
+_REASONING_CONTENT_REJECT_MODELS: frozenset[str] = frozenset({
     "deepseek-reasoner",
-)
+})
 
 
 def _provider_uses_reasoning_content(provider_id: str | None, model_id: str | None) -> bool:
     """Decide whether to echo prior `reasoning_content` to the active provider."""
     if not provider_id or provider_id in _REASONING_CONTENT_SKIP_PROVIDERS:
         return False
-    if model_id and model_id.startswith(_REASONING_CONTENT_REJECT_MODEL_PREFIXES):
+    if model_id and model_id in _REASONING_CONTENT_REJECT_MODELS:
         return False
     return True
 
@@ -578,8 +579,23 @@ async def get_message_history_for_llm(
                             "content": output or "(no output)",
                         })
 
-            # Build assistant message
-            if text_parts or tool_calls:
+            # Build assistant message. A turn with only reasoning (no text and
+            # no tool_calls) is rare but legal — preserve it when reasoning is
+            # being echoed so the assistant entry doesn't go missing from the
+            # alternating role sequence.
+            reasoning_text = ""
+            if echo_reasoning and reasoning_parts:
+                joined = "\n".join(r for r in reasoning_parts if r)
+                if joined:
+                    # Reasoning blocks can be tens of thousands of chars per
+                    # turn — trim to the same per-message budget as the
+                    # assistant content so a single thinking-heavy turn cannot
+                    # consume the request budget by itself.
+                    reasoning_text = trim_for_context(
+                        joined, max_assistant_text_chars, "reasoning",
+                    )
+
+            if text_parts or tool_calls or reasoning_text:
                 assistant_content = "\n".join(text_parts) if text_parts else ""
                 if assistant_content:
                     assistant_content = trim_for_context(
@@ -593,10 +609,8 @@ async def get_message_history_for_llm(
                 }
                 if tool_calls:
                     assistant_msg["tool_calls"] = tool_calls
-                if echo_reasoning and reasoning_parts:
-                    reasoning_text = "\n".join(r for r in reasoning_parts if r)
-                    if reasoning_text:
-                        assistant_msg["reasoning_content"] = reasoning_text
+                if reasoning_text:
+                    assistant_msg["reasoning_content"] = reasoning_text
                 llm_messages.append(assistant_msg)
 
             # Append tool results

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -475,9 +475,15 @@ class SessionPrompt:
         from app.session.microcompact import microcompact_messages, apply_tool_result_budget
         from app.session.middleware import MiddlewareContext
 
+        provider_id = self.provider.id if self.provider else None
         async with self.session_factory() as db:
             async with db.begin():
-                llm_messages = await get_message_history_for_llm(db, self.job.session_id)
+                llm_messages = await get_message_history_for_llm(
+                    db,
+                    self.job.session_id,
+                    provider_id=provider_id,
+                    model_id=self.model_id,
+                )
         llm_messages = _sanitize_llm_messages_for_request(
             llm_messages,
             session_id=self.job.session_id,

--- a/backend/app/session/utils.py
+++ b/backend/app/session/utils.py
@@ -219,13 +219,27 @@ def sanitize_llm_messages_for_request(
                 m["content"] = trim_for_context(
                     content, max_request_chars, "user content"
                 )
+        # `reasoning_content` (echoed back to DeepSeek v4 / Kimi / Qwen3 etc.)
+        # is just as bulky as the assistant content and would otherwise slip
+        # past the per-message + cumulative budgets entirely.
+        reasoning = m.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning:
+            m["reasoning_content"] = trim_for_context(
+                reasoning, _cfg().max_assistant_content_chars, "reasoning",
+            )
         sanitized.append(m)
 
-    total_chars = 0
-    for m in sanitized:
+    def _msg_chars(m: dict[str, Any]) -> int:
+        n = 0
         c = m.get("content")
         if isinstance(c, str):
-            total_chars += len(c)
+            n += len(c)
+        r = m.get("reasoning_content")
+        if isinstance(r, str):
+            n += len(r)
+        return n
+
+    total_chars = sum(_msg_chars(m) for m in sanitized)
 
     if total_chars <= max_request_chars:
         return sanitized
@@ -233,11 +247,10 @@ def sanitize_llm_messages_for_request(
     trimmed: list[dict[str, Any]] = []
     running = 0
     for m in reversed(sanitized):
-        c = m.get("content")
-        c_len = len(c) if isinstance(c, str) else 0
-        if running + c_len <= max_request_chars:
+        m_len = _msg_chars(m)
+        if running + m_len <= max_request_chars:
             trimmed.append(m)
-            running += c_len
+            running += m_len
             continue
 
         remaining = max_request_chars - running
@@ -247,33 +260,39 @@ def sanitize_llm_messages_for_request(
             "assistant": "assistant content",
             "user": "user content",
         }.get(role, "message")
+        c = m.get("content")
 
         if isinstance(c, str) and remaining >= MIN_PARTIAL_MESSAGE_CHARS:
             partial = dict(m)
             partial["content"] = trim_for_context(c, remaining, kind)
+            # Drop the reasoning blob when budget is this tight — its purpose
+            # is multi-turn echo and the model can survive without it.
+            partial.pop("reasoning_content", None)
             trimmed.append(partial)
-            running += len(partial["content"])
+            running += _msg_chars(partial)
             continue
 
         if not trimmed:
             trimmed.append(m)
-            running += c_len
+            running += m_len
             continue
 
         # Budget exhausted but older turns remain. Preserve the message
         # envelope (and any tool_calls) so conversation shape survives, but
         # collapse large string content to a tiny "truncated" marker rather
         # than silently dropping the turn.
+        c_len = len(c) if isinstance(c, str) else 0
         if isinstance(c, str) and c_len > MIN_PARTIAL_MESSAGE_CHARS:
             stub = dict(m)
             stub["content"] = (
                 f"[{kind} truncated for context: original {c_len} chars, kept 0]"
             )
+            stub.pop("reasoning_content", None)
             trimmed.append(stub)
-            running += len(stub["content"])
+            running += _msg_chars(stub)
         else:
             trimmed.append(m)
-            running += c_len
+            running += m_len
     trimmed.reverse()
 
     logger.warning(

--- a/backend/tests/test_session/test_manager.py
+++ b/backend/tests/test_session/test_manager.py
@@ -107,6 +107,83 @@ class TestMessageManager:
         assert history[1]["content"] == "4"
 
     @pytest.mark.asyncio
+    async def test_history_reasoning_echo_provider_matrix(
+        self, db: AsyncSession,
+    ):
+        """Issue #126: thinking-mode providers using DeepSeek's
+        `reasoning_content` convention 400 on multi-turn follow-ups unless the
+        prior assistant turn echoes its reasoning. The exceptions are:
+
+          * providers with their own reasoning protocol
+            (openrouter / anthropic / google / openai / azure)
+          * the legacy `deepseek-reasoner` (R1) model, which rejects the field
+            on input.
+        """
+        session = await create_session(db, title="Thinking Echo")
+
+        user_msg = await create_message(db, session_id=session.id, data={"role": "user"})
+        await create_part(
+            db, message_id=user_msg.id, session_id=session.id,
+            data={"type": "text", "text": "What is 2+2?"},
+        )
+
+        asst_msg = await create_message(db, session_id=session.id, data={"role": "assistant"})
+        await create_part(
+            db, message_id=asst_msg.id, session_id=session.id,
+            data={"type": "reasoning", "text": "User wants arithmetic. 2+2=4."},
+        )
+        await create_part(
+            db, message_id=asst_msg.id, session_id=session.id,
+            data={"type": "text", "text": "4"},
+        )
+
+        expected_reasoning = "User wants arithmetic. 2+2=4."
+
+        # Every openai-compat provider that surfaces reasoning_content must
+        # receive the echo. Default behavior — no enumeration needed except
+        # for documentation: catalog providers + ollama / rapid-mlx / BYOK.
+        echo_providers = (
+            "deepseek", "kimi", "qwen", "zhipu",
+            "groq", "mistral", "xai", "together", "deepinfra",
+            "cerebras", "cohere", "perplexity", "fireworks",
+            "minimax", "siliconflow", "xiaomi",
+            "ollama", "rapid-mlx",
+            "some-byok-id",  # GenericOpenAIProvider with a custom id
+        )
+        for provider_id in echo_providers:
+            history = await get_message_history_for_llm(
+                db, session.id, provider_id=provider_id,
+            )
+            assert history[1]["role"] == "assistant"
+            assert history[1].get("reasoning_content") == expected_reasoning, (
+                f"{provider_id} should echo reasoning_content"
+            )
+
+        # Providers with their own reasoning protocol — never echo.
+        skip_providers = (
+            "openrouter", "anthropic", "google",
+            "openai", "openai-subscription", "azure",
+            None,  # no provider hint (compaction / workspace memory callers)
+        )
+        for provider_id in skip_providers:
+            history = await get_message_history_for_llm(
+                db, session.id, provider_id=provider_id,
+            )
+            assert "reasoning_content" not in history[1], (
+                f"{provider_id} must not receive reasoning_content"
+            )
+
+        # Legacy deepseek-reasoner (R1) actively 400s when reasoning_content
+        # is included on input — strip regardless of provider id.
+        for model_id in ("deepseek-reasoner", "deepseek-reasoner-lite"):
+            history = await get_message_history_for_llm(
+                db, session.id, provider_id="deepseek", model_id=model_id,
+            )
+            assert "reasoning_content" not in history[1], (
+                f"{model_id} must not receive reasoning_content"
+            )
+
+    @pytest.mark.asyncio
     async def test_history_with_tool_calls(self, db: AsyncSession):
         session = await create_session(db, title="Tool History")
 

--- a/backend/tests/test_session/test_manager.py
+++ b/backend/tests/test_session/test_manager.py
@@ -174,14 +174,85 @@ class TestMessageManager:
             )
 
         # Legacy deepseek-reasoner (R1) actively 400s when reasoning_content
-        # is included on input — strip regardless of provider id.
-        for model_id in ("deepseek-reasoner", "deepseek-reasoner-lite"):
-            history = await get_message_history_for_llm(
-                db, session.id, provider_id="deepseek", model_id=model_id,
-            )
-            assert "reasoning_content" not in history[1], (
-                f"{model_id} must not receive reasoning_content"
-            )
+        # is included on input — strip even though the provider is deepseek.
+        history = await get_message_history_for_llm(
+            db, session.id, provider_id="deepseek", model_id="deepseek-reasoner",
+        )
+        assert "reasoning_content" not in history[1]
+
+        # Match is exact, not prefix: a hypothetical future model whose name
+        # starts with `deepseek-reasoner-` is not assumed to share R1's
+        # rejection rule, so the echo still applies.
+        history = await get_message_history_for_llm(
+            db, session.id, provider_id="deepseek", model_id="deepseek-reasoner-v2",
+        )
+        assert history[1].get("reasoning_content") == expected_reasoning
+
+    @pytest.mark.asyncio
+    async def test_history_reasoning_only_assistant_turn_preserved(
+        self, db: AsyncSession,
+    ):
+        """An assistant turn with only reasoning (no text, no tool_calls) must
+        survive in history when echo is on, otherwise the assistant slot goes
+        missing from the alternating sequence.
+        """
+        session = await create_session(db, title="Reasoning-only turn")
+
+        user_msg = await create_message(db, session_id=session.id, data={"role": "user"})
+        await create_part(
+            db, message_id=user_msg.id, session_id=session.id,
+            data={"type": "text", "text": "Continue thinking."},
+        )
+
+        asst_msg = await create_message(db, session_id=session.id, data={"role": "assistant"})
+        await create_part(
+            db, message_id=asst_msg.id, session_id=session.id,
+            data={"type": "reasoning", "text": "Still working it out."},
+        )
+
+        echoed = await get_message_history_for_llm(
+            db, session.id, provider_id="deepseek",
+        )
+        assert echoed[-1]["role"] == "assistant"
+        assert echoed[-1]["content"] == ""
+        assert echoed[-1]["reasoning_content"] == "Still working it out."
+
+        # When echo is off the orphan turn is collapsed (no value in keeping
+        # an empty assistant message that won't be sent).
+        skipped = await get_message_history_for_llm(db, session.id)
+        assert all(m["role"] == "user" for m in skipped)
+
+    @pytest.mark.asyncio
+    async def test_history_reasoning_content_is_trimmed(self, db: AsyncSession):
+        """Reasoning blocks can be tens of thousands of chars; per-message
+        trimming caps each turn so a single thinking-heavy reply cannot
+        consume the entire request budget.
+        """
+        session = await create_session(db, title="Huge reasoning")
+
+        user_msg = await create_message(db, session_id=session.id, data={"role": "user"})
+        await create_part(
+            db, message_id=user_msg.id, session_id=session.id,
+            data={"type": "text", "text": "ping"},
+        )
+
+        huge = "x" * 200_000
+        asst_msg = await create_message(db, session_id=session.id, data={"role": "assistant"})
+        await create_part(
+            db, message_id=asst_msg.id, session_id=session.id,
+            data={"type": "reasoning", "text": huge},
+        )
+        await create_part(
+            db, message_id=asst_msg.id, session_id=session.id,
+            data={"type": "text", "text": "pong"},
+        )
+
+        history = await get_message_history_for_llm(
+            db, session.id, provider_id="deepseek",
+        )
+        reasoning = history[1]["reasoning_content"]
+        assert len(reasoning) < len(huge)
+        assert "[reasoning truncated for context" in reasoning
 
     @pytest.mark.asyncio
     async def test_history_with_tool_calls(self, db: AsyncSession):


### PR DESCRIPTION
## Summary

DeepSeek v4 thinking models (`deepseek-v4-pro`, `deepseek-v4-flash`) 400 on follow-up requests after a tool call when the prior assistant turn omits `reasoning_content`. Moonshot Kimi K2 thinking and Qwen3 thinking have the same requirement; Zhipu GLM and others accept it. Streaming already captured `delta.reasoning_content` into a stored `ReasoningPart`, but `get_message_history_for_llm` dropped it when rebuilding the assistant turn for the next request.

Reconstruct reasoning into `reasoning_content` for every openai-compat provider that surfaces it. The rule is a small denylist so the behavior is aligned across **all** providers, not just DeepSeek.

## Provider matrix

| Provider id | Echo? | Reason |
|---|:--:|---|
| `deepseek` (v4-pro / v4-flash) | yes | required, otherwise 400 |
| `deepseek` + model = `deepseek-reasoner` | **no** | R1 rejects `reasoning_content` on input |
| `kimi` (Moonshot K2 thinking) | yes | required |
| `qwen` (DashScope Qwen3 thinking) | yes | required on tool turns |
| `zhipu` (GLM thinking) | yes | accepted |
| `mistral` (Magistral), `xai` (Grok 3+), `groq`, `together`, `deepinfra`, `cerebras`, `fireworks`, `siliconflow`, `cohere`, `perplexity`, `minimax`, `xiaomi` | yes | all surface `reasoning_content` |
| `ollama`, `rapid-mlx`, BYOK `generic_openai` | yes | local OpenAI-compat, same convention |
| `openrouter` | no | uses `reasoning` / `reasoning_details` |
| `anthropic` | no | native API, signed `thinking_blocks` |
| `google` | no | native Gemini, `thought` parts |
| `openai`, `azure`, `openai-subscription` | no | o-series reasoning is server-side; chat completions does not return `reasoning_content` |
| `provider_id=None` (compaction / workspace memory callers) | no | not the next-turn LLM call; preserves prior behavior |

## Test plan

- [x] `backend/tests/test_session/test_manager.py` — new matrix test covering 18 echo providers, 7 skip providers, and the `deepseek-reasoner` strip
- [x] `pytest tests/test_session` — 113/113 pass
- [ ] Manual: DeepSeek BYOK with `deepseek-v4-pro`, ask a question that triggers a tool call, confirm the follow-up turn no longer 400s
- [ ] Manual: DeepSeek BYOK with `deepseek-reasoner` (R1), confirm multi-turn still works (no echo)
- [ ] Manual: Kimi K2 / Qwen3 thinking, confirm multi-turn tool calls work

## Sources consulted

- [DeepSeek Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode)
- [DeepSeek Reasoning Model docs (R1)](https://api-docs.deepseek.com/guides/reasoning_model)
- [LiteLLM #26395 — DeepSeek V4 reasoning_content stripped](https://github.com/BerriAI/litellm/issues/26395)
- [LiteLLM #23765 — Kimi K2.5 thinking same bug](https://github.com/BerriAI/litellm/issues/23765)
- [OpenRouter Reasoning Tokens — uses reasoning_details](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens)