### PR TITLE
Fix random "Job not found" error after backend restart

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -438,8 +438,12 @@ async def stream_events(
         # Return 200 (not 404) so that EventSource reads the body.
         # EventSource ignores response bodies on non-2xx status codes,
         # causing the frontend to never receive the agent_error event.
+        #
+        # Tag it JOB_NOT_FOUND: an absent in-memory job almost always means the
+        # backend restarted out from under an in-flight generation, which the
+        # client can recover from silently (the conversation is safe in the DB).
         return StreamingResponse(
-            _error_stream("Job not found"),
+            _error_stream("Job not found", code="JOB_NOT_FOUND"),
             media_type="text/event-stream",
         )
 
@@ -529,8 +533,16 @@ async def respond_to_prompt(request: Request, sm: StreamManagerDep, body: Respon
     return {"status": "submitted"}
 
 
-async def _error_stream(message: str):
-    """Yield a single error event."""
-    event = SSEEvent(AGENT_ERROR, {"error_message": message})
+async def _error_stream(message: str, code: str | None = None):
+    """Yield a single error event.
+
+    ``code`` is an optional machine-readable tag (e.g. ``"JOB_NOT_FOUND"``) so
+    the client can recover quietly from benign cases instead of surfacing the
+    raw message as an alarming toast.
+    """
+    data: dict[str, Any] = {"error_message": message}
+    if code is not None:
+        data["code"] = code
+    event = SSEEvent(AGENT_ERROR, data)
     event.id = 1
     yield event.encode()

--- a/backend/tests/test_streaming/test_lifecycle_contract.py
+++ b/backend/tests/test_streaming/test_lifecycle_contract.py
@@ -223,6 +223,9 @@ class TestChatStreamEndpointContract:
         assert response.status_code == 200
         assert [event["event"] for event in events] == [AGENT_ERROR]
         assert events[0]["data"]["error_message"] == "Job not found"
+        # Tagged so the client can recover quietly (e.g. after a backend restart)
+        # instead of surfacing the raw message as an alarming toast.
+        assert events[0]["data"]["code"] == "JOB_NOT_FOUND"
 
     @pytest.mark.asyncio
     async def test_active_jobs_exposes_terminal_step_without_done(self, app_client) -> None:

--- a/frontend/src/lib/session-stream-registry.ts
+++ b/frontend/src/lib/session-stream-registry.ts
@@ -885,6 +885,7 @@ function maybeNotifyFinish(sessionId: string, kind: "done" | "error", errorMessa
 export function disposeAllStreams(): void {
   for (const inst of instances.values()) disposeInstance(inst);
   instances.clear();
+  pendingStarts.clear();
   unlistenBackendRestarting?.();
   unlistenBackendRestarted?.();
   unlistenVisibilityChange?.();

--- a/frontend/src/lib/session-stream-registry.ts
+++ b/frontend/src/lib/session-stream-registry.ts
@@ -99,6 +99,13 @@ interface StreamInstance {
 
 const instances = new Map<string, StreamInstance>();
 
+// Sessions whose startStream() is mid-setup (parked on the async backend
+// url/token fetch). startStream only registers its instance *after* that await,
+// so without this guard a second concurrent start for the same session — e.g.
+// restart reconcile firing while a user prompt's start is still in flight —
+// would build a second SSEClient, duplicating deltas and leaking an EventSource.
+const pendingStarts = new Set<string>();
+
 let queryClientRef: QueryClient | null = null;
 let globalListenersInstalled = false;
 let unlistenBackendRestarting: (() => void) | null = null;
@@ -171,8 +178,18 @@ export async function startStream(sessionId: string, streamId: string): Promise<
     stopStream(sessionId);
   }
 
+  // Reserve this session across the one async gap below. Everything from here
+  // to instances.set() is synchronous, so this is enough to serialize starts.
+  if (pendingStarts.has(sessionId)) return;
+  pendingStarts.add(sessionId);
+
   if (IS_DESKTOP) {
-    await Promise.all([getBackendUrl(), getBackendToken()]);
+    try {
+      await Promise.all([getBackendUrl(), getBackendToken()]);
+    } catch (err) {
+      pendingStarts.delete(sessionId);
+      throw err;
+    }
   }
 
   ensureGlobalListeners();
@@ -706,6 +723,7 @@ export async function startStream(sessionId: string, streamId: string): Promise<
   }, IDLE_CHECK_INTERVAL_MS);
 
   instances.set(sessionId, instance);
+  pendingStarts.delete(sessionId);
 }
 
 // ─── Global cross-stream listeners (installed once on first start) ───

--- a/frontend/src/lib/session-stream-registry.ts
+++ b/frontend/src/lib/session-stream-registry.ts
@@ -35,6 +35,12 @@ import type { PaginatedMessages } from "@/types/message";
 
 const PROGRESSIVE_BUFFER_INTERVAL_MS = 60;
 
+// After a desktop backend restart, wait a beat before reconciling: the
+// companion onBackendRestart handler in constants.ts (registered at module
+// load, fires in the same event dispatch) must reset the URL/token caches
+// first, and the freshly-spawned backend needs a moment to bind its port.
+const RESTART_RECONCILE_DELAY_MS = 250;
+
 class ProgressiveBuffer {
   private pending = "";
   private timerId: ReturnType<typeof setTimeout> | null = null;
@@ -609,6 +615,10 @@ export async function startStream(sessionId: string, streamId: string): Promise<
   });
 
   client.on(SSE_EVENTS.DONE, async () => {
+    // Close synchronously before the awaits below: the stream ends right after
+    // DONE, so the dying EventSource must not schedule a reconnect to a job
+    // that is already complete (→ a spurious "Job not found").
+    client.close();
     cancelPendingStepFinish();
     textBuffer.flush();
     reasoningBuffer.flush();
@@ -629,10 +639,22 @@ export async function startStream(sessionId: string, streamId: string): Promise<
     stopStream(sessionId);
   });
 
