### PR TITLE
Keep the persisted model from resetting to the default on load (#146)

### DIFF
--- a/frontend/src/components/selectors/header-model-dropdown.tsx
+++ b/frontend/src/components/selectors/header-model-dropdown.tsx
@@ -138,6 +138,7 @@ export function HeaderModelDropdown() {
   const [open, setOpen] = useState(false);
   const {
     data: models,
+    allModels,
     isLoading,
     isError,
     activeProvider,
@@ -160,6 +161,13 @@ export function HeaderModelDropdown() {
 
   // Auto-select a sensible default when no model is selected or current model doesn't exist in the active provider
   useEffect(() => {
+    // Don't touch the selection until the models list has actually loaded. While
+    // the query is still loading/refetching `allModels` is undefined and
+    // `visibleModels` is transiently empty — running the reset below in that
+    // window would wipe the user's persisted model and then auto-pick the
+    // default, silently swapping their model out (cold load, or returning from
+    // settings while /models is stale/refetching). See #146.
+    if (!allModels) return;
     if (visibleModels.length === 0) {
       if (selectedModel) setSelectedModel(null);
       return;
@@ -185,6 +193,7 @@ export function HeaderModelDropdown() {
       setSelectedModel(chosen.id, chosen.provider_id);
     }
   }, [
+    allModels,
     visibleModels,
     selectedModel,
     selectedProviderId,

--- a/frontend/tests/ui/openyak-deep-surfaces.spec.ts
+++ b/frontend/tests/ui/openyak-deep-surfaces.spec.ts
@@ -122,6 +122,43 @@ test.describe("OpenYak deep claimed-feature GUI surfaces", () => {
     await expectNoAppCrash(page);
   });
 
+  test("model selector workflow: a persisted model survives a slow models load and is not reset to the default (#146)", async ({ page }) => {
+    const state = await setupMockedApp(page);
+    // Persist an explicit, NON-default custom model. For the "custom" provider the
+    // fixture lists Qwen3 Coder Local first (the default) and Acme Coder second.
+    await page.addInitScript(() => {
+      const raw = window.localStorage.getItem("openyak-settings");
+      const settings = raw ? JSON.parse(raw) : { state: {}, version: 0 };
+      settings.state = {
+        ...settings.state,
+        hasCompletedOnboarding: true,
+        activeProvider: "custom",
+        selectedModel: "custom_acme/acme-coder",
+        selectedProviderId: "custom_acme",
+      };
+      window.localStorage.setItem("openyak-settings", JSON.stringify(settings));
+    });
+    // Widen the models-loading window so the persisted choice hydrates while the
+    // list is still empty — the exact race that used to wipe the selection and
+    // auto-pick the default. Fall back to the standard mock for the payload.
+    await page.route("**/api/models", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await route.fallback();
+    });
+
+    await page.goto("/c/new");
+
+    // The composer must keep the persisted model, not swap to the default
+    // (visibleModels[0] = "Qwen3 Coder Local").
+    await expect(page.getByRole("button", { name: /Acme Coder/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Qwen3 Coder Local/i })).toHaveCount(0);
+
+    // And the model actually sent matches the persisted choice.
+    await sendPrompt(page, "Confirm the persisted model survived the load");
+    expect(JSON.stringify(state.promptBodies[0])).toContain("custom_acme/acme-coder");
+    await expectNoAppCrash(page);
+  });
+
   test("sidebar workflow: pin, rename, export, delete confirmation, and undo are reachable from the real menu", async ({ page }) => {
     const state = await setupMockedApp(page);
 


### PR DESCRIPTION
## Summary

- Stop the chat composer's model from silently resetting to the provider default when the models list reloads (e.g. returning from Settings). The explicitly chosen model now sticks — the "pin" the reporter asked for.

## Motivation

Fixes #146 (split from discussion #129, bug 2 of 2).

> 模型有时候会变，能不能钉住具体模型？ (the model sometimes changes — can you pin a specific model?)

**Root cause:** the auto-select effect in `header-model-dropdown.tsx` ran *while the models query was still loading*. During that window `allModels` is `undefined`, so `visibleModels` is transiently `[]`, and the effect executed `setSelectedModel(null)` and then auto-picked `visibleModels[0]` once the list arrived. On a cold models query — app start, or returning from Settings while `/models` is stale/refetching (provider panels call `invalidateQueries(queryKeys.models)`) — the user's persisted choice was dropped and replaced by the default.

## Changes

### Frontend
- `header-model-dropdown.tsx`: gate the auto-select effect on the list having loaded — `if (!allModels) return;`. The persisted selection is now preserved across loads/refetches and only changes when the chosen model genuinely no longer exists in a *settled* list (true first-run, or the model was removed). `allModels` added to the destructure and to the effect deps.
- `openyak-deep-surfaces.spec.ts`: regression test — a persisted non-default model (`custom_acme/acme-coder`) survives a deliberately slowed `/models` load and is not swapped for the default (`local/qwen3-coder`). **Fails without the fix** (verified by reverting the one-liner).

### Backend
- None.

## How to Test

1. Pick a non-default model in the composer, open Settings (or anything that reloads `/models`), return to the chat — the chosen model stays selected.
2. Automated: `cd frontend && npx playwright test -g "persisted model survives" --project=chromium`.

## Checklist

- [x] Self-reviewed the diff
- [x] No unrelated changes included
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Backend tests pass (`pytest`) — N/A, frontend-only
- [x] Tested manually in desktop app — verified via the new UI test (mocked backend, real app); the test deterministically reproduces the bug (fails without the fix) and passes with it
- [ ] Updated documentation if needed — N/A

## Screenshots / Recordings

N/A (selection-state fix; no visual change beyond the model name staying correct).
