### PR TITLE
Warn up front when attaching images to a non-vision model

### DIFF
--- a/frontend/src/components/chat/chat-form.tsx
+++ b/frontend/src/components/chat/chat-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from 'react-i18next';
-import { Check, ChevronDown, GitBranch, Play, Plus, Trash2 } from "lucide-react";
+import { AlertTriangle, Check, ChevronDown, GitBranch, Play, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ChatTextarea } from "./chat-textarea";
@@ -21,6 +21,7 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useProviderModels } from "@/hooks/use-provider-models";
 import { useIndexStatus } from "@/hooks/use-index-status";
 import { useAgents } from "@/hooks/use-agents";
+import { hasImageAttachments, selectedModelSupportsVision } from "@/hooks/use-chat";
 import { IS_DESKTOP } from "@/lib/constants";
 import type { TaskBatchMode, TaskBatchTask } from "@/types/chat";
 
@@ -237,6 +238,13 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
   const selectedModel = useSettingsStore((s) => s.selectedModel);
   const selectedProviderId = useSettingsStore((s) => s.selectedProviderId);
   const noModelsAvailable = !activeProvider || providerModels.length === 0;
+  // Surface the vision constraint up front: an image is attached but the
+  // selected model can't read images. The send is also blocked server-side and
+  // in useChat, but that only fires on send — leaving the composer looking like
+  // nothing happened. This warns the moment the image is added.
+  const imageNeedsVisionModel =
+    hasImageAttachments(attachments) &&
+    !selectedModelSupportsVision(providerModels, selectedModel, selectedProviderId);
 
   const sendingRef = useRef(false);
   const taskDraftIdRef = useRef(0);
@@ -727,6 +735,13 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
               </div>
             )}
 
+            {imageNeedsVisionModel && (
+              <div className="flex items-start gap-1.5 pb-2 text-xs text-[var(--color-warning)]">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-px" />
+                <span>{t('imageNeedsVisionModel')}</span>
+              </div>
+            )}
+
             <ChatTextarea
               ref={ref}
               value={input}
@@ -763,6 +778,7 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
                 disabled={isInputDisabled}
                 className="shrink-0 flex items-center justify-center h-8 w-8 rounded-full hover:bg-[var(--surface-tertiary)] transition-colors text-[var(--text-secondary)]"
                 aria-label={t('attachFile')}
+                title={t('attachFile')}
                 onClick={handleBrowse}
               >
                 <Plus className="h-4 w-4" />

--- a/frontend/src/components/chat/chat-form.tsx
+++ b/frontend/src/components/chat/chat-form.tsx
@@ -244,6 +244,7 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
   // nothing happened. This warns the moment the image is added.
   const imageNeedsVisionModel =
     hasImageAttachments(attachments) &&
+    !!selectedModel &&
     !selectedModelSupportsVision(providerModels, selectedModel, selectedProviderId);
 
   const sendingRef = useRef(false);

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -31,11 +31,11 @@ function isImageAttachment(attachment: FileAttachment): boolean {
   return IMAGE_EXTENSIONS.has(source.slice(dot).toLowerCase());
 }
 
-function hasImageAttachments(attachments?: FileAttachment[]): boolean {
+export function hasImageAttachments(attachments?: FileAttachment[]): boolean {
   return !!attachments?.some(isImageAttachment);
 }
 
-function selectedModelSupportsVision(
+export function selectedModelSupportsVision(
   models: ModelInfo[] | undefined,
   modelId: string | null,
   providerId: string | null,

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -6,6 +6,7 @@
   "noModelPlaceholder": "No model available — configure a provider in Settings first",
   "placeholderMention": " (@ to mention files)",
   "attachFile": "Attach file",
+  "imageNeedsVisionModel": "This model can't read images. Switch to a vision-capable model to send them.",
   "uploading": "Uploading...",
   "duplicateFilesSkipped": "{{count}} duplicate file skipped",
   "duplicateFilesSkipped_other": "{{count}} duplicate files skipped",

--- a/frontend/src/i18n/locales/zh/chat.json
+++ b/frontend/src/i18n/locales/zh/chat.json
@@ -6,6 +6,7 @@
   "noModelPlaceholder": "暂无可用模型 — 请先在设置中配置服务商",
   "placeholderMention": "（@ 提及文件）",
   "attachFile": "附加文件",
+  "imageNeedsVisionModel": "当前模型无法识别图片，请切换到支持视觉的模型后再发送。",
   "uploading": "上传中...",
   "duplicateFilesSkipped": "已跳过 {{count}} 个重复文件",
   "duplicateFilesSkipped_other": "已跳过 {{count}} 个重复文件",


### PR DESCRIPTION
## What

File attachment works — documents (DOCX/PDF/XLSX/CSV) send fine. But attaching an **image** to a non-vision model only failed at **send time** with a transient toast, so it looked like "nothing happens." The shipped default local model (`qwen3.5-4b`) is non-vision, so this hit default users out of the box. The attach control is also a bare `+`, easy to miss.

## Fix

- **Front-load the constraint**: when an image is attached and the selected model lacks vision, show a **persistent inline warning** above the composer (`chat-form.tsx`) instead of only erroring on send. Exported `hasImageAttachments` / `selectedModelSupportsVision` from `use-chat.ts` for reuse. The existing send-time block (and the backend `MODEL_DOES_NOT_SUPPORT_IMAGES` 400) stay as backstops.
- Add a `title` tooltip to the `+` attach button for discoverability.
- New `imageNeedsVisionModel` string (`en` + `zh`).

## Files

- `frontend/src/components/chat/chat-form.tsx`, `frontend/src/hooks/use-chat.ts`
- `frontend/src/i18n/locales/{en,zh}/chat.json`

## Verification

- `tsc --noEmit` and `eslint` clean; both locale JSON files validated.
- ⚠️ **Not yet exercised in a live build.** Manual check needed: attach an image on a non-vision model and confirm the warning appears (and disappears after switching to a vision model).

Note: the mobile composer (`src/app/(mobile)/m/new/page.tsx`) has its own independent gate and is **not** covered here — follow-up if desired.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