-  const handleAgentError = async (data: { error_message?: string | null }) => {
+  const handleAgentError = async (data: { error_message?: string | null; code?: string | null }) => {
+    // Close the dead connection synchronously, before the awaits below. The
+    // server ends the response right after this single error event, so the
+    // EventSource would otherwise fire onerror mid-await and schedule a
+    // reconnect to a stream the backend no longer has.
+    client.close();
+
     const message = data.error_message ?? "Unknown stream error";
+    // A missing job almost always means the local backend restarted out from
+    // under an in-flight generation. The conversation is safe in the DB, so
+    // recover quietly rather than alarming the user with an opaque toast.
+    const streamGone = data.code === "JOB_NOT_FOUND" || message === "Job not found";
     const contextLimitError = /maximum context length|requested about/i.test(message);
-    if (contextLimitError) {
+    if (streamGone) {
+      // Silent — recovered from the DB below.
+    } else if (contextLimitError) {
       toast.error("Context too long for this model. Start a new chat or shorten the conversation.");
     } else {
       toast.error(message);
@@ -652,7 +674,7 @@ export async function startStream(sessionId: string, streamId: string): Promise<
       }, 500);
       qc.invalidateQueries({ queryKey: queryKeys.sessions.detail(sessionId) });
     }
-    maybeNotifyFinish(sessionId, "error", message);
+    if (!streamGone) maybeNotifyFinish(sessionId, "error", message);
     stopStream(sessionId);
   };
   client.on(SSE_EVENTS.AGENT_ERROR, handleAgentError);
@@ -698,7 +720,14 @@ function ensureGlobalListeners(): void {
       for (const inst of instances.values()) inst.client.pauseReconnect();
     });
     unlistenBackendRestarted = desktopAPI.onBackendRestart(() => {
-      for (const inst of instances.values()) inst.client.resumeReconnect();
+      // Stop every client's auto-reconnect immediately so none races to a
+      // stream_id the freshly-restarted backend no longer has — that race is
+      // exactly what produced the spurious "Job not found" toasts. Then
+      // reconcile against the new backend once its caches/port have settled.
+      for (const inst of instances.values()) inst.client.pauseReconnect();
+      setTimeout(() => {
+        void reconcileStreamsAfterRestart();
+      }, RESTART_RECONCILE_DELAY_MS);
     });
   }
 
