### PR TITLE
Refresh curated model lists: Fable 5 vision, GPT-5.6 subscription default

### DIFF
--- a/backend/app/provider/openai_subscription.py
+++ b/backend/app/provider/openai_subscription.py
@@ -32,6 +32,18 @@ PROVIDER_ID = "openai-subscription"
 # Curated models available through ChatGPT subscription
 _SUBSCRIPTION_MODELS: list[dict[str, Any]] = [
     {
+        "id": "gpt-5.6",
+        "name": "GPT-5.6",
+        "capabilities": {
+            "function_calling": True,
+            "vision": True,
+            "reasoning": True,
+            "json_output": True,
+            "max_context": 1_050_000,
+            "max_output": 128_000,
+        },
+    },
+    {
         "id": "gpt-5.5",
         "name": "GPT-5.5",
         "capabilities": {

--- a/backend/app/provider/vision_allowlist.py
+++ b/backend/app/provider/vision_allowlist.py
@@ -104,6 +104,8 @@ _ALLOW: list[str] = [
     # ---- Anthropic ----
     r"claude-3",                       # claude-3 / 3.5 / 3.7
     r"claude-(?:opus|sonnet|haiku)",   # every modern tier (incl. -4-x and -latest)
+    r"claude-(?:fable|mythos)",        # 2026 Mythos-class tier — claude-fable-5
+                                       # verified attachment=true on live models.dev
     r"claude-[4-9]",                   # legacy claude-4* style ids
 
     # ---- Google Gemini / Gemma ----

--- a/backend/tests/test_provider/test_vision_allowlist.py
+++ b/backend/tests/test_provider/test_vision_allowlist.py
@@ -33,6 +33,12 @@ VISION_MODELS = [
     "claude-3-5-sonnet-20241022",
     "claude-3.7-sonnet",
     "claude-sonnet-4-5",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "anthropic/claude-fable-5",
+    "gpt-5.6",
+    "gpt-5.6-sol",
     "claude-opus-4-1",
     "anthropic/claude-3.5-sonnet",
     # Google

--- a/frontend/src/components/selectors/header-model-dropdown.tsx
+++ b/frontend/src/components/selectors/header-model-dropdown.tsx
@@ -176,6 +176,7 @@ export function HeaderModelDropdown() {
         // subscription tier hasn't rolled it out yet, then to whatever the
         // backend did return.
         const preferred =
+          visibleModels.find((m) => m.id === "openai-subscription/gpt-5.6") ??
           visibleModels.find((m) => m.id === "openai-subscription/gpt-5.5") ??
           visibleModels.find((m) => m.id === "openai-subscription/gpt-5.4");
         chosen = preferred ?? visibleModels[0];


### PR DESCRIPTION
Answering "do our model lists need updating for GPT-5.6 / Opus 4.8 / Fable 5?" — verified against the **live models.dev catalog** (2026-07-20), per the house rule of never trusting training memory for registries.

## Findings

| 清单 | 状态 | 处理 |
|---|---|---|
| vision allowlist (`vision_allowlist.py`) | **缺口**:`claude-fable-5`(2026-06-07 发布,models.dev 标注支持图片)不匹配任何家族模式 → 贴图会被误警告,#142 同类 bug | 新增 `claude-(?:fable\|mythos)` 家族模式 |
| 同上,其余 2026 旗舰 | 已覆盖:`gpt-?5` → GPT-5.6(含 luna/sol/terra 变体);`claude-(opus\|sonnet\|haiku)` → Opus 4.8 / Sonnet 5;`gemini-3` → 3.x/3.5 | 仅补回归测试行 |
| ChatGPT 订阅 provider (`openai_subscription.py`) | **过时**:只有 gpt-5.5 / 5.4;GPT-5.6 已于 2026-07-09 GA | 新增 gpt-5.6(1,050k ctx / 128k out,来自 models.dev),置顶;**未删除任何旧条目** |
| 模型下拉默认偏好 (`header-model-dropdown.tsx`) | 偏好 5.5 → 5.4 | 5.6 → 5.5 → 5.4 |
| Rapid-MLX 本地目录 | 不受影响(本地 MLX 模型,另一维度) | 不动 |

Note: gpt-5.6 的 luna/sol/terra 命名变体暂未加入订阅列表 — WHAM 接口实际提供哪些需要真实登录态验证,列为后续确认项。

## Validation

Backend provider tests 200 passed (new regression rows: claude-fable-5, anthropic/claude-fable-5, claude-opus-4-8, claude-sonnet-5, gpt-5.6, gpt-5.6-sol); frontend tsc + ESLint clean.