### PR TITLE
docs: document all 21 BYOK providers (README listed only 12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,18 @@ Finally, write a follow-up email I can send to the team directly.
 | Kimi | BYOK | Moonshot models |
 | MiniMax | BYOK | Direct provider key |
 | Zhipu | BYOK | Direct provider key |
+| Together AI | BYOK | Direct provider key |
+| DeepInfra | BYOK | Direct provider key |
+| Cerebras | BYOK | Fast hosted inference |
+| Cohere | BYOK | Command models |
+| Perplexity | BYOK | Sonar models |
+| Fireworks AI | BYOK | Direct provider key |
+| Azure OpenAI | BYOK | Your own Azure deployment |
+| SiliconFlow | BYOK | Direct provider key |
+| Xiaomi MiMo | BYOK | Direct provider key |
 | ChatGPT | Subscription | Use an existing ChatGPT Plus, Pro, Team, or Enterprise plan when available |
 
-Cloud and subscription paths are optional. OpenYak does not provide hosted model accounts and does not proxy model traffic; requests go directly from your desktop to the provider you configure.
+Any provider not listed above can still be used through a custom OpenAI-compatible endpoint. Cloud and subscription paths are optional. OpenYak does not provide hosted model accounts and does not proxy model traffic; requests go directly from your desktop to the provider you configure.
 
 ## Core Capabilities
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,9 +147,18 @@ OpenYak 可以在同一个线程里综合多份文件，并在右侧 artifact pa
 | Kimi | BYOK | Moonshot 模型 |
 | MiniMax | BYOK | 直连提供商密钥 |
 | 智谱 | BYOK | 直连提供商密钥 |
+| Together AI | BYOK | 直连提供商密钥 |
+| DeepInfra | BYOK | 直连提供商密钥 |
+| Cerebras | BYOK | 高速托管推理 |
+| Cohere | BYOK | Command 模型 |
+| Perplexity | BYOK | Sonar 模型 |
+| Fireworks AI | BYOK | 直连提供商密钥 |
+| Azure OpenAI | BYOK | 使用自己的 Azure 部署 |
+| SiliconFlow | BYOK | 直连提供商密钥 |
+| Xiaomi MiMo | BYOK | 直连提供商密钥 |
 | ChatGPT | 订阅 | 在可用时使用现有 ChatGPT Plus、Pro、Team 或 Enterprise 方案 |
 
-云端和订阅路径都是可选项。OpenYak 不提供内置模型账号，也不代理模型流量；请求会从你的桌面端直接发往你配置的 provider。
+未列入上表的 provider，仍可通过自定义 OpenAI 兼容端点接入。云端和订阅路径都是可选项。OpenYak 不提供内置模型账号，也不代理模型流量；请求会从你的桌面端直接发往你配置的 provider。
 
 ## 核心能力
 


### PR DESCRIPTION
Fallout from the strategic ruling that **BYOK stays — OpenYak is local-first, not local-only**.

Auditing the provider surface against that ruling turned up a documentation gap: `backend/app/provider/catalog.py` registers **21 providers**, but both READMEs listed only 12. Missing: Together AI, DeepInfra, Cerebras, Cohere, Perplexity, Fireworks AI, Azure OpenAI, SiliconFlow, Xiaomi MiMo.

Also adds a line noting that any provider *not* in the table can still be reached through a custom OpenAI-compatible endpoint — that escape hatch was documented only for local servers, not as the general "bring any API" path it actually is.

Both English and Chinese READMEs updated in lockstep. Docs-only; no code changes.