@@ -730,6 +759,86 @@ function ensureGlobalListeners(): void {
 
 function store_isGenerating(sessionId: string): boolean {
   return useChatStore.getState().sessions[sessionId]?.isGenerating ?? false;
+}
+
+/**
+ * After a desktop backend restart the in-memory StreamManager is empty: every
+ * pre-restart stream_id is gone. Blindly reconnecting those dead ids is what
+ * surfaced "Job not found" to users. Instead, ask the new backend which
+ * generations are actually still running and reconcile each live stream:
+ *  - resume it if it survived (a health blip that didn't kill the process),
+ *  - re-attach if the backend now reports a different job for that session,
+ *  - otherwise finalize it from the DB (the generation died with the old
+ *    process; the conversation itself is safe).
+ */
+async function reconcileStreamsAfterRestart(): Promise<void> {
+  if (instances.size === 0) return;
+
+  let activeJobs: Array<{ stream_id: string; session_id: string }> | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      activeJobs = await api.get<Array<{ stream_id: string; session_id: string }>>(API.CHAT.ACTIVE);
+      break;
+    } catch {
+      // New backend not serving yet — back off and retry.
+      await new Promise((r) => setTimeout(r, 400 * (attempt + 1)));
+    }
+  }
+
+  if (activeJobs === null) {
+    // Couldn't confirm backend state. Don't strand the UI in "generating":
+    // finalize each interrupted session from the DB so spinners clear and
+    // history is refetched. A later user action re-establishes streaming.
+    for (const inst of [...instances.values()]) {
+      await finalizeInterruptedStream(inst.sessionId);
+    }
+    return;
+  }
+
+  const liveStreamBySession = new Map(activeJobs.map((job) => [job.session_id, job.stream_id]));
+
+  // Sessions we already track are reconciled in the loop below; the final
+  // attach loop must skip them so it can't double-start one whose async
+  // startStream() has not yet re-registered its instance.
+  const handledSessions = new Set(instances.keys());
+
+  for (const inst of [...instances.values()]) {
+    const liveStreamId = liveStreamBySession.get(inst.sessionId);
+    if (liveStreamId === inst.streamId) {
+      inst.client.resumeReconnect();
+    } else if (liveStreamId) {
+      stopStream(inst.sessionId);
+      useChatStore.getState().startGeneration(inst.sessionId, liveStreamId);
+      void startStream(inst.sessionId, liveStreamId);
+    } else {
+      await finalizeInterruptedStream(inst.sessionId);
+    }
+  }
+
+  // Attach any still-running jobs we are not yet tracking (parity with boot
+  // hydration — e.g. a background session started just before the restart).
+  for (const job of activeJobs) {
+    if (handledSessions.has(job.session_id) || instances.has(job.session_id)) continue;
+    useChatStore.getState().startGeneration(job.session_id, job.stream_id);
+    void startStream(job.session_id, job.stream_id);
+  }
+}
+
+/**
+ * Wind down a stream whose backend job no longer exists: flush partial output,
+ * drop the dead client, clear the generating flag, and refetch authoritative
+ * state from the DB. No error toast — an interrupted local generation is a
+ * recoverable, expected event, not a failure the user must act on.
+ */
+async function finalizeInterruptedStream(sessionId: string): Promise<void> {
+  stopStream(sessionId); // disposeInstance flushes buffered text while still generating
+  useChatStore.getState().finishGeneration(sessionId);
+  const qc = queryClientRef;
+  if (qc) {
+    await qc.invalidateQueries({ queryKey: queryKeys.messages.list(sessionId) });
+    qc.invalidateQueries({ queryKey: queryKeys.sessions.all });
+    qc.invalidateQueries({ queryKey: queryKeys.sessions.detail(sessionId) });
+  }
 }
 
 /**

--- a/frontend/src/types/streaming.ts
+++ b/frontend/src/types/streaming.ts
@@ -81,6 +81,8 @@ export interface SSEEventData {
   // error
   error_type?: string | null;
   error_message?: string | null;
+  /** Machine-readable error tag (e.g. "JOB_NOT_FOUND") for quiet recovery. */
+  code?: string | null;
 
   // done
   finish_reason?: string | null;


### PR DESCRIPTION
## What

"Job not found" errors appeared mid-conversation in the desktop app. Root cause: when the local backend restarts (watchdog after repeated health failures, or a crash), its **in-memory `StreamManager` is wiped**, but the frontend's persistent SSE registry called `resumeReconnect()` on every surviving stream — reconnecting to `stream_id`s the new backend no longer has → an alarming "Job not found" toast. Regression exposed by the v1.2.0 background-session refactor (#121).

No data was ever lost (history lives in the DB and the UI recovered), but the error looked random and scary.

## Fix

- On `backend-restart`, **pause all streams immediately**, then **reconcile against the new backend's `/chat/active`** instead of blindly reconnecting: resume survivors, re-attach if the backend now reports a different job for a session, and **finalize the rest from the DB** (clear the spinner, refetch messages — no toast). Guarded against an async `startStream` double-start race.
- Backend tags the missing-job error with `code="JOB_NOT_FOUND"`; the client treats it as a **quiet, recoverable event** (refetch DB state, clear spinner) rather than `toast.error(...)`.
- Close the SSE client **synchronously** in the `DONE` / agent-error handlers, before their `await`s, to kill a self-reconnect race that could re-hit the just-ended stream.

## Files

- `frontend/src/lib/session-stream-registry.ts` — reconcile-on-restart, silent `JOB_NOT_FOUND` recovery, close-before-await
- `backend/app/api/chat.py` — `code="JOB_NOT_FOUND"` on the missing-job error stream
- `frontend/src/types/streaming.ts` — `code?` on `SSEEventData`
- `backend/tests/test_streaming/test_lifecycle_contract.py` — assert the new code

## Verification

- `backend/tests/test_streaming` + `test_api/test_e2e`: **27 passed, 6 (pre-existing) skipped**.
- Frontend `tsc --noEmit` and `eslint` clean.
- ⚠️ **Not yet exercised in a live desktop build.** Manual check needed: kill the backend mid-generation and confirm the UI recovers silently (no "Job not found" toast, spinner clears, history intact).

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
