### PR TITLE
UX P1: app-wide keyboard shortcuts (⌘B / ⌘N / ⌘, / ⌘⇧]⌘⇧[)

### DIFF
--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -34,6 +34,7 @@ import { useActivityStore } from "@/stores/activity-store";
 import { useArtifactStore } from "@/stores/artifact-store";
 import { IS_DESKTOP, TITLE_BAR_HEIGHT } from "@/lib/constants";
 import { useIsDesktop } from "@/hooks/use-is-desktop";
+import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { desktopAPI } from "@/lib/tauri-api";
 import { useTranslation } from "react-i18next";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -49,6 +50,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const isMac = useIsMacOS();
   useAutoDetectProvider();
   useTraySync();
+  useGlobalShortcuts();
 
   const settingsHydrated = useSettingsHasHydrated();
 

--- a/frontend/src/hooks/use-global-shortcuts.ts
+++ b/frontend/src/hooks/use-global-shortcuts.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { getChatRoute, resolveSessionId } from "@/lib/routes";
+import { useSessions } from "@/hooks/use-sessions";
+import { useSidebarStore } from "@/stores/sidebar-store";
+import type { SessionResponse } from "@/types/session";
+
+/**
+ * App-wide keyboard shortcuts, mounted once by the main layout.
+ *
+ * - Cmd/Ctrl + B          toggle the sidebar
+ * - Cmd/Ctrl + N          new chat (Cmd/Ctrl + Shift + K also works)
+ * - Cmd/Ctrl + ,          settings
+ * - Cmd/Ctrl + Shift + ]  next conversation
+ * - Cmd/Ctrl + Shift + [  previous conversation
+ *
+ * Chat-scoped actions (Esc to stop, copy last message) stay in
+ * `use-keyboard-shortcuts`, which only mounts on chat views.
+ */
+export function useGlobalShortcuts() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const toggleSidebar = useSidebarStore((s) => s.toggle);
+  const { data } = useSessions();
+
+  const cycleSession = useCallback(
+    (delta: number) => {
+      const sessions: SessionResponse[] = (data?.pages ?? []).flat();
+      if (sessions.length === 0) return;
+
+      const pathSessionId = pathname?.startsWith("/c/")
+        ? pathname.slice("/c/".length)
+        : null;
+      const currentId = resolveSessionId(
+        pathSessionId,
+        searchParams?.get("sessionId"),
+      );
+
+      const index = sessions.findIndex((s) => s.id === currentId);
+      // Not on a session (or it's gone): enter the list at either end.
+      const nextIndex =
+        index === -1
+          ? delta > 0
+            ? 0
+            : sessions.length - 1
+          : (index + delta + sessions.length) % sessions.length;
+
+      const next = sessions[nextIndex];
+      if (next && next.id !== currentId) router.push(getChatRoute(next.id));
+    },
+    [data, pathname, router, searchParams],
+  );
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Accept either modifier, matching search-command-dialog. Deriving the
+      // platform from the deprecated navigator.platform is unreliable (it
+      // silently disables every binding when the sniff misses).
+      const modKey = e.metaKey || e.ctrlKey;
+      if (!modKey) return;
+
+      const target = e.target as HTMLElement | null;
+      const isTyping =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable === true;
+
+      // Sidebar toggle and settings stay available while typing — they don't
+      // consume the composer's text and users reach for them mid-draft.
+      if (!e.shiftKey && (e.key === "b" || e.key === "B")) {
+        e.preventDefault();
+        toggleSidebar();
+        return;
+      }
+      if (e.key === ",") {
+        e.preventDefault();
+        router.push("/settings");
+        return;
+      }
+
+      if (isTyping) return;
+
+      if (!e.shiftKey && (e.key === "n" || e.key === "N")) {
+        e.preventDefault();
+        router.push("/c/new");
+        return;
+      }
+      if (e.shiftKey && (e.key === "]" || e.key === "}")) {
+        e.preventDefault();
+        cycleSession(1);
+        return;
+      }
+      if (e.shiftKey && (e.key === "[" || e.key === "{")) {
+        e.preventDefault();
+        cycleSession(-1);
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [cycleSession, router, toggleSidebar]);
+}

--- a/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -13,11 +13,12 @@ interface KeyboardShortcutsOptions {
 }
 
 /**
- * Global keyboard shortcuts for the app
+ * Chat-scoped keyboard shortcuts. App-wide navigation bindings
+ * (sidebar, new chat, settings, session cycling) live in
+ * `use-global-shortcuts`, mounted once by the main layout.
  *
  * Shortcuts:
  * - Cmd/Ctrl + K: Toggle search command palette (handled globally by SearchCommandDialog)
- * - Cmd/Ctrl + Shift + K: New chat
  * - Esc: Stop generation
  * - Cmd/Ctrl + Shift + C: Copy last message
  */
