### PR TITLE
Fix invisible button text: tailwind-merge was deleting text colors next to text-ui-* sizes

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,19 +8,22 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
+        // Text colors use the explicit `color:` hint — a bare var() in
+        // text-[...] is ambiguous to tailwind-merge and can be dropped as a
+        // font-size conflict.
         default:
-          "bg-[var(--ink-solid)] text-[var(--ink-solid-text)] hover:bg-[var(--ink-solid-hover)] shadow-[var(--shadow-sm)]",
+          "bg-[var(--ink-solid)] text-[color:var(--ink-solid-text)] hover:bg-[var(--ink-solid-hover)] shadow-[var(--shadow-sm)]",
         brand:
-          "bg-[var(--brand-primary)] text-[var(--brand-primary-text)] hover:bg-[var(--brand-primary-hover)] shadow-[var(--shadow-sm)]",
+          "bg-[var(--brand-primary)] text-[color:var(--brand-primary-text)] hover:bg-[var(--brand-primary-hover)] shadow-[var(--shadow-sm)]",
         destructive:
           "bg-[var(--color-destructive)] text-white hover:opacity-90",
         outline:
-          "border border-[var(--border-default)] bg-transparent hover:bg-[var(--surface-secondary)] text-[var(--text-primary)]",
+          "border border-[var(--border-default)] bg-transparent hover:bg-[var(--surface-secondary)] text-[color:var(--text-primary)]",
         secondary:
-          "bg-[var(--surface-secondary)] text-[var(--text-primary)] hover:bg-[var(--surface-tertiary)]",
+          "bg-[var(--surface-secondary)] text-[color:var(--text-primary)] hover:bg-[var(--surface-tertiary)]",
         ghost:
-          "hover:bg-[var(--surface-secondary)] text-[var(--text-primary)]",
-        link: "text-[var(--brand-primary)] underline-offset-4 hover:underline",
+          "hover:bg-[var(--surface-secondary)] text-[color:var(--text-primary)]",
+        link: "text-[color:var(--brand-primary)] underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,36 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
 import type { PartData, TextPart } from "@/types/message";
+
+// tailwind-merge doesn't know our custom text-ui-* font-size utilities and
+// its default heuristic classifies unknown `text-*` classes as text COLOR —
+// which silently deleted real color classes (e.g. a button's
+// text-[var(--ink-solid-text)]) whenever a text-ui-* size appeared later in
+// the list. Register them in the font-size group so they only ever compete
+// with other font sizes.
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        "text-ui-overline",
+        "text-ui-caption",
+        "text-ui-body",
+        "text-ui-title-sm",
+        "text-ui-title",
+        "text-ui-title-lg",
+        "text-ui-3xs",
+        "text-ui-2xs",
+        "text-ui-xs",
+        "text-ui-sm",
+        "text-ui-md",
+        "text-ui-lg",
+        "text-ui-xl",
+        "text-ui-code",
+        "text-ui-qr",
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/frontend/tests/ui/openyak-permission-scope.spec.ts
+++ b/frontend/tests/ui/openyak-permission-scope.spec.ts
@@ -61,7 +61,29 @@ test("scoped remember: command-family approval persists and rides the next promp
   await scopeSelect.selectOption("prefix");
   await expect(page.getByText("npm *", { exact: true })).toBeVisible();
 
-  await page.getByRole("button", { name: /Allow/ }).click();
+  // Regression: the ink-filled Allow button must keep readable text —
+  // tailwind-merge once dropped its color class as a bogus font-size
+  // conflict, leaving near-black text on the ink fill. Assert real
+  // luminance contrast, not just string inequality.
+  const allowButton = page.getByRole("button", { name: /Allow/ });
+  const contrastRatio = await allowButton.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    const lum = (rgb: string) => {
+      const [r, g, b] = (rgb.match(/\d+/g) ?? ["0", "0", "0"])
+        .slice(0, 3)
+        .map((v) => {
+          const c = Number(v) / 255;
+          return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+        });
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    };
+    const l1 = lum(cs.color);
+    const l2 = lum(cs.backgroundColor);
+    return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+  });
+  expect(contrastRatio).toBeGreaterThan(4.5);
+
+  await allowButton.click();
 
   // The respond payload carries the chosen scope to the backend.
   await expect.poll(() => mockState.chatResponses.length).toBeGreaterThan(0);


### PR DESCRIPTION
User-reported: the ink-filled **Allow** button in the permission dialog rendered with near-invisible text.

**Root cause**: `cn()` runs tailwind-merge with the default config, which doesn't know our custom `text-ui-*` font-size utilities and classifies any unknown `text-*` class as a text **color**. So in `Button` (cva base `text-sm` + variant `text-[var(--ink-solid-text)]` + size `text-ui-xs`), the size class displaced the variant's color class as a bogus same-group conflict. The bug predates the ink fill — the old blue fill rendered dark-on-blue and nobody noticed; ink black exposed it.

**Fix (two layers)**
- `cn()` uses `extendTailwindMerge` registering all fifteen `text-ui-*` utilities in the font-size group — fixes every `cn()` call site in one place.
- Button variant colors use the explicit `color:` hint (`text-[color:var(--x)]`) so a bare `var()` can never be misclassified again.

**Verification**
- Live probe: Allow button computed style now `rgb(255,255,255)` on `rgb(23,23,23)` (light), class list retains the color class.
- New regression assertion in `openyak-permission-scope.spec.ts`: WCAG-style luminance contrast > 4.5 on the ink button, theme-independent — **verified to fail against the unfixed code** (stash-the-fix check).
- `tsc` + ESLint clean; permission + preflight suites pass (only the known pre-existing settings-providers failure remains).

Static `className` strings are unaffected (no merge runs there); the exposure was limited to `cn()`/cva component paths.