### PR TITLE
Green the UI suite (7 long-red tests) + flag blocked sessions in the sidebar

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -10,6 +10,7 @@ const workers = Number(process.env.OPENYAK_UI_WORKERS ?? 2);
 
 export default defineConfig({
   testDir: "./tests/ui",
+  globalSetup: "./tests/ui/global-setup.ts",
   timeout: 60_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,

--- a/frontend/src/components/layout/mobile-nav.tsx
+++ b/frontend/src/components/layout/mobile-nav.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SidebarHeader } from "./sidebar-header";
-import { SidebarNav } from "./sidebar-nav";
 import { SessionList } from "./session-list";
 import { SidebarFooter } from "./sidebar-footer";
 import { useSidebarStore } from "@/stores/sidebar-store";
@@ -37,7 +36,6 @@ export function MobileNav() {
         <TooltipProvider delayDuration={200}>
           <div className="flex flex-col h-full">
             <SidebarHeader />
-            <SidebarNav />
             <SessionList />
             <SidebarFooter />
           </div>

--- a/frontend/src/components/layout/session-item.tsx
+++ b/frontend/src/components/layout/session-item.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Archive, EllipsisVertical, Loader2, MessageCircle, Pin, PinOff } from "lucide-react";
+import { Archive, CircleAlert, EllipsisVertical, Loader2, MessageCircle, Pin, PinOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
 import { API, queryKeys } from "@/lib/constants";
@@ -84,6 +84,10 @@ export const SessionItem = memo(function SessionItem({
   // attached, including ones the user navigated away from.
   const liveBucket = useChatSession(session.id);
   const isLive = liveBucket.isGenerating || liveBucket.isCompacting;
+  // A background run that has stopped to ask the user something. Without this
+  // the row just goes quiet — the run looks finished when it is actually
+  // blocked, which is the whole failure mode of unattended automation.
+  const needsInput = !!liveBucket.pendingPermission || !!liveBucket.pendingQuestion;
   const hasDirectory = !!session.directory && session.directory !== ".";
   const deeplink = `openyak://chat?sessionId=${encodeURIComponent(session.id)}`;
   const pinLabel = session.is_pinned
@@ -366,12 +370,21 @@ export const SessionItem = memo(function SessionItem({
                   >
                     {title}
                   </span>
-                  {isLive && (
+                  {needsInput ? (
+                    <CircleAlert
+                      aria-label={
+                        liveBucket.pendingPermission
+                          ? t('sessionNeedsApproval', { defaultValue: 'Waiting for your approval' })
+                          : t('sessionNeedsAnswer', { defaultValue: 'Waiting for your answer' })
+                      }
+                      className="h-3 w-3 shrink-0 text-[var(--color-warning)]"
+                    />
+                  ) : isLive ? (
                     <Loader2
                       aria-label={t('sessionIsGenerating', { defaultValue: 'Generating in background' })}
                       className="h-3 w-3 shrink-0 animate-spin text-[var(--brand-primary)]"
                     />
-                  )}
+                  ) : null}
                 </p>
                 {snippet && (
                   <p className="mt-0.5 truncate text-ui-2xs leading-4 text-[var(--text-tertiary)]">

--- a/frontend/src/components/layout/sidebar-nav.tsx
+++ b/frontend/src/components/layout/sidebar-nav.tsx
@@ -1,3 +1,0 @@
-export function SidebarNav() {
-  return null;
-}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Suspense } from "react";
-import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SidebarHeader } from "./sidebar-header";
@@ -12,14 +11,6 @@ import { SidebarResizeHandle } from "./sidebar-resize-handle";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { useIsMacOS } from "@/hooks/use-platform";
 import { IS_DESKTOP, TITLE_BAR_HEIGHT } from "@/lib/constants";
-
-const SidebarNav = dynamic(
-  () => import("./sidebar-nav").then((mod) => mod.SidebarNav),
-  {
-    ssr: false,
-    loading: () => <div className="px-3 pt-1 pb-2" aria-hidden="true" />,
-  },
-);
 
 export function Sidebar() {
   const isCollapsed = useSidebarStore((s) => s.isCollapsed);
@@ -41,7 +32,6 @@ export function Sidebar() {
         transition={{ type: "spring", damping: 30, stiffness: 300 }}
       >
         <SidebarHeader />
-        <SidebarNav />
         <Suspense fallback={<div className="flex-1" />}>
           <SessionList />
         </Suspense>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -91,5 +91,7 @@
   "modelsUnavailableHint": "Check your provider connection, firewall, or VPN settings.",
   "setupProvider": "Set up provider",
   "setUpProvider": "Set up provider",
-  "apiKey": "API Key"
+  "apiKey": "API Key",
+  "sessionNeedsApproval": "Waiting for your approval",
+  "sessionNeedsAnswer": "Waiting for your answer"
 }

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -91,5 +91,7 @@
   "modelsUnavailableHint": "请检查服务商连接、防火墙或 VPN 设置。",
   "setupProvider": "配置服务商",
   "setUpProvider": "配置服务商",
-  "apiKey": "API 密钥"
+  "apiKey": "API 密钥",
+  "sessionNeedsApproval": "等待你的批准",
+  "sessionNeedsAnswer": "等待你的回答"
 }

--- a/frontend/tests/ui/fixtures/openyak-api.ts
+++ b/frontend/tests/ui/fixtures/openyak-api.ts
@@ -851,7 +851,13 @@ function compactMessagePage(compacted: boolean) {
     "assistant-1",
     "assistant",
     "This conversation is above the manual compaction threshold.",
-    { input: 90000, output: 500, reasoning: 60, cache_read: 0, cache_write: 0 },
+    // The manual-compaction control unlocks at >= 50% of the *usable* context
+    // window, which the app computes as
+    //   max_context - max_output - min(20_000, max_output)
+    // (src/components/chat/context-indicator.tsx). For the seeded model
+    // (max_context 200_000, max_output 8_192) that is 183_616 usable tokens, so
+    // the old 90_000 snapshot sat at 49.0% and left the button locked.
+    { input: 150000, output: 500, reasoning: 60, cache_read: 0, cache_write: 0 },
   );
 
   if (compacted) {

--- a/frontend/tests/ui/global-setup.ts
+++ b/frontend/tests/ui/global-setup.ts
@@ -1,0 +1,33 @@
+import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+/**
+ * The PDF renderer loads its worker from /pdf.worker.min.mjs, which the
+ * production `build` script copies out of pdfjs-dist into public/. `next dev`
+ * (what the Playwright webServer runs) skips that copy, so the office-artifact
+ * test's PDF pane renders no <canvas> and the suite is red for an environment
+ * reason, not a product one. Stage the worker (and the cmaps/fonts the same
+ * build step copies) before the dev server starts so the test is reliable in
+ * CI and locally, regardless of whether a prior `next build` happened to leave
+ * the asset behind.
+ */
+export default function globalSetup() {
+  const root = resolve(__dirname, "..", "..");
+  const pub = resolve(root, "public");
+  const dist = resolve(root, "node_modules", "pdfjs-dist");
+
+  const worker = resolve(pub, "pdf.worker.min.mjs");
+  const src = resolve(dist, "build", "pdf.worker.min.mjs");
+  if (!existsSync(worker) && existsSync(src)) {
+    mkdirSync(dirname(worker), { recursive: true });
+    cpSync(src, worker);
+  }
+
+  for (const dir of ["cmaps", "standard_fonts"]) {
+    const dest = resolve(pub, dir);
+    const from = resolve(dist, dir);
+    if (!existsSync(dest) && existsSync(from)) {
+      cpSync(from, dest, { recursive: true });
+    }
+  }
+}

--- a/frontend/tests/ui/openyak-deep-surfaces.spec.ts
+++ b/frontend/tests/ui/openyak-deep-surfaces.spec.ts
@@ -29,16 +29,22 @@ async function sendPrompt(page: Page, text: string) {
   await promptResponse;
 }
 
-async function seedByokProvider(page: Page) {
+/**
+ * Seed the custom-endpoint bucket. Custom OpenAI-compatible endpoints are a
+ * provider bucket of their own (see src/lib/providers.ts) — they are
+ * deliberately NOT surfaced under "byok", so a test that switches to a
+ * custom-endpoint model has to start in this bucket.
+ */
+async function seedCustomEndpointProvider(page: Page) {
   await page.addInitScript(() => {
     const raw = window.localStorage.getItem("openyak-settings");
     const settings = raw ? JSON.parse(raw) : { state: {}, version: 0 };
     settings.state = {
       ...settings.state,
       hasCompletedOnboarding: true,
-      activeProvider: "byok",
-      selectedModel: "openrouter/anthropic/claude-sonnet-4.5",
-      selectedProviderId: "openrouter",
+      activeProvider: "custom",
+      selectedModel: "local/qwen3-coder",
+      selectedProviderId: "local",
     };
     window.localStorage.setItem("openyak-settings", JSON.stringify(settings));
   });
@@ -102,11 +108,11 @@ test.describe("OpenYak deep claimed-feature GUI surfaces", () => {
 
   test("model selector workflow: search, sort modes, model switch, and send payload stay aligned", async ({ page }) => {
     const state = await setupMockedApp(page);
-    await seedByokProvider(page);
+    await seedCustomEndpointProvider(page);
 
     await page.goto("/c/new");
-    await expect(page.getByRole("button", { name: /Claude Sonnet 4\.5/i })).toBeVisible();
-    await page.getByRole("button", { name: /Claude Sonnet 4\.5/i }).click();
+    await expect(page.getByRole("button", { name: /Qwen3 Coder Local/i })).toBeVisible();
+    await page.getByRole("button", { name: /Qwen3 Coder Local/i }).click();
     await expect(page.getByPlaceholder("Search models...")).toBeVisible();
 
     await page.getByRole("button", { name: /^Price$/i }).click();

--- a/frontend/tests/ui/openyak-natural-office-workflows.spec.ts
+++ b/frontend/tests/ui/openyak-natural-office-workflows.spec.ts
@@ -140,11 +140,21 @@ test.describe("OpenYak natural office GUI workflows", () => {
 
     await startOfficeWorkflow(page, [files.budgetSheet], prompt);
 
-    await expect(mainContent(page).getByText("Finance review").last()).toBeVisible({ timeout: 20_000 });
-    await expect(mainContent(page).getByText("Budget vs actuals").last()).toBeVisible();
-    await expect(mainContent(page).getByText("Biggest variance").last()).toBeVisible();
-    await expect(mainContent(page).getByText("Forecast").last()).toBeVisible();
-    await expect(mainContent(page).getByText("Owner questions").last()).toBeVisible();
+    // The Finance answer is rendered as a markdown table (see `naturalOfficeResponses.budget`
+    // in tests/ui/fixtures/openyak-api.ts). The prose-heading form this test used to assert
+    // ("Budget vs actuals" / "Biggest variance" / "Owner questions") was replaced in e76d3a8;
+    // openyak-readme-media-light.spec.ts:175 pins the current "Finance workbook review"
+    // heading and the README screenshots were regenerated from it, so the table is the
+    // intended shape. None of the strings below appear in the user prompt, so they can only
+    // be satisfied by the assistant answer itself.
+    await expect(mainContent(page).getByText("Finance workbook review").last()).toBeVisible({ timeout: 20_000 });
+    await expect(mainContent(page).getByText("Actual / forecast signal").last()).toBeVisible();
+    await expect(mainContent(page).getByText("Variance call").last()).toBeVisible();
+    await expect(mainContent(page).getByText("Owner question").last()).toBeVisible();
+    // The biggest variance line item, with its magnitude.
+    await expect(mainContent(page).getByText("Support contractors").last()).toBeVisible();
+    await expect(mainContent(page).getByText("18% over").last()).toBeVisible();
+    await expect(mainContent(page).getByText("Finance recommendation").last()).toBeVisible();
     expect(state.fileUploads).toEqual(["budget-review.xlsx"]);
     expect(JSON.stringify(state.promptBodies[0])).toContain(prompt);
     await expectNoAppCrash(page);

--- a/frontend/tests/ui/openyak-preflight.spec.ts
+++ b/frontend/tests/ui/openyak-preflight.spec.ts
@@ -811,9 +811,10 @@ test.describe("OpenYak UI preflight", () => {
       page.getByText("http://localhost:11434/v1", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText("Acme Local Proxy")).toBeVisible();
-    await page
-      .getByPlaceholder("Endpoint Name (e.g. My Local Model)")
-      .fill("Preflight Endpoint");
+    // Slug-based "Custom provider" form (82b5416): Provider ID + Base URL are
+    // required, Display name / API key optional, submitted with "Submit".
+    await page.getByPlaceholder("myprovider").fill("preflight-endpoint");
+    await page.getByPlaceholder("My AI Provider").fill("Preflight Endpoint");
     await page
       .getByPlaceholder(
         "http://localhost:1234/v1 or https://api.example.com/v1",
@@ -822,7 +823,15 @@ test.describe("OpenYak UI preflight", () => {
     await page
       .getByPlaceholder("API Key (Leave blank if not required)")
       .fill("sk-custom-preflight");
-    await page.getByRole("button", { name: "Add Endpoint" }).click();
+    const customSave = page.waitForRequest(
+      (req) =>
+        req.url().includes("/api/config/custom") && req.method() === "POST",
+    );
+    await page.getByRole("button", { name: "Submit" }).click();
+    const saved = JSON.parse((await customSave).postData() ?? "{}");
+    expect(saved.slug).toBe("preflight-endpoint");
+    expect(saved.name).toBe("Preflight Endpoint");
+    expect(saved.base_url).toBe("http://localhost:1234/v1");
   });
 
   test("automations path: create dialog, required fields, templates", async ({

--- a/frontend/tests/ui/openyak-sidebar-attention.spec.ts
+++ b/frontend/tests/ui/openyak-sidebar-attention.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { mockOpenYakApi, seedOpenYakStorage } from "./fixtures/openyak-api";
+
+test("a background run blocked on approval flags itself in the sidebar", async ({
+  page,
+}) => {
+  // "ask" mode so the run actually stops for a permission decision.
+  await seedOpenYakStorage(page, { workMode: "ask" });
+  await mockOpenYakApi(page);
+
+  await page.goto("/c/new");
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page
+    .getByPlaceholder(/Describe the result you want/i)
+    .fill("Please run the permission demo command");
+  await page
+    .locator('button[aria-label="Send message"]:not([disabled])')
+    .click();
+  await expect(page.getByText("Permission Required")).toBeVisible();
+
+  // The sidebar row for this session must advertise that it is blocked —
+  // this is the signal that makes an unattended run recoverable.
+  const flagged = page.getByLabel("Waiting for your approval");
+  await expect(flagged).toBeVisible();
+
+  // It must survive navigating away: the whole point is noticing a blocked
+  // run from somewhere else in the app.
+  await page.getByRole("button", { name: "New chat" }).first().click();
+  await expect(
+    page
+      .getByRole("heading", {
+        name: /What should (OpenYak help you do|we do in)/i,
+      })
+      .first(),
+  ).toBeVisible();
+  await expect(page.getByLabel("Waiting for your approval")).toBeVisible();
+});
+
+test("a plain background run shows the generating spinner, not the alert", async ({
+  page,
+}) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+
+  await page.goto("/c/new");
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page
+    .getByPlaceholder(/Describe the result you want/i)
+    .fill("Start a slow stream so I can watch the sidebar");
+  await page
+    .locator('button[aria-label="Send message"]:not([disabled])')
+    .click();
+
+  await expect(page.getByLabel("Generating in background")).toBeVisible();
+  await expect(page.getByLabel("Waiting for your approval")).toHaveCount(0);
+});

--- a/frontend/tests/ui/openyak-workflows.spec.ts
+++ b/frontend/tests/ui/openyak-workflows.spec.ts
@@ -40,8 +40,14 @@ test.describe("OpenYak complete GUI workflows", () => {
         name: /What should (OpenYak help you do|we do in)/i,
       }),
     ).toBeVisible();
+    // The header model dropdown renders the selected model's display name
+    // (header-model-dropdown.tsx: `selectedLabel = selectedInfo?.name ?? …`).
+    // The seeded default is the first fixture model, "Claude Sonnet 4.5". The
+    // old "Best Free" (openyak/best-free, provider openyak-proxy) was removed
+    // along with the whole OpenYak proxy/billing surface in eeef3c2 — it no
+    // longer exists in the fixture model list or in backend/app/provider.
     await expect(
-      page.getByRole("button", { name: /Best Free/i }),
+      page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
     ).toBeVisible();
 
     await page.locator('input[type="file"]').setInputFiles({
@@ -151,9 +157,12 @@ test.describe("OpenYak complete GUI workflows", () => {
     await expect(
       page.getByText("http://localhost:11434/v1", { exact: true }),
     ).toBeVisible();
-    await page
-      .getByPlaceholder("Endpoint Name (e.g. My Local Model)")
-      .fill("Workflow Endpoint");
+    // The custom-endpoint form is the slug-based "Custom provider" form added
+    // in 82b5416 (opencode-style custom provider): Provider ID + Display name +
+    // Base URL, submitted with "Submit". Provider ID and Base URL are required
+    // (see `submitDisabled` in src/components/settings/providers/custom-endpoint-form.tsx).
+    await page.getByPlaceholder("myprovider").fill("workflow-endpoint");
+    await page.getByPlaceholder("My AI Provider").fill("Workflow Endpoint");
     await page
       .getByPlaceholder(
         "http://localhost:1234/v1 or https://api.example.com/v1",
@@ -165,9 +174,10 @@ test.describe("OpenYak complete GUI workflows", () => {
         res.request().method() === "POST" &&
         res.status() === 200,
     );
-    await page.getByRole("button", { name: "Add Endpoint" }).click();
+    await page.getByRole("button", { name: "Submit" }).click();
     await customSave;
     expect(JSON.stringify(state.providerSaves)).toContain("Workflow Endpoint");
+    expect(JSON.stringify(state.providerSaves)).toContain("workflow-endpoint");
     expect(JSON.stringify(state.providerSaves)).toContain(
       "http://localhost:1234/v1",
     );


### PR DESCRIPTION
Two related threads of UI-health work. The headline: **the Playwright suite is fully green for the first time** — 64 passed / 5 skipped / 0 failed.

## The 7 long-red tests (all diagnosed to root, none a product bug — but one a real env defect)

The suite had been silently red on clean main, which lets real regressions hide inside the known-failure noise. Each failure was traced to a specific commit or cause:

| Test | Cause | Fix |
|---|---|---|
| model selector (deep-surfaces) | seeded `byok` but expected a custom-endpoint model; `src/lib/providers.ts` deliberately excludes custom endpoints from byok | seed the custom bucket instead |
| provider setup ×2 (workflows:103, preflight:783) | drove the two-field add-endpoint form removed in 82b5416 | rewired to the slug-based form; **strengthened** preflight to assert the POST body it never checked |
| chat task journey (workflows:30) | waited for the 'Best Free' model removed with the proxy/billing surface (eeef3c2) | expect the seeded default model |
| budget workflow (natural-office:136) | asserted prose headings e76d3a8 rewrote into a table | assert the rendered table structure |
| manual compression (conversation-scale:30) | mock usage sat at 49%, one point under the 50% manual-compaction gate → button disabled | raise the fixture snapshot to 150k tokens |
| **office PDF preview (office-errors:35)** | **REAL env defect** — the PDF renderer loads `/pdf.worker.min.mjs`, which only the production `build` copies into public/; `next dev` skips it, so the PDF pane rendered no canvas. A prior `next build` leaving the file behind is why it looked flaky. | added a Playwright `globalSetup` that stages the worker + cmaps/fonts before the server starts — **verified from a clean `public/` that the test fails without it and passes with it** |

Only test files + the Playwright config changed for these; no product code.

## P1.2 — flag sessions blocked waiting on you (product change)

A background run that stops for a permission decision or an agent question went visually silent in the sidebar — the spinner cleared, so a blocked run looked finished. That is the core failure mode of unattended automation. Session rows now show an amber alert (distinct labels for approval vs answer) where the spinner would be, taking precedence over it. Also removes the `return null` `sidebar-nav.tsx` dead component. Real-GUI spec covers the blocked case (badge visible, survives navigating away) and the plain-run case (spinner, no alert); verified to fail with the fix stashed.

Deliberately skipped from the spec's P1.2 list: migrating channel badges to semantic tokens — those are third-party platform brand colors (P0.4 established brand colors stay).

## Note

The 6 test fixes came from a multi-agent diagnostic pass; I **independently re-verified** each rather than trusting the agents — and caught that the office-errors 'flaky, no change needed' verdict was wrong: the agent's worktree had a stale `pdf.worker.min.mjs` from a prior build, so its 'passes under turbopack' was environment contamination. The globalSetup fix is the real remedy.