@@ -52,13 +53,6 @@ export function useKeyboardShortcuts({
 
       // Don't process other shortcuts when typing
       if (isTyping) return;
-
-      // Cmd/Ctrl + Shift + K: New chat
-      if (modKey && e.shiftKey && (e.key === "k" || e.key === "K")) {
-        e.preventDefault();
-        router.push("/c/new");
-        return;
-      }
 
       // Cmd/Ctrl + Shift + C: Copy last message
       if (modKey && e.shiftKey && e.key === "C") {

--- a/frontend/tests/ui/openyak-global-shortcuts.spec.ts
+++ b/frontend/tests/ui/openyak-global-shortcuts.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockOpenYakApi, seedOpenYakStorage } from "./fixtures/openyak-api";
+
+test.beforeEach(async ({ page }) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+});
+
+async function openChat(page: Page) {
+  await page.goto("/c/new");
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/** Sidebar width is animated; read the rendered box instead of a class. */
+async function sidebarWidth(page: Page): Promise<number> {
+  const box = await page
+    .getByRole("complementary", { name: "Chat sidebar" })
+    .boundingBox();
+  return box?.width ?? 0;
+}
+
+test("Cmd+B toggles the sidebar, and works while typing in the composer", async ({
+  page,
+}) => {
+  await openChat(page);
+  expect(await sidebarWidth(page)).toBeGreaterThan(100);
+
+  await page.keyboard.press("ControlOrMeta+b");
+  await expect.poll(() => sidebarWidth(page)).toBeLessThan(10);
+
+  await page.keyboard.press("ControlOrMeta+b");
+  await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(100);
+
+  // Deliberate: the sidebar toggle stays live mid-draft, and must not eat
+  // the composer text.
+  const composer = page.getByPlaceholder(/Describe the result you want/i);
+  await composer.fill("draft in progress");
+  await composer.press("ControlOrMeta+b");
+  await expect.poll(() => sidebarWidth(page)).toBeLessThan(10);
+  await expect(composer).toHaveValue("draft in progress");
+  await page.keyboard.press("ControlOrMeta+b");
+});
+
+test("Cmd+N starts a new chat but never fires while typing", async ({
+  page,
+}) => {
+  await page.goto("/c/session-artifacts");
+  await expect(page.getByText("Artifact showcase").first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await page.keyboard.press("ControlOrMeta+n");
+  await expect(
+    page
+      .getByRole("heading", {
+        name: /What should (OpenYak help you do|we do in)/i,
+      })
+      .first(),
+  ).toBeVisible();
+
+  // Typing "n" with the modifier inside the composer must not navigate away
+  // and lose the draft.
+  const composer = page.getByPlaceholder(/Describe the result you want/i);
+  await composer.fill("keep me");
+  await composer.press("ControlOrMeta+n");
+  await expect(composer).toHaveValue("keep me");
+});
+
+test("Cmd+Shift+] and Cmd+Shift+[ cycle through conversations", async ({
+  page,
+}) => {
+  await openChat(page);
+
+  await page.keyboard.press("ControlOrMeta+Shift+]");
+  await expect.poll(() => page.url()).toMatch(/\/c\/(?!new)/);
+  const first = page.url();
+
+  await page.keyboard.press("ControlOrMeta+Shift+]");
+  await expect.poll(() => page.url()).not.toBe(first);
+  const second = page.url();
+
+  // Stepping back returns to the previous conversation.
+  await page.keyboard.press("ControlOrMeta+Shift+[");
+  await expect.poll(() => page.url()).toBe(first);
+  expect(second).not.toBe(first);
+});
+
+test("Cmd+, opens settings", async ({ page }) => {
+  await openChat(page);
+  await page.keyboard.press("ControlOrMeta+,");
+  await expect.poll(() => page.url()).toContain("/settings");
+});


### PR DESCRIPTION
Next P1 slice of the Codex alignment — the keyboard-first part of the "command center" pattern.

## What

OpenYak had `⌘K` search plus two chat-scoped bindings, and those only fired on chat pages because the hook was mounted in `chat-view` instead of the layout. Adds a layout-mounted `use-global-shortcuts`:

| Binding | Action | Notes |
|---|---|---|
| `⌘/Ctrl+B` | 切换侧栏 | 打字时仍生效——起草到一半去开合侧栏是常见动作,且它不吞输入 |
| `⌘/Ctrl+N` | 新会话 | 打字时抑制,避免吞掉草稿 |
| `⌘/Ctrl+,` | 设置 | |
| `⌘/Ctrl+Shift+]` / `[` | 前后切换会话 | 两端循环;不在会话页时从列表首/尾进入 |

New-chat moves out of the chat-scoped hook so it isn't registered twice.

## 一个值得记的坑

首版用 `navigator.platform` 判断 Mac 来决定看 `metaKey` 还是 `ctrlKey`——**在测试里全部按键静默失效**。改为对齐仓库里本来就能工作的 `search-command-dialog` 写法(`e.metaKey || e.ctrlKey`)。若只跑 tsc/build 不驱动真实 GUI,这个会原样发布出去。

## Validation

- Real-GUI Playwright spec(新增,永久回归)驱动全部四组绑定,含两处「打字时不应触发」的抑制用例与循环回绕。
- `next build` 通过且所有路由仍静态预渲染 —— 确认 layout 层的 `useSearchParams` 没有破坏桌面端静态导出。
- 全量 chromium:55 passed,失败集仍为 main 上那 7 个存量项,净新增为零。

## Follow-up

快捷键目前没有可发现的说明面(帮助面板/命令面板提示),建议随 P1.3 composer 刷新一并补 `/` 命令面板时加入。