### PR TITLE
UX alignment P0: design-token completion, overlay motion, system typography, ink buttons

### DIFF
--- a/frontend/src/app/(main)/automations/shared-ui.tsx
+++ b/frontend/src/app/(main)/automations/shared-ui.tsx
@@ -45,10 +45,10 @@ export function StatusBadge({ status, sessionId, t }: { status: string | null; s
   if (!status) return null;
 
   const config: Record<string, { icon: React.ElementType; color: string; labelKey: string }> = {
-    running: { icon: Loader2, color: "text-amber-400", labelKey: "statusRunning" },
-    success: { icon: Check, color: "text-emerald-400", labelKey: "statusSuccess" },
-    error:   { icon: XCircle, color: "text-red-400", labelKey: "statusError" },
-    timeout: { icon: XCircle, color: "text-orange-400", labelKey: "statusTimeout" },
+    running: { icon: Loader2, color: "text-[var(--tool-pending)]", labelKey: "statusRunning" },
+    success: { icon: Check, color: "text-[var(--color-success)]", labelKey: "statusSuccess" },
+    error:   { icon: XCircle, color: "text-[var(--color-destructive)]", labelKey: "statusError" },
+    timeout: { icon: XCircle, color: "text-[var(--color-warning)]", labelKey: "statusTimeout" },
   };
 
   const normalizedStatus = status.startsWith("running") ? "running" : status;
@@ -87,11 +87,11 @@ export function StatusBadge({ status, sessionId, t }: { status: string | null; s
 
 export function TriggeredByBadge({ triggeredBy, t }: { triggeredBy: string; t: (key: string) => string }) {
   const map: Record<string, { label: string; color: string }> = {
-    schedule:         { label: t("triggerSchedule"), color: "bg-blue-500/10 text-blue-400" },
-    manual:           { label: t("triggerManual"), color: "bg-amber-500/10 text-amber-400" },
+    schedule:         { label: t("triggerSchedule"), color: "bg-[var(--brand-primary)]/10 text-[var(--brand-primary)]" },
+    manual:           { label: t("triggerManual"), color: "bg-[var(--color-warning)]/10 text-[var(--color-warning)]" },
     startup_catchup:  { label: t("triggerCatchup"), color: "bg-purple-500/10 text-purple-400" },
   };
-  const info = map[triggeredBy] || { label: triggeredBy, color: "bg-zinc-500/10 text-zinc-400" };
+  const info = map[triggeredBy] || { label: triggeredBy, color: "bg-[var(--text-tertiary)]/10 text-[var(--text-tertiary)]" };
   return <span className={`text-ui-3xs px-1.5 py-0.5 rounded ${info.color}`}>{info.label}</span>;
 }
 
@@ -152,7 +152,7 @@ export function DeleteConfirmDialog({ name, onConfirm, onCancel, isPending, t }:
       </div>
       <div className="flex justify-end gap-2 px-4 py-3 border-t border-[var(--border-default)]">
         <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onCancel}>{t("cancel")}</Button>
-        <Button size="sm" className="h-7 text-xs bg-red-600 hover:bg-red-700 text-white" onClick={onConfirm} disabled={isPending}>
+        <Button variant="destructive" size="sm" className="h-7 text-xs" onClick={onConfirm} disabled={isPending}>
           {isPending && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />}
           {t("delete")}
         </Button>

--- a/frontend/src/app/(main)/plugins/content.tsx
+++ b/frontend/src/app/(main)/plugins/content.tsx
@@ -46,12 +46,12 @@ import type { PluginInfo, SkillInfo, StoreSkill } from "@/types/plugins";
 import type { ConnectorInfo } from "@/types/connectors";
 
 const SOURCE_COLORS: Record<string, string> = {
-  builtin: "bg-blue-500/10 text-blue-400",
-  global: "bg-amber-500/10 text-amber-400",
-  project: "bg-emerald-500/10 text-emerald-400",
-  plugin: "bg-purple-500/10 text-purple-400",
-  bundled: "bg-blue-500/10 text-blue-400",
-  custom: "bg-orange-500/10 text-orange-400",
+  builtin: "bg-[var(--brand-primary)]/10 text-[var(--brand-primary)]",
+  global: "bg-[var(--color-warning)]/10 text-[var(--color-warning)]",
+  project: "bg-[var(--color-success)]/10 text-[var(--color-success)]",
+  plugin: "bg-[var(--skill-accent)]/10 text-[var(--skill-accent)]",
+  bundled: "bg-[var(--brand-primary)]/10 text-[var(--brand-primary)]",
+  custom: "bg-[var(--color-warning)]/10 text-[var(--color-warning)]",
 };
 
 /** Derive i18n key from category slug: "dev-tools" → "category_dev_tools" */
@@ -120,9 +120,9 @@ export function PluginsTabContent() {
 /* ------------------------------------------------------------------ */
 
 const STATUS_COLORS: Record<string, string> = {
-  connected: "bg-emerald-500",
-  needs_auth: "bg-amber-500",
-  failed: "bg-red-500",
+  connected: "bg-[var(--color-success)]",
+  needs_auth: "bg-[var(--color-warning)]",
+  failed: "bg-[var(--color-destructive)]",
   disconnected: "bg-[var(--text-tertiary)]",
   disabled: "bg-[var(--text-tertiary)]",
 };
@@ -304,7 +304,7 @@ function ConnectorRow({
             {connector.name}
           </span>
           {connector.type === "local" && id !== "google-workspace" && (
-            <span className="text-ui-3xs px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-400">
+            <span className="text-ui-3xs px-1.5 py-0.5 rounded-full bg-[var(--color-warning)]/10 text-[var(--color-warning)]">
               {t("localSetup")}
             </span>
           )}
@@ -966,7 +966,7 @@ function PluginCard({
 
         <span
           className={`h-2 w-2 rounded-full shrink-0 ${
-            plugin.enabled ? "bg-emerald-500" : "bg-[var(--text-tertiary)]"
+            plugin.enabled ? "bg-[var(--color-success)]" : "bg-[var(--text-tertiary)]"
           }`}
         />
 

--- a/frontend/src/app/(main)/remote/content.tsx
+++ b/frontend/src/app/(main)/remote/content.tsx
@@ -154,8 +154,8 @@ export function RemoteTabContent() {
 
       {/* Tunnel URL changed warning */}
       {tunnelChanged && status?.enabled && (
-        <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 animate-slide-up">
-          <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+        <div className="flex items-start gap-3 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/5 p-3 animate-slide-up">
+          <AlertTriangle className="h-4 w-4 text-[var(--color-warning)] shrink-0 mt-0.5" />
           <div className="flex-1">
             <p className="text-sm font-medium text-[var(--text-primary)]">{t("tunnelUrlChanged")}</p>
             <p className="text-xs text-[var(--text-secondary)] mt-0.5">
@@ -172,7 +172,7 @@ export function RemoteTabContent() {
       {/* Enable/Disable toggle */}
       <div className="flex items-center justify-between rounded-lg border border-[var(--border-default)] p-3">
         <div className="flex items-center gap-3">
-          {toggling ? <Loader2 className="h-4 w-4 animate-spin text-[var(--text-secondary)]" /> : status?.enabled ? <Wifi className="h-4 w-4 text-green-500" /> : <WifiOff className="h-4 w-4 text-[var(--text-tertiary)]" />}
+          {toggling ? <Loader2 className="h-4 w-4 animate-spin text-[var(--text-secondary)]" /> : status?.enabled ? <Wifi className="h-4 w-4 text-[var(--color-success)]" /> : <WifiOff className="h-4 w-4 text-[var(--text-tertiary)]" />}
           <div>
             <p className="text-sm font-medium text-[var(--text-primary)]">{toggling ? t("remoteStarting") : status?.enabled ? t("remoteActive") : t("remoteDisabled")}</p>
             {status?.enabled && status.tunnel_url && <p className="text-xs text-[var(--text-secondary)] truncate max-w-[280px]">{status.tunnel_url}</p>}
@@ -353,7 +353,7 @@ function ChannelsSection() {
       {/* Status indicator */}
       <div className="rounded-lg border border-[var(--border-default)] p-3">
         <div className="flex items-center gap-2">
-          <span className="h-2 w-2 rounded-full bg-emerald-500" />
+          <span className="h-2 w-2 rounded-full bg-[var(--color-success)]" />
           <span className="text-xs font-medium text-[var(--text-primary)]">Channel System</span>
           <span className="text-ui-3xs text-[var(--text-tertiary)]">
             Built-in &middot; {Object.keys(channels).length} active
@@ -368,13 +368,13 @@ function ChannelsSection() {
           const isExpanded = expandedPlatform === p.id;
           return (
             <div key={p.id} className={`rounded-lg border p-3 space-y-2 transition-colors ${
-              connected ? "border-emerald-500/30 bg-emerald-500/5" : "border-[var(--border-default)]"
+              connected ? "border-[var(--color-success)]/30 bg-[var(--color-success)]/5" : "border-[var(--border-default)]"
             } ${isExpanded ? "col-span-2" : ""}`}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <span className={p.color}>{p.icon}</span>
                   <span className="text-xs font-medium text-[var(--text-primary)]">{p.name}</span>
-                  {connected && <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />}
+                  {connected && <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />}
                 </div>
                 {!connected ? (
                   <Button variant="outline" size="sm" className="h-6 text-ui-3xs px-2"
@@ -467,7 +467,7 @@ function TokenForm({ platform, onDone }: { platform: PlatformDef; onDone: () => 
       )}
 
       {error && (
-        <p className="text-ui-2xs text-red-400">{error}</p>
+        <p className="text-ui-2xs text-[var(--color-destructive)]">{error}</p>
       )}
 
       <Button size="sm" className="h-7 text-ui-2xs w-full" onClick={handleSubmit}
@@ -551,7 +551,7 @@ function QrLoginFlow({ channel, onDone }: { channel: string; onDone: () => void 
   }, [channel, onDone, t]);
 
   if (error) {
-    return <p className="text-ui-2xs text-red-400 py-2">{error}</p>;
+    return <p className="text-ui-2xs text-[var(--color-destructive)] py-2">{error}</p>;
   }
 
   return (
@@ -602,7 +602,7 @@ function RemoveChannelButton({ channel, onRemoved }: { channel: string; onRemove
   };
 
   return (
-    <Button variant="outline" size="sm" className="h-6 text-ui-3xs px-2 text-red-400 border-red-400/30 hover:bg-red-400/10"
+    <Button variant="outline" size="sm" className="h-6 text-ui-3xs px-2 text-[var(--color-destructive)] border-[var(--color-destructive)]/30 hover:bg-[var(--color-destructive)]/10"
       disabled={removeChannel.isPending}
       onClick={handleRemove}>
       {removeChannel.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <><Unplug className="h-3 w-3" />{t("channelDisconnect")}</>}

--- a/frontend/src/app/(mobile)/m/page.tsx
+++ b/frontend/src/app/(mobile)/m/page.tsx
@@ -16,10 +16,10 @@ function ConnectionDot({ status }: { status: RemoteHealthStatus }) {
   if (status === "unknown") return null;
   const color =
     status === "connected"
-      ? "bg-emerald-500"
+      ? "bg-[var(--color-success)]"
       : status === "limited"
-        ? "bg-amber-500"
-        : "bg-red-500";
+        ? "bg-[var(--color-warning)]"
+        : "bg-[var(--color-destructive)]";
   return (
     <span
       className={`inline-block h-2 w-2 rounded-full ${color} shrink-0`}
@@ -154,12 +154,12 @@ export default function MobileTaskListPage() {
                         {session.title || "Untitled task"}
                       </p>
                       {needsInputIds.has(session.id) ? (
-                        <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-500 text-[10px] font-medium">
+                        <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-warning)]/10 text-[var(--color-warning)] text-[10px] font-medium">
                           <MessageCircle className="w-2.5 h-2.5" />
                           Needs input
                         </span>
                       ) : activeSessionIds.has(session.id) ? (
-                        <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-500 text-[10px] font-medium">
+                        <span className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-success)]/10 text-[var(--color-success)] text-[10px] font-medium">
                           <Loader2 className="w-2.5 h-2.5 animate-spin" />
                           Running
                         </span>

--- a/frontend/src/app/(mobile)/m/settings/page.tsx
+++ b/frontend/src/app/(mobile)/m/settings/page.tsx
@@ -217,8 +217,8 @@ export default function MobileSettingsPage() {
         <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-secondary)] p-4">
           <div className="flex items-center gap-3">
             {isConnected ? (
-              <div className="h-10 w-10 rounded-full bg-emerald-500/10 flex items-center justify-center shrink-0">
-                <Wifi className="w-5 h-5 text-emerald-500" />
+              <div className="h-10 w-10 rounded-full bg-[var(--color-success)]/10 flex items-center justify-center shrink-0">
+                <Wifi className="w-5 h-5 text-[var(--color-success)]" />
               </div>
             ) : (
               <div className="h-10 w-10 rounded-full bg-[var(--surface-tertiary)] flex items-center justify-center shrink-0">
@@ -238,7 +238,7 @@ export default function MobileSettingsPage() {
             {isConnected && (
               <button
                 onClick={handleDisconnect}
-                className="h-8 w-8 flex items-center justify-center rounded-full hover:bg-red-500/10 text-[var(--text-tertiary)] hover:text-red-400 active:scale-[0.95] transition-all"
+                className="h-8 w-8 flex items-center justify-center rounded-full hover:bg-[var(--color-destructive)]/10 text-[var(--text-tertiary)] hover:text-[var(--color-destructive)] active:scale-[0.95] transition-all"
               >
                 <Trash2 className="w-4 h-4" />
               </button>
@@ -356,7 +356,7 @@ export default function MobileSettingsPage() {
                       </p>
                     </div>
                     {isActive && (
-                      <div className="h-2 w-2 rounded-full bg-emerald-500 shrink-0" />
+                      <div className="h-2 w-2 rounded-full bg-[var(--color-success)] shrink-0" />
                     )}
                   </button>
                 );
@@ -397,7 +397,7 @@ function ChannelsStatusCard() {
       <div className="flex items-center justify-between">
         <p className="text-[13px] font-medium">Channels</p>
         <div className="flex items-center gap-1.5">
-          <span className={`h-2 w-2 rounded-full ${running ? "bg-emerald-500" : "bg-[var(--text-tertiary)]"}`} />
+          <span className={`h-2 w-2 rounded-full ${running ? "bg-[var(--color-success)]" : "bg-[var(--text-tertiary)]"}`} />
           <span className="text-[11px] text-[var(--text-tertiary)]">
             {running ? "Running" : "Stopped"}
           </span>
@@ -411,7 +411,7 @@ function ChannelsStatusCard() {
               className="inline-flex items-center gap-1.5 text-[11px] rounded-full border border-[var(--border-default)] px-2.5 py-1"
             >
               <span className={`h-1.5 w-1.5 rounded-full ${
-                ch.status === "connected" ? "bg-emerald-500" : "bg-[var(--text-tertiary)]"
+                ch.status === "connected" ? "bg-[var(--color-success)]" : "bg-[var(--text-tertiary)]"
               }`} />
               {ch.name}
             </span>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -34,7 +34,9 @@
 
   /* Semantic */
   --color-success: #22C55E;
-  --color-warning: #EAB308;
+  /* Darkened amber: #EAB308 text on white fails contrast (permission dialog,
+     status chips); #B45309 passes AA at the sizes we use. */
+  --color-warning: #B45309;
   --color-destructive: #EF4444;
 
   /* Sidebar */
@@ -98,6 +100,46 @@
   --ui-font-title-sm: var(--ui-size-md);
   --ui-font-title: var(--ui-size-lg);
   --ui-font-title-lg: var(--ui-size-xl);
+
+  /* ─── Codex-alignment tokens (P0) ─── */
+
+  /* Text — fourth tier was referenced in several places but never defined */
+  --text-quaternary: #A9AEB8;
+  --text-accent: var(--brand-primary);
+
+  /* Ink fill — primary-action language: solid ink pill, brand color stays
+     reserved for interaction accents (links, focus, selection) */
+  --ink-solid: #171717;
+  --ink-solid-hover: #2E2E2E;
+  --ink-solid-text: #FFFFFF;
+
+  /* Border aliases — these names were already used across forms; without a
+     definition every such control rendered with no focus ring at all */
+  --border-hover: var(--border-heavy);
+  --border-focus: var(--ring);
+  --border-primary: var(--border-default);
+  --accent-primary: var(--brand-primary);
+
+  /* Diff semantics */
+  --diff-added-fg: #16A34A;
+  --diff-added-bg: rgba(34, 197, 94, 0.1);
+  --diff-removed-fg: #DC2626;
+  --diff-removed-bg: rgba(239, 68, 68, 0.1);
+
+  /* Skill accent — skills get their own semantic hue, distinct from brand */
+  --skill-accent: #7C5CFC;
+
+  /* Radius scale — inline chips → cards/inputs → dialogs/panels → composer */
+  --radius-sm: 6px;
+  --radius-md: var(--radius);
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+
+  /* Motion */
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --motion-slow: 320ms;
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .dark {
@@ -164,6 +206,17 @@
   --prose-accent: #9fc1ff;
   --prose-blockquote-bg: rgba(138, 180, 255, 0.06);
   --prose-marker: #727272;
+
+  /* ─── Codex-alignment tokens (P0) ─── */
+  --text-quaternary: #6E7178;
+  --ink-solid: #FFFFFF;
+  --ink-solid-hover: #E6E6E6;
+  --ink-solid-text: #171717;
+  --diff-added-fg: #3ED08F;
+  --diff-added-bg: rgba(62, 208, 143, 0.12);
+  --diff-removed-fg: #E86D73;
+  --diff-removed-bg: rgba(232, 109, 115, 0.12);
+  --skill-accent: #A78BFA;
 }
 
 /* ─── Base Styles ─── */
@@ -451,25 +504,9 @@ pre code {
   --code-inserted: #89D185;
 }
 
-.dark {
-  --code-bg: #1E1E1E;
-  --code-text: #D4D4D4;
-  --code-comment: #6A9955;
-  --code-keyword: #569CD6;
-  --code-string: #CE9178;
-  --code-function: #DCDCAA;
-  --code-variable: #9CDCFE;
-  --code-number: #B5CEA8;
-  --code-operator: #D4D4D4;
-  --code-class: #4EC9B0;
-  --code-tag: #569CD6;
-  --code-attr-name: #9CDCFE;
-  --code-attr-value: #CE9178;
-  --code-builtin: #4EC9B0;
-  --code-regex: #D16969;
-  --code-deleted: #F44747;
-  --code-inserted: #89D185;
-}
+/* Both themes intentionally share the same code palette (code blocks stay
+   dark even in light mode, like ChatGPT/Claude), so the :root values above
+   apply globally — no .dark override needed. */
 
 /* Highlight.js Theme — VS Code Dark+ inspired */
 .hljs {
@@ -1116,5 +1153,108 @@ pre code {
   .shimmer-text {
     animation: none;
     -webkit-text-fill-color: var(--text-secondary);
+  }
+}
+
+/* ─── Enter/exit animation utilities (P0 motion revival) ───
+   The shadcn-style popover/dialog/sheet components reference animate-in /
+   fade-in-0 / zoom-in-95 / slide-in-from-* classes that were never defined
+   (no animation plugin installed), so every overlay popped with zero motion.
+   Minimal dependency-free implementation of exactly the classes this codebase
+   uses; utility API adapted from tw-animate-css (MIT). */
+
+@utility animate-in {
+  animation: oy-enter var(--tw-duration, var(--motion-base)) var(--tw-ease, var(--ease-out-expo));
+  --tw-enter-opacity: initial;
+  --tw-enter-scale: initial;
+  --tw-enter-translate-x: initial;
+  --tw-enter-translate-y: initial;
+}
+
+@utility animate-out {
+  animation: oy-exit var(--tw-duration, var(--motion-fast)) var(--tw-ease, ease-in);
+  --tw-exit-opacity: initial;
+  --tw-exit-scale: initial;
+  --tw-exit-translate-x: initial;
+  --tw-exit-translate-y: initial;
+}
+
+@keyframes oy-enter {
+  from {
+    opacity: var(--tw-enter-opacity, 1);
+    transform: translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0)
+      scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1));
+  }
+}
+
+@keyframes oy-exit {
+  to {
+    opacity: var(--tw-exit-opacity, 1);
+    transform: translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0)
+      scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1));
+  }
+}
+
+@utility fade-in-0 {
+  --tw-enter-opacity: 0;
+}
+@utility fade-out-0 {
+  --tw-exit-opacity: 0;
+}
+@utility zoom-in-95 {
+  --tw-enter-scale: 0.95;
+}
+@utility zoom-out-95 {
+  --tw-exit-scale: 0.95;
+}
+
+@utility slide-in-from-top {
+  --tw-enter-translate-y: -100%;
+}
+@utility slide-in-from-bottom {
+  --tw-enter-translate-y: 100%;
+}
+@utility slide-in-from-left {
+  --tw-enter-translate-x: -100%;
+}
+@utility slide-in-from-right {
+  --tw-enter-translate-x: 100%;
+}
+@utility slide-out-to-top {
+  --tw-exit-translate-y: -100%;
+}
+@utility slide-out-to-bottom {
+  --tw-exit-translate-y: 100%;
+}
+@utility slide-out-to-left {
+  --tw-exit-translate-x: -100%;
+}
+@utility slide-out-to-right {
+  --tw-exit-translate-x: 100%;
+}
+
+@utility slide-in-from-top-* {
+  --tw-enter-translate-y: calc(--value([percentage], [length]) * -1);
+  --tw-enter-translate-y: calc(--value(ratio) * -100%);
+}
+@utility slide-in-from-left-* {
+  --tw-enter-translate-x: calc(--value([percentage], [length]) * -1);
+  --tw-enter-translate-x: calc(--value(ratio) * -100%);
+}
+@utility slide-out-to-top-* {
+  --tw-exit-translate-y: calc(--value([percentage], [length]) * -1);
+  --tw-exit-translate-y: calc(--value(ratio) * -100%);
+}
+@utility slide-out-to-left-* {
+  --tw-exit-translate-x: calc(--value([percentage], [length]) * -1);
+  --tw-exit-translate-x: calc(--value(ratio) * -100%);
+}
+
+/* Entry/exit motion collapses to imperceptible under reduced-motion; ongoing
+   informative animations (spinners, progress) are governed separately above. */
+@media (prefers-reduced-motion: reduce) {
+  [class*="animate-in"],
+  [class*="animate-out"] {
+    animation-duration: 1ms !important;
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,13 +1,12 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono, Noto_Sans_SC } from "next/font/google";
+import { JetBrains_Mono, Noto_Sans_SC } from "next/font/google";
 import { AppProviders } from "@/components/providers/app-providers";
 import "./globals.css";
 
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-sans",
-});
-
+// UI text intentionally uses the system font stack (see globals.css @layer
+// base) — Inter previously rode in via the `font-sans` utility and overrode
+// it, which also broke the --font-cjk fallback for Chinese text. JetBrains
+// Mono stays available as an opt-in code font via appearance settings.
 const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
@@ -35,7 +34,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} ${jetbrainsMono.variable} ${notoSansSC.variable} font-sans antialiased`}>
+      <body className={`${jetbrainsMono.variable} ${notoSansSC.variable} antialiased`}>
         <AppProviders>{children}</AppProviders>
       </body>
     </html>

--- a/frontend/src/components/artifacts/renderers/csv-renderer.tsx
+++ b/frontend/src/components/artifacts/renderers/csv-renderer.tsx
@@ -179,7 +179,7 @@ export function CsvRenderer({ content, title }: CsvRendererProps) {
                     <th
                       key={i}
                       onClick={() => handleSort(i)}
-                      className="cursor-pointer select-none hover:bg-[#eee]"
+                      className="cursor-pointer select-none hover:bg-[var(--surface-tertiary)]"
                     >
                       <span className="inline-flex items-center gap-1">
                         {header}

--- a/frontend/src/components/interactive/permission-dialog.tsx
+++ b/frontend/src/components/interactive/permission-dialog.tsx
@@ -367,7 +367,7 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
   if (isMobile) {
     return (
       <div className="px-3 pb-[max(env(safe-area-inset-bottom),8px)]">
-        <div className="rounded-2xl border-2 border-[var(--color-warning)]/40 bg-[var(--surface-primary)] shadow-lg p-4 animate-slide-up">
+        <div className="rounded-2xl border-2 border-[var(--color-warning)]/40 bg-[var(--surface-primary)] shadow-[var(--shadow-lg)] p-4 animate-slide-up">
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/frontend/src/components/messages/user-message.tsx
+++ b/frontend/src/components/messages/user-message.tsx
@@ -244,7 +244,7 @@ export function UserMessage({ message, isNew = true, onEditAndResend, isGenerati
                 handleCancel();
               }
             }}
-            className="w-full resize-none bg-transparent text-[13px] text-[var(--text-primary)] leading-relaxed outline-none"
+            className="w-full resize-none bg-transparent text-[13px] text-[var(--text-primary)] leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
             rows={1}
           />
           {(editAttachments.length > 0 || uploading) && (

--- a/frontend/src/components/parts/reasoning-part.tsx
+++ b/frontend/src/components/parts/reasoning-part.tsx
@@ -127,7 +127,7 @@ export function ReasoningPart({ texts, toolParts = [], isStreaming, onDurationCh
             <div className="border-l-2 border-[var(--border-heavy)] pl-4 ml-1 mt-1.5 mb-1 space-y-2">
               {/* Reasoning text */}
               {combinedText && (
-                <div className="prose prose-sm max-w-none text-[var(--text-secondary)] leading-relaxed [&_p]:my-2 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-sm [&_strong]:text-[var(--text-primary)] [&_hr]:border-[var(--border-default)] [&_hr]:my-3">
+                <div className="prose max-w-none text-[var(--text-secondary)] leading-relaxed [&_p]:my-2 [&_h1]:text-sm [&_h2]:text-sm [&_h3]:text-sm [&_strong]:text-[var(--text-primary)] [&_hr]:border-[var(--border-default)] [&_hr]:my-3">
                   <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
                     {combinedText}
                   </ReactMarkdown>

--- a/frontend/src/components/settings/general-tab.tsx
+++ b/frontend/src/components/settings/general-tab.tsx
@@ -224,7 +224,7 @@ export function GeneralTab() {
               </Button>
             )}
             {updateStatus === "up-to-date" && (
-              <Button variant="outline" size="sm" className="text-ui-caption h-7 text-green-500 border-green-500/30" disabled>
+              <Button variant="outline" size="sm" className="text-ui-caption h-7 text-[var(--color-success)] border-[var(--color-success)]/30" disabled>
                 <Check className="h-3 w-3 mr-1.5" />
                 {t('upToDate')}
               </Button>

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         success:
           "border-transparent bg-[var(--color-success)] text-white",
         warning:
-          "border-transparent bg-[var(--color-warning)] text-white",
+          "border-transparent bg-[var(--color-warning)]/15 text-[var(--color-warning)]",
         destructive:
           "border-transparent bg-[var(--color-destructive)] text-white",
       },

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -9,6 +9,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
+          "bg-[var(--ink-solid)] text-[var(--ink-solid-text)] hover:bg-[var(--ink-solid-hover)] shadow-[var(--shadow-sm)]",
+        brand:
           "bg-[var(--brand-primary)] text-[var(--brand-primary-text)] hover:bg-[var(--brand-primary-hover)] shadow-[var(--shadow-sm)]",
         destructive:
           "bg-[var(--color-destructive)] text-white hover:opacity-90",

--- a/frontend/src/components/workspace/progress-section.tsx
+++ b/frontend/src/components/workspace/progress-section.tsx
@@ -144,7 +144,7 @@ export function ProgressCard() {
                         ? "border-[var(--text-accent)]/50 bg-[var(--text-accent)]/10 text-[var(--text-accent)]"
                         : item.status === "failed"
                           ? "border-[var(--tool-error)]/40 bg-[var(--tool-error)]/10 text-[var(--tool-error)]"
-                        : "border-white/15 text-[var(--text-quaternary)]",
+                        : "border-[var(--border-default)] text-[var(--text-quaternary)]",
                   )}
                 >
                   {item.status === "completed" ? (

--- a/frontend/tests/ui/openyak-preflight.spec.ts
+++ b/frontend/tests/ui/openyak-preflight.spec.ts
@@ -197,8 +197,11 @@ test.describe("OpenYak UI preflight", () => {
 
     await page.getByRole("button", { name: /Auto-edit/i }).click();
     await page.getByRole("button", { name: /Plan first/i }).click();
+    // Exact match: during the popover's exit animation the "Plan first ..."
+    // menu option briefly coexists with the pill, and a broad regex would
+    // trip strict mode.
     await expect(
-      page.getByRole("button", { name: /Plan first/i }),
+      page.getByRole("button", { name: "Plan first", exact: true }),
     ).toBeVisible();
 
     await page.locator('input[type="file"]').setInputFiles({


### PR DESCRIPTION
First implementation slice of the Codex design-language alignment (spec: P0.1–P0.5). Stacked on #149 — **merge #149 first, then retarget this PR to `main` BEFORE deleting the base branch** (base-branch deletion auto-closes stacked PRs without retargeting).

## What

- **P0.1 tokens** — registers the tokens the codebase already referenced but never defined (`--text-quaternary`, `--text-accent`, `--border-hover/focus/primary`, `--accent-primary`): every form pointing at them finally gets a visible focus ring. Adds the Codex-aligned families: ink fill (`--ink-solid*`), diff semantics, `--skill-accent`, radius scale, motion tokens. Light-theme warning amber darkened to AA contrast. Dedupes the identical `.dark` syntax-color block.
- **P0.2 motion** — dependency-free implementation of the shadcn enter/exit utilities (`animate-in/out`, fade/zoom, `slide-in-from-*` incl. functional values; API adapted from tw-animate-css, MIT). Every popover/dialog/dropdown/sheet referenced these classes with no plugin installed, so all overlays popped with zero motion. Collapses to 1ms under `prefers-reduced-motion`.
- **P0.3 typography** — drops the Inter override so the system stack (+ `--font-cjk`, previously dead) actually applies; JetBrains Mono stays as the opt-in code font.
- **P0.4 ink buttons + status colors** — Button `default` variant becomes ink-fill per the alignment; blue stays available as `variant="brand"`. All hardcoded semantic palette colors in automations/plugins/remote/general-tab/mobile migrate to tokens (platform brand colors and the functional white QR backdrop untouched). Running-state maps to `--color-success`, not `--tool-running` (ink-black, no dark override — flagged for token cleanup).
- **P0.5 defect fixes** — csv hover dark-theme break, invisible light-theme progress circle, bare shadow, badge contrast, edit-textarea focus ring, dead `prose-sm`. `react-renderer`'s `#ef4444` deliberately left (iframe srcdoc; CSS vars can't cross the document boundary).

Deliberate deferral: the spec's `@theme` registration is skipped — `--color-success/warning/destructive` already exist as plain vars with the exact names `@theme` would claim; collision risk outweighs utility-name sugar.

## Validation

- `tsc --noEmit` + ESLint clean.
- Compiled CSS verified: keyframes, variant classes, functional slide values, `color-mix` opacity forms all present.
- Real-GUI: light + dark themes visually verified on the dev build (system font, ink buttons, sidebar/composer surfaces); enter/exit animations verified in Playwright via animation-event probe — `animationstart`/`animationend` fire and Radix unmounts closed overlays.
- Full chromium suite: **51 passed / 5 skipped / 7 failed — the 7 failures reproduce identically on clean `origin/main`** (verified against a main-baseline worktree; they are pre-existing: model-selector, manual-compression, budget-workflow, PPTX-binary, chat-task-journey, provider-setup-journey, settings-providers). Zero net-new failures from this branch.
- One real interaction between motion and tests found and fixed: exit animations make a closing popover's option briefly coexist with the trigger, which is terminal for broad strict-mode locators — the affected assertion now matches exactly.

## Known follow-ups (chipped/tracked, not in this PR)

- App misbehaves under OS `prefers-reduced-motion` (pre-existing global CSS squashes all animations indiscriminately) — task chip filed; once fixed, `reducedMotion: 'reduce'` should be enabled in the Playwright config permanently.
- The 7 pre-existing failing UI tests on main.
- P0.3's bare `text-[Npx]` → scale migration ships separately per directory as planned.