### PR TITLE
Fix session rename flashing shut when triggered from a menu (#144)

### DIFF
--- a/frontend/src/components/layout/session-item.tsx
+++ b/frontend/src/components/layout/session-item.tsx
@@ -430,14 +430,26 @@ export const SessionItem = memo(function SessionItem({
                   <EllipsisVertical className="h-3.5 w-3.5" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent
+                align="end"
+                className="w-48"
+                // Don't restore focus to the trigger on close: when "Rename" is
+                // selected it would steal focus from the just-opened inline input,
+                // blurring it and instantly committing+closing the rename ("一闪而过").
+                onCloseAutoFocus={(e) => e.preventDefault()}
+              >
                 <MenuItems Item={DropdownMenuItem} Separator={DropdownMenuSeparator} />
               </DropdownMenuContent>
             </DropdownMenu>
           )}
         </div>
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-48">
+      <ContextMenuContent
+        className="w-48"
+        // See DropdownMenuContent above: prevent focus-restore so a "Rename"
+        // selection doesn't blur the inline input out of existence.
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         <MenuItems Item={ContextMenuItem} Separator={ContextMenuSeparator} />
       </ContextMenuContent>
     </ContextMenu>

--- a/frontend/tests/ui/openyak-deep-surfaces.spec.ts
+++ b/frontend/tests/ui/openyak-deep-surfaces.spec.ts
@@ -139,6 +139,12 @@ test.describe("OpenYak deep claimed-feature GUI surfaces", () => {
     await alphaAfterPin.locator("button").last().click();
     await page.getByRole("menuitem", { name: /Rename/i }).click();
     await expect(alphaAfterPin.locator('input[type="text"]')).toBeVisible();
+    // #144: after the menu closes the rename input must keep focus — otherwise it
+    // blurs, commits empty, and "flashes" shut ("一闪而过"). The underlying focus-
+    // restore race is engine-timing-specific (loses on Windows WebView2; chromium
+    // wins it either way), so this pins the intended contract — it does not by
+    // itself reproduce the platform bug.
+    await expect(alphaAfterPin.locator('input[type="text"]')).toBeFocused();
     await alphaAfterPin.locator('input[type="text"]').fill("Quarterly planning notes renamed");
     await page.keyboard.press("Enter");
     await expect(page.getByRole("option", { name: /Quarterly planning notes renamed/i })).toBeVisible();


### PR DESCRIPTION
## Summary

- Fix session rename "一闪而过" — the inline rename input opened and instantly closed when triggered from a menu, making rename impossible.

## Motivation

Fixes #144 (split from discussion #129, reported on Windows desktop v1.2.0).

Triggering **Rename** from the right-click `ContextMenu` or the ••• `DropdownMenu` opened the inline input and immediately closed it before the user could type. This is **distinct from #135** (discoverability), which did not address it — menu-triggered rename still flashed on v1.2.1; only the double-click path happened to work.

**Root cause:** on close, Radix restores focus to the menu's trigger. That focus-restore lands *after* the input's `requestAnimationFrame` focus, blurring the input → `onBlur` → `handleSubmitRename` (commits empty) → `onEditEnd` → `editingId=null` → the input unmounts. The ordering is engine-timing-sensitive, so it loses on **Windows WebView2** but typically wins on **macOS WKWebView / chromium** — which is why it wasn't seen in dev or CI.

## Changes

### Frontend
- `session-item.tsx`: add `onCloseAutoFocus={(e) => e.preventDefault()}` to both `ContextMenuContent` and `DropdownMenuContent`, so the menu no longer yanks focus back to its trigger and the explicit input focus survives. Same pattern already used in `projects-toolbar.tsx:176`.
- `openyak-deep-surfaces.spec.ts`: add a `toBeFocused()` assertion to the existing sidebar rename test, pinning the contract that the rename input keeps focus after the menu closes.

### Backend
- None.

## How to Test

1. **Windows desktop (the real repro):** hover a session → right-click (or ••• menu) → **Rename**. The inline input should appear, be focused with the title selected, and **stay open** until Enter/Escape/click-away. Repeat with the ••• menu.
2. Automated: `cd frontend && npx playwright test -g "sidebar workflow: pin, rename" --project=chromium`.

## Checklist

- [x] Self-reviewed the diff
- [x] No unrelated changes included
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Backend tests pass (`pytest`) — N/A, frontend-only
- [ ] Tested manually in desktop app — ⚠️ **needs a Windows smoke-test:** the race only loses on Windows WebView2; chromium/macOS win it regardless, so the automated test confirms *no regression* and the focus contract but cannot reproduce the platform bug. Verified clean on macOS via the mocked-backend UI test.
- [ ] Updated documentation if needed — N/A

## Screenshots / Recordings

N/A (focus-timing fix; no visual change to the happy path).
