### PR TITLE
Scoped permission memory: remember approvals per command family / path, not per tool

### DIFF
--- a/backend/app/agent/permission.py
+++ b/backend/app/agent/permission.py
@@ -110,6 +110,15 @@ def presets_to_ruleset(presets: dict[str, bool] | None) -> Ruleset:
     return Ruleset(rules=rules)
 
 
+def pattern_matches(value: str, pattern: str) -> bool:
+    """Public glob check: does this resource value fall under this pattern?
+
+    Used by the processor to validate that a user-chosen remember-scope
+    actually covers the resource that was just approved.
+    """
+    return _glob_match(value, pattern)
+
+
 def _glob_match(value: str, pattern: str) -> bool:
     """Glob match for permission patterns.
 

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -29,6 +29,7 @@ from app.agent.agent import AgentRegistry
 from app.agent.permission import (
     RejectedError,
     evaluate,
+    pattern_matches,
 )
 from app.provider.registry import ProviderRegistry
 from app.schemas.agent import PermissionRule
@@ -791,6 +792,12 @@ class SessionProcessor:
         rp = "*"
         if tool.id in _FILE_TOOLS:
             rp = ta.get("file_path", "*")
+        elif tool.id == "bash":
+            # The command is the resource, so pattern rules like "git *" can
+            # scope approvals to a command family instead of all of bash.
+            command = ta.get("command")
+            if isinstance(command, str) and command.strip():
+                rp = command.strip()
         action = evaluate(tool.id, rp, sp.merged_permissions)
 
         if action == "deny":
@@ -815,7 +822,7 @@ class SessionProcessor:
                     job.session_id,
                     sp,
                     permission=tool.id,
-                    pattern=rp,
+                    pattern=_resolve_remember_pattern(rp, decision.get("pattern")),
                     allow=bool(decision.get("allowed")),
                 )
             if not decision.get("allowed"):
@@ -1481,7 +1488,7 @@ async def _ask_permission(
     tool_name: str,
     tool_args: dict[str, Any],
     resource_pattern: str = "*",
-) -> dict[str, bool]:
+) -> dict[str, Any]:
     """Ask user for permission via SSE and wait for response."""
     permission_call_id = generate_ulid()
     arguments, truncated = _permission_arguments_for_event(tool_args)
@@ -1507,17 +1514,32 @@ async def _ask_permission(
         return _permission_decision_from_response(response)
     except TimeoutError:
         logger.warning("Permission request timed out for %s", tool_name)
-        return {"allowed": False, "remember": False}
+        return {"allowed": False, "remember": False, "pattern": None}
 
 
-def _permission_decision_from_response(response: Any) -> dict[str, bool]:
+def _permission_decision_from_response(response: Any) -> dict[str, Any]:
     if isinstance(response, dict):
+        pattern = response.get("pattern")
         return {
             "allowed": bool(response.get("allowed")),
             "remember": bool(response.get("remember")),
+            "pattern": pattern if isinstance(pattern, str) and pattern.strip() else None,
         }
     allowed = str(response).lower() in ("allow", "yes", "true", "1")
-    return {"allowed": allowed, "remember": False}
+    return {"allowed": allowed, "remember": False, "pattern": None}
+
+
+def _resolve_remember_pattern(resource: str, chosen: Any) -> str:
+    """Pick the pattern to remember for an approved permission.
+
+    The user-chosen scope is honored only if it actually covers the resource
+    that was just approved; anything else falls back to the exact resource.
+    """
+    if isinstance(chosen, str) and chosen.strip():
+        chosen = chosen.strip()
+        if pattern_matches(resource, chosen):
+            return chosen
+    return resource
 
 
 async def _remember_permission_rule(

--- a/backend/tests/test_agent/test_permission.py
+++ b/backend/tests/test_agent/test_permission.py
@@ -49,6 +49,28 @@ class TestEvaluate:
         rs = Ruleset(rules=[])
         assert evaluate("anything", "*", rs) == "deny"
 
+    def test_command_scoped_bash_rule(self):
+        # The processor passes the bash command as the resource, so a
+        # remembered "git *" rule covers the git family and nothing else.
+        rs = merge_rulesets(
+            GLOBAL_DEFAULTS,
+            Ruleset(rules=[
+                PermissionRule(action="allow", permission="bash", pattern="git *"),
+            ]),
+        )
+        assert evaluate("bash", "git push origin main", rs) == "allow"
+        assert evaluate("bash", "git status", rs) == "allow"
+        assert evaluate("bash", "rm -rf build", rs) == "ask"
+        # A remembered exact command matches only itself.
+        rs_exact = merge_rulesets(
+            GLOBAL_DEFAULTS,
+            Ruleset(rules=[
+                PermissionRule(action="allow", permission="bash", pattern="npm run preflight:ui"),
+            ]),
+        )
+        assert evaluate("bash", "npm run preflight:ui", rs_exact) == "allow"
+        assert evaluate("bash", "npm run deploy", rs_exact) == "ask"
+
     def test_exact_match(self):
         rs = Ruleset(rules=[
             PermissionRule(action="deny", permission="*"),

--- a/backend/tests/test_session/test_processor_permission.py
+++ b/backend/tests/test_session/test_processor_permission.py
@@ -4,6 +4,7 @@ from app.session.processor import (
     _permission_arguments_for_event,
     _permission_decision_from_response,
     _permission_message,
+    _resolve_remember_pattern,
 )
 from app.agent.agent import AgentRegistry
 from app.agent.permission import evaluate
@@ -61,19 +62,64 @@ def test_permission_message_shows_file_target_and_truncation() -> None:
 
 
 def test_permission_decision_accepts_legacy_bool() -> None:
-    assert _permission_decision_from_response(True) == {"allowed": True, "remember": False}
-    assert _permission_decision_from_response(False) == {"allowed": False, "remember": False}
+    assert _permission_decision_from_response(True) == {
+        "allowed": True,
+        "remember": False,
+        "pattern": None,
+    }
+    assert _permission_decision_from_response(False) == {
+        "allowed": False,
+        "remember": False,
+        "pattern": None,
+    }
 
 
 def test_permission_decision_accepts_remember_payload() -> None:
     assert _permission_decision_from_response({"allowed": True, "remember": True}) == {
         "allowed": True,
         "remember": True,
+        "pattern": None,
     }
     assert _permission_decision_from_response({"allowed": False, "remember": True}) == {
         "allowed": False,
         "remember": True,
+        "pattern": None,
     }
+
+
+def test_permission_decision_extracts_scope_pattern() -> None:
+    decision = _permission_decision_from_response(
+        {"allowed": True, "remember": True, "pattern": "git *"}
+    )
+    assert decision["pattern"] == "git *"
+
+    # Non-string / empty patterns are ignored, not remembered verbatim.
+    assert _permission_decision_from_response(
+        {"allowed": True, "remember": True, "pattern": 42}
+    )["pattern"] is None
+    assert _permission_decision_from_response(
+        {"allowed": True, "remember": True, "pattern": "   "}
+    )["pattern"] is None
+
+
+def test_resolve_remember_pattern_honors_covering_scope() -> None:
+    # Chosen scope covers the approved resource → honored.
+    assert _resolve_remember_pattern("git push origin main", "git *") == "git *"
+    assert _resolve_remember_pattern("/ws/report/q3.md", "/ws/report/*") == "/ws/report/*"
+    assert _resolve_remember_pattern("npm run build", "*") == "*"
+    # Exact resource is a valid scope of itself.
+    assert _resolve_remember_pattern("git status", "git status") == "git status"
+
+
+def test_resolve_remember_pattern_falls_back_on_mismatch() -> None:
+    # A scope that does not cover the approved resource falls back to the
+    # exact resource instead of persisting an unrelated rule.
+    assert _resolve_remember_pattern("git push", "npm *") == "git push"
+    assert _resolve_remember_pattern("/ws/a.txt", "/other/*") == "/ws/a.txt"
+    # Missing/blank/non-string scopes also fall back.
+    assert _resolve_remember_pattern("git push", None) == "git push"
+    assert _resolve_remember_pattern("git push", "") == "git push"
+    assert _resolve_remember_pattern("git push", 7) == "git push"
 
 
 class _Provider:

--- a/frontend/src/components/interactive/permission-dialog.tsx
+++ b/frontend/src/components/interactive/permission-dialog.tsx
@@ -11,7 +11,62 @@ import type { PermissionRequest } from "@/types/streaming";
 
 interface PermissionDialogProps {
   permission: PermissionRequest;
-  onRespond: (allow: boolean, remember?: boolean) => void;
+  onRespond: (allow: boolean, remember?: boolean, pattern?: string) => void;
+}
+
+/** A remember-scope option: how broadly the user's choice should apply. */
+interface RememberScope {
+  id: string;
+  label: string;
+  pattern: string;
+}
+
+/**
+ * Scope options for remembering this decision, safest first. File tools can be
+ * scoped to the exact file or its folder; bash to the exact command or its
+ * command family; everything can be scoped to the whole tool.
+ */
+function getRememberScopes(permission: PermissionRequest): RememberScope[] {
+  const tool = permission.tool || permission.permission;
+  const args = permission.arguments ?? {};
+  const scopes: RememberScope[] = [];
+
+  if (tool === "bash") {
+    const command = typeof args.command === "string" ? args.command.trim() : "";
+    if (command) {
+      scopes.push({ id: "exact", label: "This exact command", pattern: command });
+      const firstWord = command.split(/\s+/)[0];
+      if (firstWord && firstWord.length < command.length) {
+        scopes.push({
+          id: "prefix",
+          label: `All "${firstWord}" commands`,
+          pattern: `${firstWord} *`,
+        });
+      }
+    }
+    scopes.push({ id: "all", label: "All shell commands", pattern: "*" });
+    return scopes;
+  }
+
+  const rawPath = [args.file_path, args.path].find(
+    (value) => typeof value === "string" && value.trim(),
+  ) as string | undefined;
+  const filePath =
+    rawPath?.trim() ?? permission.patterns.find((p) => p && p !== "*");
+  if (filePath) {
+    scopes.push({ id: "exact", label: "This file only", pattern: filePath });
+    const sepIndex = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+    if (sepIndex > 0) {
+      const sep = filePath[sepIndex];
+      scopes.push({
+        id: "dir",
+        label: "This folder",
+        pattern: `${filePath.slice(0, sepIndex)}${sep}*`,
+      });
+    }
+  }
+  scopes.push({ id: "all", label: `Everywhere (all ${tool})`, pattern: "*" });
+  return scopes;
 }
 
 const TOOL_EXPLANATIONS: Record<string, {
@@ -133,6 +188,42 @@ function PermissionDetails({
   );
 }
 
+function RememberScopeSelect({
+  scopes,
+  value,
+  onChange,
+  selectId,
+}: {
+  scopes: RememberScope[];
+  value: RememberScope;
+  onChange: (id: string) => void;
+  selectId: string;
+}) {
+  if (scopes.length <= 1) return null;
+  return (
+    <div className="space-y-1 pl-1">
+      <select
+        id={selectId}
+        value={value.id}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Remember scope"
+        className="w-full rounded-md border border-[var(--border-default)] bg-[var(--surface-secondary)] px-2 py-1.5 text-xs text-[var(--text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-warning)]"
+      >
+        {scopes.map((scope) => (
+          <option key={scope.id} value={scope.id}>
+            {scope.label}
+          </option>
+        ))}
+      </select>
+      {value.pattern !== "*" && (
+        <p className="truncate font-mono text-[10px] text-[var(--text-tertiary)]" title={value.pattern}>
+          {value.pattern}
+        </p>
+      )}
+    </div>
+  );
+}
+
 /** Send a browser notification if tab is not focused. */
 function notifyIfHidden(tool: string) {
   if (typeof document === "undefined" || document.visibilityState !== "hidden") return;
@@ -159,6 +250,7 @@ function useRequestNotificationPermission() {
 export function PermissionDialog({ permission, onRespond }: PermissionDialogProps) {
   const [remainingMs, setRemainingMs] = useState(PERMISSION_TIMEOUT);
   const [rememberChoice, setRememberChoice] = useState(false);
+  const [scopeId, setScopeId] = useState("exact");
   const [submitting, setSubmitting] = useState(false);
   const startTimeRef = useRef(Date.now());
   const expired = remainingMs <= 0;
@@ -169,16 +261,28 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
   const details = getToolExplanation(permission.tool || permission.permission);
   const isMobile = isRemoteMode();
 
+  const rememberScopes = getRememberScopes(permission);
+  const selectedScope =
+    rememberScopes.find((scope) => scope.id === scopeId) ?? rememberScopes[0];
+
   useRequestNotificationPermission();
 
   const handleRespond = useCallback(async (allow: boolean) => {
     if (submitting) return;
     setSubmitting(true);
     if (rememberChoice) {
-      savePermissionRule(permission.tool || permission.permission, allow);
+      savePermissionRule(
+        permission.tool || permission.permission,
+        allow,
+        selectedScope.pattern,
+      );
     }
     try {
-      await onRespond(allow, rememberChoice);
+      await onRespond(
+        allow,
+        rememberChoice,
+        rememberChoice ? selectedScope.pattern : undefined,
+      );
     } finally {
       setSubmitting(false);
     }
@@ -188,6 +292,7 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
     permission.tool,
     rememberChoice,
     savePermissionRule,
+    selectedScope,
     submitting,
   ]);
 
@@ -221,6 +326,7 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
 
   useEffect(() => {
     setSubmitting(false);
+    setScopeId("exact");
     hasDeniedRef.current = false;
   }, [permission.callId]);
 
@@ -313,18 +419,28 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
                   />
                 </div>
 
-                <div className="flex items-center gap-2 py-2 border-t border-[var(--border-default)]">
-                  <Switch
-                    checked={rememberChoice}
-                    onCheckedChange={setRememberChoice}
-                    id="remember-choice-mobile"
-                  />
-                  <label
-                    htmlFor="remember-choice-mobile"
-                    className="text-sm text-[var(--text-secondary)] cursor-pointer select-none"
-                  >
-                    Remember for <span className="font-medium text-[var(--text-primary)]">{displayTool}</span>
-                  </label>
+                <div className="space-y-2 py-2 border-t border-[var(--border-default)]">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      checked={rememberChoice}
+                      onCheckedChange={setRememberChoice}
+                      id="remember-choice-mobile"
+                    />
+                    <label
+                      htmlFor="remember-choice-mobile"
+                      className="text-sm text-[var(--text-secondary)] cursor-pointer select-none"
+                    >
+                      Remember for <span className="font-medium text-[var(--text-primary)]">{displayTool}</span>
+                    </label>
+                  </div>
+                  {rememberChoice && (
+                    <RememberScopeSelect
+                      scopes={rememberScopes}
+                      value={selectedScope}
+                      onChange={setScopeId}
+                      selectId="remember-scope-mobile"
+                    />
+                  )}
                 </div>
                 <div className="flex items-center gap-3">
                   <button
@@ -406,18 +522,28 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
                     />
                   </div>
 
-                  <div className="flex items-center gap-2 py-2 border-t border-[var(--border-default)]">
-                    <Switch
-                      checked={rememberChoice}
-                      onCheckedChange={setRememberChoice}
-                      id="remember-choice"
-                    />
-                    <label
-                      htmlFor="remember-choice"
-                      className="text-xs text-[var(--text-secondary)] cursor-pointer select-none"
-                    >
-                      Remember this choice for <span className="font-medium text-[var(--text-primary)]">{displayTool}</span>
-                    </label>
+                  <div className="space-y-2 py-2 border-t border-[var(--border-default)]">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={rememberChoice}
+                        onCheckedChange={setRememberChoice}
+                        id="remember-choice"
+                      />
+                      <label
+                        htmlFor="remember-choice"
+                        className="text-xs text-[var(--text-secondary)] cursor-pointer select-none"
+                      >
+                        Remember this choice for <span className="font-medium text-[var(--text-primary)]">{displayTool}</span>
+                      </label>
+                    </div>
+                    {rememberChoice && (
+                      <RememberScopeSelect
+                        scopes={rememberScopes}
+                        value={selectedScope}
+                        onChange={setScopeId}
+                        selectId="remember-scope"
+                      />
+                    )}
                   </div>
                   <div className="flex items-center gap-2">
                     <Button

--- a/frontend/src/components/settings/permissions-tab.tsx
+++ b/frontend/src/components/settings/permissions-tab.tsx
@@ -82,7 +82,7 @@ export function PermissionsTab() {
             const Icon = rule.allow ? ShieldCheck : ShieldX;
             return (
               <div
-                key={`${rule.tool}-${rule.timestamp}`}
+                key={`${rule.tool}-${rule.pattern ?? "*"}-${rule.timestamp}`}
                 className={cn(
                   "flex items-center gap-3 px-4 py-3",
                   index > 0 && "border-t border-[var(--border-default)]",
@@ -115,14 +115,20 @@ export function PermissionsTab() {
                     </span>
                   </div>
                   <p className="mt-1 truncate text-xs text-[var(--text-secondary)]">
-                    {t("permissionsScopeAll", { tool: rule.tool })}
+                    {(rule.pattern ?? "*") === "*" ? (
+                      t("permissionsScopeAll", { tool: rule.tool })
+                    ) : (
+                      <span className="font-mono" title={rule.pattern}>
+                        {rule.pattern}
+                      </span>
+                    )}
                     {formatTime(rule.timestamp) ? ` · ${formatTime(rule.timestamp)}` : ""}
                   </p>
                 </div>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => clearPermissionRule(rule.tool)}
+                  onClick={() => clearPermissionRule(rule.tool, rule.pattern ?? "*")}
                   title={t("permissionsRevoke")}
                   aria-label={t("permissionsRevokeRule", { tool: rule.tool })}
                   className="shrink-0 text-[var(--text-secondary)]"

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -134,7 +134,7 @@ export function useChat(currentSessionId?: string) {
         const permissionRules = settingsState.savedPermissions.map((rule) => ({
           action: rule.allow ? "allow" as const : "deny" as const,
           permission: rule.tool,
-          pattern: "*",
+          pattern: rule.pattern ?? "*",
         }));
 
         const res = await api.post<PromptResponse>(API.CHAT.PROMPT, {
@@ -347,7 +347,7 @@ export function useChat(currentSessionId?: string) {
   }, [currentSessionId, queryClient]);
 
   const respondToPermission = useCallback(
-    async (allow: boolean, remember = false) => {
+    async (allow: boolean, remember = false, pattern?: string) => {
       const chatState = useChatStore.getState();
       const targetSessionId = currentSessionId ?? null;
       const bucket = targetSessionId === null
@@ -364,7 +364,9 @@ export function useChat(currentSessionId?: string) {
           allowed: allow,
           remember,
           permission: perm.tool || perm.permission,
-          pattern: perm.patterns[0] ?? "*",
+          // The scope the user picked in the dialog; falls back to the exact
+          // resource the backend asked about.
+          pattern: pattern ?? perm.patterns[0] ?? "*",
         },
       };
 
@@ -421,7 +423,7 @@ export function useChat(currentSessionId?: string) {
         const permissionRules = settingsState.savedPermissions.map((rule) => ({
           action: rule.allow ? "allow" as const : "deny" as const,
           permission: rule.tool,
-          pattern: "*",
+          pattern: rule.pattern ?? "*",
         }));
 
         const res = await api.post<PromptResponse>(API.CHAT.EDIT, {

--- a/frontend/src/stores/settings-store.ts
+++ b/frontend/src/stores/settings-store.ts
@@ -13,6 +13,9 @@ export interface PermissionPresets {
 export interface SavedPermissionRule {
   tool: string;
   allow: boolean;
+  /** Resource scope: "*" = the whole tool, otherwise a glob over the resource
+   * (file path for read/write/edit, command for bash). */
+  pattern: string;
   timestamp: number;
 }
 
@@ -71,12 +74,12 @@ interface SettingsStore {
   setReasoningEnabled: (enabled: boolean) => void;
   /** Toggle a single permission preset */
   togglePermissionPreset: (key: keyof PermissionPresets) => void;
-  /** Save a permission rule for a tool */
-  savePermissionRule: (tool: string, allow: boolean) => void;
-  /** Get saved permission for a tool (if any) */
+  /** Save a permission rule for a tool, optionally scoped to a resource pattern */
+  savePermissionRule: (tool: string, allow: boolean, pattern?: string) => void;
+  /** Get saved tool-wide permission for a tool (if any) */
   getSavedPermission: (tool: string) => boolean | null;
-  /** Clear a saved permission rule */
-  clearPermissionRule: (tool: string) => void;
+  /** Clear a saved permission rule (all rules for the tool when no pattern given) */
+  clearPermissionRule: (tool: string, pattern?: string) => void;
   /** Clear all saved permission rules */
   clearAllPermissionRules: () => void;
   /** Set workspace directory (null = unrestricted) */
@@ -176,20 +179,28 @@ export const useSettingsStore = create<SettingsStore>()(
                 : "ask";
           return { permissionPresets: next, workMode };
         }),
-      savePermissionRule: (tool, allow) =>
+      savePermissionRule: (tool, allow, pattern = "*") =>
         set((s) => ({
           savedPermissions: [
-            ...s.savedPermissions.filter((r) => r.tool !== tool),
-            { tool, allow, timestamp: Date.now() },
+            ...s.savedPermissions.filter(
+              (r) => !(r.tool === tool && (r.pattern ?? "*") === pattern),
+            ),
+            { tool, allow, pattern, timestamp: Date.now() },
           ],
         })),
       getSavedPermission: (tool) => {
-        const rule = get().savedPermissions.find((r) => r.tool === tool);
+        const rule = get().savedPermissions.find(
+          (r) => r.tool === tool && (r.pattern ?? "*") === "*",
+        );
         return rule ? rule.allow : null;
       },
-      clearPermissionRule: (tool) =>
+      clearPermissionRule: (tool, pattern) =>
         set((s) => ({
-          savedPermissions: s.savedPermissions.filter((r) => r.tool !== tool),
+          savedPermissions: s.savedPermissions.filter((r) =>
+            pattern === undefined
+              ? r.tool !== tool
+              : !(r.tool === tool && (r.pattern ?? "*") === pattern),
+          ),
         })),
       clearAllPermissionRules: () => set({ savedPermissions: [] }),
       setWorkspaceDirectory: (dir) => set({ workspaceDirectory: dir }),
@@ -205,24 +216,31 @@ export const useSettingsStore = create<SettingsStore>()(
     }),
     {
       name: "openyak-settings",
-      version: 3,
+      version: 4,
       migrate: (persistedState) => {
-        if (
-          persistedState &&
-          typeof persistedState === "object" &&
-          "activeProvider" in persistedState
-        ) {
-          if (persistedState.activeProvider === "openyak") {
-            return { ...persistedState, activeProvider: null } as SettingsStore;
-          }
-          if (persistedState.activeProvider === "local") {
-            return {
-              ...persistedState,
-              activeProvider: "custom",
-            } as SettingsStore;
+        let state = persistedState as Record<string, unknown> | null;
+        if (state && typeof state === "object" && "activeProvider" in state) {
+          if (state.activeProvider === "openyak") {
+            state = { ...state, activeProvider: null };
+          } else if (state.activeProvider === "local") {
+            state = { ...state, activeProvider: "custom" };
           }
         }
-        return persistedState as SettingsStore;
+        // v4: saved permission rules gained a resource pattern; legacy
+        // tool-wide rules map to "*".
+        if (state && Array.isArray(state.savedPermissions)) {
+          const legacyRules = state.savedPermissions as Array<
+            Omit<SavedPermissionRule, "pattern"> & { pattern?: string }
+          >;
+          state = {
+            ...state,
+            savedPermissions: legacyRules.map((r) => ({
+              ...r,
+              pattern: r.pattern ?? "*",
+            })),
+          };
+        }
+        return state as unknown as SettingsStore;
       },
     },
   ),

--- a/frontend/tests/ui/fixtures/openyak-api.ts
+++ b/frontend/tests/ui/fixtures/openyak-api.ts
@@ -103,7 +103,14 @@ export interface OpenYakMockOptions {
 
 export interface OpenYakSeedOptions {
   hasCompletedOnboarding?: boolean;
-  savedPermissions?: Array<{ tool: string; allow: boolean; timestamp: number }>;
+  /** Work mode to seed; "ask" surfaces permission dialogs instead of auto-approving. */
+  workMode?: "plan" | "ask" | "auto";
+  savedPermissions?: Array<{
+    tool: string;
+    allow: boolean;
+    pattern?: string;
+    timestamp: number;
+  }>;
   force?: boolean;
 }
 
@@ -1078,7 +1085,7 @@ function seededSettings(options: OpenYakSeedOptions = {}) {
       selectedProviderId: "openrouter",
       selectedAgent: "build",
       safeMode: false,
-      workMode: "auto",
+      workMode: options.workMode ?? "auto",
       reasoningEnabled: true,
       permissionPresets: { fileChanges: true, runCommands: true },
       savedPermissions: options.savedPermissions ?? [],
@@ -1098,6 +1105,7 @@ export async function seedOpenYakStorage(
   const overwrite =
     options.force === true ||
     options.hasCompletedOnboarding !== undefined ||
+    options.workMode !== undefined ||
     options.savedPermissions !== undefined;
   await page.addInitScript(
     ({ settings, overwrite: shouldOverwrite }) => {

--- a/frontend/tests/ui/openyak-permission-scope.spec.ts
+++ b/frontend/tests/ui/openyak-permission-scope.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  mockOpenYakApi,
+  seedOpenYakStorage,
+  type OpenYakMockState,
+} from "./fixtures/openyak-api";
+
+let mockState: OpenYakMockState;
+
+test.beforeEach(async ({ page }) => {
+  await seedOpenYakStorage(page);
+  mockState = await mockOpenYakApi(page);
+});
+
+async function openNewChat(page: Page) {
+  await page.goto("/c/new");
+  await expect(
+    page
+      .getByRole("heading", {
+        name: /What should (OpenYak help you do|we do in)/i,
+      })
+      .first(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function sendPrompt(page: Page, text: string) {
+  await page.getByPlaceholder(/Describe the result you want/i).fill(text);
+  const promptResponse = page.waitForResponse(
+    (res) => res.url().includes("/api/chat/prompt") && res.status() === 200,
+  );
+  await page
+    .locator('button[aria-label="Send message"]:not([disabled])')
+    .click();
+  await promptResponse;
+}
+
+test("scoped remember: command-family approval persists and rides the next prompt", async ({
+  page,
+}) => {
+  // "ask" mode so the permission dialog actually surfaces (auto would
+  // silently approve via the stream registry).
+  await seedOpenYakStorage(page, { workMode: "ask" });
+  await openNewChat(page);
+  await sendPrompt(page, "Please run the permission demo command");
+
+  // The permission dialog surfaces the exact command under review.
+  await expect(page.getByText("Permission Required")).toBeVisible();
+  await expect(page.getByText("npm run preflight:ui").first()).toBeVisible();
+
+  // Turning Remember on reveals the scope selector, defaulting to the
+  // safest option (this exact command).
+  await page.locator("#remember-choice").click();
+  const scopeSelect = page.locator("#remember-scope");
+  await expect(scopeSelect).toBeVisible();
+  await expect(scopeSelect).toHaveValue("exact");
+
+  // Choose the command-family scope and confirm the pattern preview.
+  await scopeSelect.selectOption("prefix");
+  await expect(page.getByText("npm *", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: /Allow/ }).click();
+
+  // The respond payload carries the chosen scope to the backend.
+  await expect.poll(() => mockState.chatResponses.length).toBeGreaterThan(0);
+  const respond = mockState.chatResponses.at(-1) as {
+    response: Record<string, unknown>;
+  };
+  expect(respond.response).toMatchObject({
+    allowed: true,
+    remember: true,
+    permission: "bash",
+    pattern: "npm *",
+  });
+
+  // The rule is persisted with its pattern in settings storage.
+  const stored = (await page.evaluate(() =>
+    JSON.parse(window.localStorage.getItem("openyak-settings") ?? "{}"),
+  )) as { state: { savedPermissions: unknown[] } };
+  expect(stored.state.savedPermissions).toEqual([
+    expect.objectContaining({ tool: "bash", allow: true, pattern: "npm *" }),
+  ]);
+
+  // A fresh prompt sends the scoped rule to the backend. Navigate in-app —
+  // a full page.goto would re-run the storage seed and wipe the saved rule.
+  await page.getByRole("button", { name: "New chat" }).first().click();
+  await expect(
+    page
+      .getByRole("heading", {
+        name: /What should (OpenYak help you do|we do in)/i,
+      })
+      .first(),
+  ).toBeVisible();
+  await sendPrompt(page, "Summarize the workspace files");
+  const lastPrompt = mockState.promptBodies.at(-1) as {
+    permission_rules: unknown[];
+  };
+  expect(lastPrompt.permission_rules).toEqual([
+    expect.objectContaining({
+      action: "allow",
+      permission: "bash",
+      pattern: "npm *",
+    }),
+  ]);
+});
+
+test("legacy tool-wide rules migrate to pattern '*' and still ride prompts", async ({
+  page,
+}) => {
+  await seedOpenYakStorage(page, {
+    savedPermissions: [{ tool: "bash", allow: true, timestamp: 1 }],
+    force: true,
+  });
+  await openNewChat(page);
+  await sendPrompt(page, "Summarize the workspace files");
+
+  const lastPrompt = mockState.promptBodies.at(-1) as {
+    permission_rules: unknown[];
+  };
+  expect(lastPrompt.permission_rules).toEqual([
+    expect.objectContaining({ permission: "bash", pattern: "*" }),
+  ]);
+});

--- a/frontend/tests/ui/openyak-preflight.spec.ts
+++ b/frontend/tests/ui/openyak-preflight.spec.ts
@@ -530,6 +530,9 @@ test.describe("OpenYak UI preflight", () => {
     await page
       .getByRole("switch", { name: /Remember this choice for bash/i })
       .setChecked(true);
+    // Tool-wide allow is this test's subject; the scope selector defaults to
+    // the safest option (this exact command), so widen it explicitly.
+    await page.locator("#remember-scope").selectOption("all");
 
     const respond = page.waitForResponse(
       (res) => res.url().includes("/api/chat/respond") && res.status() === 200,
@@ -542,7 +545,7 @@ test.describe("OpenYak UI preflight", () => {
         allowed: true,
         remember: true,
         permission: "bash",
-        pattern: "npm run preflight:ui",
+        pattern: "*",
       },
     });
 

--- a/frontend/tests/ui/openyak-preflight.spec.ts
+++ b/frontend/tests/ui/openyak-preflight.spec.ts
@@ -603,6 +603,9 @@ test.describe("OpenYak UI preflight", () => {
     await page
       .getByRole("switch", { name: /Remember this choice for bash/i })
       .setChecked(true);
+    // This test covers the tool-wide deny path; the scope selector defaults
+    // to the safest option (this exact command), so widen it explicitly.
+    await page.locator("#remember-scope").selectOption("all");
 
     const respond = page.waitForResponse(
       (res) => res.url().includes("/api/chat/respond") && res.status() === 200,
@@ -615,7 +618,7 @@ test.describe("OpenYak UI preflight", () => {
         allowed: false,
         remember: true,
         permission: "bash",
-        pattern: "npm run preflight:ui",
+        pattern: "*",
       },
     });
 


### PR DESCRIPTION
## What

Closes the first item of the catch-up roadmap (permission-persistence, 1.1): "remember this choice" is no longer an all-or-nothing, tool-wide grant. The permission engine's existing two-dimensional (tool × pattern) matching is now wired end-to-end.

- **bash commands are the resource now** — the permission check passes the command string, so a remembered `git *` rule covers the git family and nothing else (`processor.py`).
- **Scope selector in the permission dialog** — with Remember on, choose *this exact command / all "npm" commands / all shell commands* (bash) or *this file / this folder / everywhere* (read/write/edit), with a live mono preview of the pattern being saved. Desktop and mobile layouts.
- **Chosen scope rides the respond payload** — the backend honors it only when it actually covers the resource that was just approved (`_resolve_remember_pattern`), otherwise falls back to the exact resource.
- **Durable, visible, revocable** — rules persist with their pattern in the settings store (v4 migration maps legacy tool-wide rules to `*`), ride every prompt's `permission_rules` per the existing Settings-as-source-of-truth design, and Settings → Permissions now shows each rule's scope and revokes per (tool, pattern).

## Validation

- Backend: `pytest` — 1059 passed, 21 skipped; new unit tests for decision parsing, scope resolution, and command-family evaluation.
- Frontend: `tsc --noEmit` + ESLint clean.
- Real-GUI: new Playwright spec (`openyak-permission-scope.spec.ts`) drives the actual dialog in ask work-mode — scope select → respond payload carries `npm *` → localStorage persists the scoped rule → an in-app new chat sends it in `permission_rules`; plus a legacy-rule migration test. Full chromium suite: 49 passed / 5 skipped.
- Note: the end-to-end ask flow is exercised against the mocked-backend Playwright harness; the live-LLM path reuses the unchanged `respond` machinery.

## Notes for review

- The permission-scope Playwright fixture gained a `workMode` seed option because the default `auto` work-mode auto-approves permission requests in the stream registry — which is exactly the static-blanket-allow the upcoming guarded-auto-mode roadmap item (2.2) will replace.
- No behavior change for users who never touch Remember: default scope preserves today's semantics at the moment of approval, and legacy saved rules keep working as tool-wide (`*`).