### PR TITLE
Fix chat display glitches in the optimistic → persisted handoff

### DIFF
--- a/frontend/src/components/messages/assistant-message.tsx
+++ b/frontend/src/components/messages/assistant-message.tsx
@@ -156,14 +156,17 @@ export const StreamingMessage = memo(function StreamingMessage({ sessionId, part
     return result;
   }, [parts, streamingReasoning, streamingText]);
 
-  // No content yet — show blinking cursor to indicate "about to type"
+  // No content yet — show a SINGLE "Thinking" stage indicator (the same one
+  // the content phase renders at the top, so it carries over seamlessly).
+  //
+  // Deliberately render it WITHOUT the animate-fade-in wrapper: sending the
+  // first message navigates Landing → /c/{id}, which unmounts and remounts
+  // this component mid-think. Fading the bare indicator back in on that
+  // remount reads as a page "jolt" followed by a second thinking animation.
+  // (This phase also used to stack a separate StreamingIndicator dot-row on
+  // top of the stage, so two different thinking animations showed at once.)
   if (liveParts.length === 0) {
-    return (
-      <div className={freshMountRef.current ? "animate-fade-in" : undefined}>
-        <StreamingStage label={t("stageThinking")} />
-        <StreamingIndicator />
-      </div>
-    );
+    return <StreamingStage label={t("stageThinking")} />;
   }
 
   // Check if there's active text/reasoning streaming.
@@ -181,7 +184,12 @@ export const StreamingMessage = memo(function StreamingMessage({ sessionId, part
   const lastStepFinish = [...liveParts].reverse().find((p) => p.type === "step-finish") as
     | (PartData & { type: "step-finish"; reason?: string }) | undefined;
   const isGenerationDone = !!lastStepFinish && lastStepFinish.reason !== "tool_use";
-  const showTail = !isActivelyStreaming && !hasRunningTool && !isGenerationDone;
+  // Only trail the dot-row when there is actual activity (reasoning/tool)
+  // above it. Without this gate, an early step-start part (no visible content
+  // yet) renders the StreamingStage line AND the trailing dots at the same
+  // time — two different "thinking" animations stacked. The stage line already
+  // covers the no-activity case.
+  const showTail = hasAnyActivity && !isActivelyStreaming && !hasRunningTool && !isGenerationDone;
 
   let stageLabel = t("stageThinking");
   if (hasRunningTool) stageLabel = t("stageWorkingWithTools");

--- a/frontend/src/components/messages/message-list.tsx
+++ b/frontend/src/components/messages/message-list.tsx
@@ -150,6 +150,7 @@ export function MessageList({
     if (anchoredSessionRef.current === sessionId) return;
     anchoredSessionRef.current = sessionId;
     setCanFetchOlderMessages(false);
+    streamedHandoffIdsRef.current = new Set();
   }, [sessionId]);
 
   useEffect(() => {
@@ -196,6 +197,14 @@ export function MessageList({
   // Messages that appear later are "new" — animate in.
   const knownIdsRef = useRef<Set<string>>(new Set());
   const initialLoadDoneRef = useRef(false);
+
+  // Message IDs whose content was already shown live by the StreamingMessage.
+  // When the stream ends, the persisted DB bubble replaces the live one in the
+  // same commit. Without this, the persisted bubble counts as "new" and fades
+  // in from opacity 0 — so the content jumps from the stream's opacity-1 down
+  // to 0 and fades back, reading as the message blinking out and flashing back.
+  // Recording these IDs lets us suppress that entry animation on handoff.
+  const streamedHandoffIdsRef = useRef<Set<string>>(new Set());
 
   // On first non-loading render with messages, seed the known IDs set
   useEffect(() => {
@@ -348,6 +357,40 @@ export function MessageList({
     );
   }
 
+  // The last assistant group is the live response while a stream is active for
+  // this session (streamId set) or during the brief post-finish fallback. Its
+  // content is shown by StreamingMessage throughout, so when the stream ends
+  // and the persisted DB bubble takes over, that bubble must NOT animate in —
+  // a fade would read as the just-finished response blinking out and flashing
+  // back. Record its IDs here (the moment it becomes the last group under an
+  // active stream, regardless of whether streaming content is "visible" yet)
+  // so the swap to the persisted bubble is always seamless. Skipped while
+  // showPendingBubble is true — then the last assistant group is a PREVIOUS
+  // turn that should stay untouched.
+  const lastGroupForCover = groups[groups.length - 1];
+  if (
+    (hasActiveStream || showStreamingFallback) &&
+    !showPendingBubble &&
+    lastGroupForCover?.kind === "assistant"
+  ) {
+    for (const m of lastGroupForCover.messages) {
+      streamedHandoffIdsRef.current.add(m.id);
+    }
+  }
+
+  // The most-recent user message must not animate in either: on send it hands
+  // off from the optimistic bubble (which already played the send animation),
+  // and otherwise it's known history. Keying off "latest user message" instead
+  // of pendingUserText avoids the same fast-turn race the assistant fix hit —
+  // the persisted copy can land AFTER pendingUserText is cleared.
+  let lastUserMessageId: string | null = null;
+  for (let i = groups.length - 1; i >= 0; i--) {
+    if (groups[i].kind === "user") {
+      lastUserMessageId = (groups[i] as { kind: "user"; message: MessageResponse }).message.id;
+      break;
+    }
+  }
+
   return (
     <div className="relative flex-1 overflow-hidden">
       <div
@@ -375,7 +418,7 @@ export function MessageList({
                   <MessageItem
                     key={group.message.id}
                     message={group.message}
-                    isNew={newMessageIds.has(group.message.id)}
+                    isNew={newMessageIds.has(group.message.id) && group.message.id !== lastUserMessageId}
                     onEditAndResend={onEditAndResend}
                     isGenerating={isGenerating}
                     directory={directory}
@@ -401,8 +444,21 @@ export function MessageList({
               const isLastOverall =
                 messages.length > 0 && lastMsg.id === messages[messages.length - 1].id;
 
-              // Check if any message in the group is new
-              const groupIsNew = group.messages.some((m) => newMessageIds.has(m.id));
+              // Assistant content always streams in live (via StreamingMessage)
+              // before it persists, so the persisted bubble must NOT also fade
+              // in — that double-appearance is the "blink out then flash back"
+              // seen at stream end. The last assistant group is always either
+              // the just-streamed response or known history, so it never
+              // animates. (The final reply can finalize as a fresh message id
+              // AFTER the stream ends — e.g. tool-call turns — so keying off the
+              // streamed id alone misses it; the isLastOverall guard catches
+              // every timing.) streamedHandoffIdsRef additionally covers a
+              // streamed reply that a later message, like a post-compaction
+              // summary, pushed out of last place.
+              const groupIsNew =
+                !isLastOverall &&
+                group.messages.some((m) => newMessageIds.has(m.id)) &&
+                !group.messages.some((m) => streamedHandoffIdsRef.current.has(m.id));
 
               if (
                 (hasActiveStream || showStreamingFallback) &&

--- a/frontend/src/stores/chat-store.ts
+++ b/frontend/src/stores/chat-store.ts
@@ -244,15 +244,22 @@ export const useChatStore = create<ChatStore>((set) => ({
 
   startGeneration: (sessionId, streamId) =>
     set((s) => {
-      // Seed sessions[sessionId] from the draft bucket if one exists (Landing
-      // flow just got a session id from the backend). The draft is left in
-      // place on purpose — Landing keeps reading from it until route
-      // navigation unmounts the page, which prevents the streaming view from
-      // flashing back to the empty landing layout. Landing's own mount
-      // effect resets the draft on the next fresh chat.
+      // Seed sessions[sessionId] for this generation. Prefer an EXISTING
+      // bucket over the draft: a follow-up message calls
+      // beginSending(sessionId, ...) which just wrote the fresh pendingUserText
+      // (and attachments) onto sessions[sessionId]. The draft bucket lingers
+      // after the Landing → new-session handoff — it is intentionally not reset
+      // until the next fresh /c/new mount — so falling back to it here would
+      // clobber the follow-up's pendingUserText with stale draft state. That
+      // made the just-sent user bubble vanish during loading and, via
+      // showPendingBubble, also hid the previous assistant reply.
+      //
+      // The draft is only the correct seed for the Landing handoff itself,
+      // where the backend just assigned an id and sessions[newId] doesn't
+      // exist yet (existing === undefined) — so it still wins in that case.
       const draft = s.draftSession;
       const existing = s.sessions[sessionId];
-      const base: ChatSessionState = draft ?? existing ?? EMPTY_SESSION_STATE;
+      const base: ChatSessionState = existing ?? draft ?? EMPTY_SESSION_STATE;
       const next: ChatSessionState = {
         ...base,
         streamId,


### PR DESCRIPTION
## What

A cluster of chat-view display glitches, all from one root cause: the **optimistic / streaming view doesn't hand off seamlessly to the persisted DB view**, so content briefly vanishes or re-animates. Found bug-bashing the web build (#138).

1. **Follow-up message + previous reply vanish while loading** — a stale `draftSession` bucket left from the Landing handoff clobbered the live session's optimistic `pendingUserText`.
2. **Two "thinking" animations + a page jolt** — the streaming view rendered a stage indicator and a trailing dot-row at once, and a fade wrapper re-ran on the Landing → `/c/[id]` remount.
3. **Agent reply blinks out then flashes back at stream end** (突然消失然后闪现) — the persisted DB bubble re-faded from opacity 0 when it replaced the live `StreamingMessage` in the same commit. Worse on tool-call turns, where the reply finalizes as a **fresh message id after the stream ends**.
4. **User bubble double-fades** on follow-ups — the optimistic bubble fades in, then the persisted copy fades in *again* from transparent.

## Fix

- **chat-store** — prefer the existing session bucket over the draft in `startGeneration`, so the live session's optimistic state isn't clobbered by a lingering draft.
- **assistant-message** — collapse the no-content phase to a single stage indicator; make the stage line and trailing dot-row mutually exclusive; drop the remount fade wrapper that caused the jolt.
- **message-list** — the **last assistant group** and the **most-recent user message** never play the entry animation: each is always either the just-streamed/just-sent content (already on screen at opacity 1) or known history. This is **timing-independent**, so it covers the fast-turn / tool-call / post-`pendingUserText`-clear races that id- or text-based suppression kept missing. A secondary `streamedHandoffIdsRef` covers a streamed reply that a later message (e.g. a compaction summary) pushes out of last place.

## Files

- `frontend/src/stores/chat-store.ts` — existing-bucket-over-draft in `startGeneration`
- `frontend/src/components/messages/assistant-message.tsx` — single streaming indicator, no remount jolt
- `frontend/src/components/messages/message-list.tsx` — suppress entry animation for the just-streamed assistant group + the most-recent user message

## Verification

Driven in the **web** dev build with an instrumented `MutationObserver` that records any element fading from opacity < 1, tagged by text content:

| Path | Spurious fade? |
|---|---|
| Follow-up · fast / slow (48s reasoning) / tool-call turns | none |
| First message in a fresh session (Landing → navigation) | none |
| User bubble | only the optimistic send animation (intended) |

After each run nothing is left below full opacity, and every message renders exactly once (no duplicate / missing). `tsc --noEmit` and `eslint` clean.

⚠️ Verified in the **web** dev build — not yet in a packaged desktop (Tauri) build.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
