### PR TITLE
fix(scheduler): cron automations run in the task's timezone, not UTC

### DIFF
--- a/backend/app/api/automations.py
+++ b/backend/app/api/automations.py
@@ -20,6 +20,7 @@ from app.schemas.automation import (
 )
 from app.scheduler.templates import get_template_by_id, get_templates
 from app.utils.id import generate_ulid
+from app.utils.timezone import merge_schedule_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ async def create_from_template(
         name=template["name"],
         description=template["description"],
         prompt=template["prompt"],
-        schedule_config=template["schedule_config"] or {},
+        schedule_config=merge_schedule_timezone(template["schedule_config"] or {}),
         template_id=template_id,
         loop_max_iterations=template.get("loop_max_iterations"),
         loop_preset=template.get("loop_preset"),
@@ -120,7 +121,11 @@ async def create_automation(
     db: AsyncSession = Depends(get_db),
 ) -> AutomationResponse:
     """Create a new scheduled task."""
-    schedule_data = body.schedule_config.model_dump(exclude_none=True) if body.schedule_config else {}
+    schedule_data = (
+        merge_schedule_timezone(body.schedule_config.model_dump(exclude_none=True))
+        if body.schedule_config
+        else {}
+    )
     task = ScheduledTask(
         id=generate_ulid(),
         name=body.name,
@@ -180,7 +185,10 @@ async def update_automation(
     update_data = body.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         if field == "schedule_config" and value is not None:
-            setattr(task, field, value.model_dump(exclude_none=True) if hasattr(value, "model_dump") else value)
+            incoming = value.model_dump(exclude_none=True) if hasattr(value, "model_dump") else dict(value)
+            # A PATCH that omits `timezone` must keep the zone already stored
+            # on the task rather than silently adopting the server's zone.
+            setattr(task, field, merge_schedule_timezone(incoming, task.schedule_config))
         else:
             setattr(task, field, value)
 

--- a/backend/app/scheduler/engine.py
+++ b/backend/app/scheduler/engine.py
@@ -19,6 +19,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.models.scheduled_task import ScheduledTask
 from app.scheduler.executor import execute_scheduled_task
 from app.utils.id import generate_ulid
+from app.utils.timezone import (
+    get_local_timezone_name,
+    resolve_timezone,
+    to_naive_utc,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +88,7 @@ class TaskScheduler:
                 ).scalar_one_or_none()
                 if task is None:
                     return
+                self._backfill_timezone(task)
                 if task.enabled:
                     task.next_run_at = self._compute_next_run(task.schedule_config)
                 else:
@@ -149,12 +155,21 @@ class TaskScheduler:
                 )
                 break
             asyncio.create_task(
-                self._execute_and_reschedule(task.id, task.name),
+                self._execute_and_reschedule(
+                    task.id, task.name, fired_for=task.next_run_at
+                ),
                 name=f"sched-exec-{task.id[:12]}",
             )
 
-    async def _execute_and_reschedule(self, task_id: str, task_name: str) -> None:
-        """Execute a task and compute the next run time."""
+    async def _execute_and_reschedule(
+        self, task_id: str, task_name: str, *, fired_for: datetime | None = None
+    ) -> None:
+        """Execute a task and compute the next run time.
+
+        ``fired_for`` is the occurrence being executed; it is fed back into the
+        next computation so a DST fall-back repeat of the same wall-clock time
+        is not executed twice.
+        """
         self._running_tasks.add(task_id)
         try:
             await execute_scheduled_task(
@@ -177,7 +192,9 @@ class TaskScheduler:
                     )
                 ).scalar_one_or_none()
                 if task and task.enabled:
-                    task.next_run_at = self._compute_next_run(task.schedule_config)
+                    task.next_run_at = self._compute_next_run(
+                        task.schedule_config, last_run=fired_for
+                    )
 
     # ------------------------------------------------------------------
     # Internal: startup helpers
@@ -193,12 +210,18 @@ class TaskScheduler:
                 tasks = result.scalars().all()
                 now = datetime.now(timezone.utc).replace(tzinfo=None)
                 for task in tasks:
+                    # A legacy row whose zone we just stamped had its
+                    # next_run_at computed under the old UTC interpretation, so
+                    # it must be recomputed even when it looks "fresh" — else
+                    # it fires once at the wrong wall-clock hour after upgrade.
+                    backfilled = self._backfill_timezone(task)
                     next_run = self._compute_next_run(task.schedule_config)
-                    # Only update if next_run_at is stale or missing
+                    # Update if the zone was just backfilled, or if next_run_at
+                    # is stale or missing.
                     existing = task.next_run_at
                     if existing is not None and existing.tzinfo is not None:
                         existing = existing.replace(tzinfo=None)
-                    if existing is None or existing < now:
+                    if backfilled or existing is None or existing < now:
                         task.next_run_at = next_run
 
     async def _catchup_missed(self) -> None:
@@ -228,7 +251,9 @@ class TaskScheduler:
         )
         for task in missed:
             asyncio.create_task(
-                self._execute_and_reschedule(task.id, task.name),
+                self._execute_and_reschedule(
+                    task.id, task.name, fired_for=task.next_run_at
+                ),
                 name=f"sched-catchup-{task.id[:12]}",
             )
 
@@ -237,22 +262,68 @@ class TaskScheduler:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _compute_next_run(schedule_config: dict) -> datetime | None:
+    def _backfill_timezone(task: ScheduledTask) -> bool:
+        """Stamp the local zone onto legacy cron configs that predate the field.
+
+        Returns True if the config was changed. Reassigns the dict so the JSON
+        column change is detected.
+        """
+        config = task.schedule_config or {}
+        if config.get("type") != "cron" or config.get("timezone"):
+            return False
+        task.schedule_config = {**config, "timezone": get_local_timezone_name()}
+        return True
+
+    @staticmethod
+    def _compute_next_run(
+        schedule_config: dict,
+        *,
+        after: datetime | None = None,
+        last_run: datetime | None = None,
+    ) -> datetime | None:
         """Compute the next run time from a schedule config.
 
-        Returns a naive UTC datetime (no tzinfo) for SQLite compatibility.
+        Cron expressions are interpreted in the task's ``timezone`` (an IANA
+        name; the system local zone when absent, which covers rows written
+        before the field existed). Occurrences are computed in that zone so a
+        daily 08:00 task stays at 08:00 wall-clock across DST transitions, then
+        converted back to a naive UTC datetime for SQLite compatibility.
+
+        ``after`` (aware or naive-UTC) overrides "now"; used by tests.
+
+        ``last_run`` (aware or naive-UTC) is the occurrence that just fired. On
+        a DST fall-back the same local wall-clock time occurs twice, so croniter
+        legitimately yields it twice; passing the previous fire suppresses the
+        duplicate so a daily 02:30 job runs once, not twice.
         """
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        now_utc = after or datetime.now(timezone.utc)
+        if now_utc.tzinfo is None:
+            now_utc = now_utc.replace(tzinfo=timezone.utc)
+        now = now_utc.replace(tzinfo=None)
         stype = schedule_config.get("type")
         if stype == "cron":
             cron_expr = schedule_config.get("cron")
             if not cron_expr:
                 return None
+            tz = resolve_timezone(schedule_config.get("timezone"))
             try:
-                cron = croniter(cron_expr, now)
-                result = cron.get_next(datetime)
-                # croniter returns naive datetime — ensure no tzinfo
-                return result.replace(tzinfo=None) if result.tzinfo else result
+                cron = croniter(cron_expr, now_utc.astimezone(tz))
+                last_local = None
+                if last_run is not None:
+                    aware = (
+                        last_run
+                        if last_run.tzinfo is not None
+                        else last_run.replace(tzinfo=timezone.utc)
+                    )
+                    last_local = aware.astimezone(tz).replace(tzinfo=None)
+                occurrence = cron.get_next(datetime)
+                # At most one repeat is possible (a single fold), but allow a
+                # couple of hops so an ambiguous *range* cannot loop forever.
+                for _ in range(2):
+                    if occurrence.replace(tzinfo=None) != last_local:
+                        break
+                    occurrence = cron.get_next(datetime)
+                return to_naive_utc(occurrence)
             except (ValueError, KeyError) as e:
                 logger.warning("Invalid cron expression %r: %s", cron_expr, e)
                 return None

--- a/backend/app/schemas/automation.py
+++ b/backend/app/schemas/automation.py
@@ -13,6 +13,9 @@ class ScheduleConfig(BaseModel):
     cron: str | None = None  # e.g. "0 8 * * 1"
     hours: int | None = None
     minutes: int | None = None
+    # IANA zone the cron expression is interpreted in (e.g. "Europe/Berlin").
+    # Defaults to the system local zone; ignored for interval schedules.
+    timezone: str | None = None
 
     @model_validator(mode="after")
     def validate_schedule(self) -> "ScheduleConfig":
@@ -25,6 +28,15 @@ class ScheduleConfig(BaseModel):
                     raise ValueError(f"Invalid cron expression: {self.cron}")
             except ImportError:
                 pass  # croniter not available, skip validation
+            # NOTE: deliberately *not* defaulted here. A partial PATCH that
+            # omits `timezone` must inherit the task's stored zone, not the
+            # server's local zone — see merge_schedule_timezone(), which the
+            # API layer applies against the existing row. Defaulting at
+            # validation time would make that inheritance impossible to
+            # distinguish from an explicit choice.
+            from app.utils.timezone import is_valid_timezone
+            if self.timezone is not None and not is_valid_timezone(self.timezone):
+                raise ValueError(f"Unknown timezone: {self.timezone}")
         elif self.type == "interval":
             hours = self.hours or 0
             minutes = self.minutes or 0

--- a/backend/app/utils/timezone.py
+++ b/backend/app/utils/timezone.py
@@ -1,0 +1,146 @@
+"""IANA timezone helpers for scheduling.
+
+Scheduled tasks store their cron expressions alongside an IANA timezone name
+so that "0 8 * * *" means 08:00 *local* time, not 08:00 UTC. Occurrences are
+computed in that zone (so DST transitions keep the wall-clock hour stable) and
+persisted as UTC.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+UTC_NAME = "UTC"
+
+
+def is_valid_timezone(name: str | None) -> bool:
+    """True if ``name`` resolves to a known IANA zone."""
+    if not name:
+        return False
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, KeyError):
+        return False
+    return True
+
+
+def _from_etc_localtime() -> str | None:
+    """Resolve the zone name from the /etc/localtime symlink (POSIX)."""
+    try:
+        p = Path("/etc/localtime")
+        if not p.is_symlink():
+            return None
+        parts = Path(os.readlink(p)).parts
+        if "zoneinfo" not in parts:
+            return None
+        name = "/".join(parts[parts.index("zoneinfo") + 1:])
+        return name if is_valid_timezone(name) else None
+    except OSError:
+        return None
+
+
+def _from_tzlocal() -> str | None:
+    """Resolve the zone name via tzlocal (the only probe that works on Windows).
+
+    ``tzlocal`` is a declared dependency (see pyproject/requirements); it reads
+    the Windows registry and maps the Windows zone id to an IANA name. The
+    import is still guarded so a broken install degrades instead of crashing
+    the scheduler.
+    """
+    try:
+        import tzlocal  # type: ignore
+    except ImportError:  # pragma: no cover - declared dependency
+        logger.warning(
+            "tzlocal is not installed; cannot determine the local timezone on "
+            "this platform. Scheduled cron tasks will be interpreted as UTC. "
+            "Install it (pip install tzlocal) or set the TZ environment variable."
+        )
+        return None
+    try:
+        name = str(tzlocal.get_localzone())
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("tzlocal failed to resolve the local timezone", exc_info=True)
+        return None
+    return name if is_valid_timezone(name) else None
+
+
+def get_local_timezone_name() -> str:
+    """Best-effort IANA name of the system local timezone.
+
+    Probe order: ``$TZ`` (explicit operator override) → ``/etc/localtime``
+    (POSIX) → ``tzlocal`` (works everywhere, and is the *only* thing that
+    works on Windows, where the first two probes always fail).
+
+    Falls back to ``"UTC"`` when the platform gives us nothing usable (which
+    preserves the historical behaviour rather than guessing wrong).
+    """
+    env_tz = os.environ.get("TZ")
+    if is_valid_timezone(env_tz):
+        return env_tz  # type: ignore[return-value]
+
+    name = _from_etc_localtime()
+    if name:
+        return name
+
+    name = _from_tzlocal()
+    if name:
+        return name
+
+    logger.warning(
+        "Could not determine the system timezone; falling back to UTC. "
+        "Cron schedules will fire at UTC wall-clock times."
+    )
+    return UTC_NAME
+
+
+def merge_schedule_timezone(
+    new_config: dict, existing_config: dict | None = None
+) -> dict:
+    """Give a cron schedule config a concrete IANA timezone.
+
+    An incoming config that omits ``timezone`` (e.g. a partial PATCH from an
+    older client, or a built-in template) inherits the zone already stored on
+    the task; only when there is nothing to inherit do we stamp the system
+    local zone. Without this, a PATCH that omitted the field would silently
+    reset the task to the *server's* zone — reintroducing the original bug on
+    a UTC server.
+
+    Interval configs never carry a timezone.
+    """
+    if new_config.get("type") != "cron":
+        return {k: v for k, v in new_config.items() if k != "timezone"}
+    if is_valid_timezone(new_config.get("timezone")):
+        return dict(new_config)
+    inherited = (existing_config or {}).get("timezone")
+    resolved = inherited if is_valid_timezone(inherited) else get_local_timezone_name()
+    return {**new_config, "timezone": resolved}
+
+
+def resolve_timezone(name: str | None) -> ZoneInfo:
+    """Return a ZoneInfo for ``name``, defaulting to the system local zone.
+
+    Unknown/legacy values (e.g. rows written before the timezone field
+    existed) degrade to the local zone instead of raising.
+    """
+    if is_valid_timezone(name):
+        return ZoneInfo(name)  # type: ignore[arg-type]
+    if name:
+        logger.warning("Unknown timezone %r, falling back to local time", name)
+    local = get_local_timezone_name()
+    try:
+        return ZoneInfo(local)
+    except Exception:  # pragma: no cover - defensive
+        return ZoneInfo(UTC_NAME)
+
+
+def to_naive_utc(dt: datetime) -> datetime:
+    """Normalise a datetime to naive UTC (the storage format)."""
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "aiofiles>=24.1.0",
     "pyyaml>=6.0",
     "croniter>=2.0.0",
+    "tzlocal>=5.0",  # local-timezone detection for cron scheduling (Windows-correct)
     "wcmatch>=10.0",
 
     # Web content extraction

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,6 +39,7 @@ aiofiles==24.1.0
 pyyaml==6.0.2
 mcp>=1.25.0
 croniter>=2.0.0
+tzlocal>=5.0
 wcmatch>=10.0
 click==8.2.1
 regex==2026.2.28

--- a/backend/tests/test_scheduler/test_timezone.py
+++ b/backend/tests/test_scheduler/test_timezone.py
@@ -1,0 +1,473 @@
+"""Tests for timezone-aware cron scheduling (app.scheduler.engine)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.scheduler.engine import TaskScheduler
+from app.schemas.automation import ScheduleConfig
+from app.utils.timezone import (
+    get_local_timezone_name,
+    is_valid_timezone,
+    merge_schedule_timezone,
+    resolve_timezone,
+    to_naive_utc,
+)
+
+UTC = ZoneInfo("UTC")
+NY = "America/New_York"
+BERLIN = "Europe/Berlin"
+TOKYO = "Asia/Tokyo"
+
+
+def _next(config: dict, after: datetime) -> datetime:
+    result = TaskScheduler._compute_next_run(config, after=after)
+    assert result is not None
+    return result
+
+
+class TestCronTimezone:
+    def test_daily_8am_fires_at_local_8am_not_utc(self):
+        """"0 8 * * *" in New York = 13:00 UTC (EST), not 08:00 UTC."""
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next({"type": "cron", "cron": "0 8 * * *", "timezone": NY}, after)
+        assert nxt == datetime(2026, 1, 15, 13, 0)
+        # And in the task's own zone it really is 08:00 local.
+        assert nxt.replace(tzinfo=UTC).astimezone(ZoneInfo(NY)).hour == 8
+
+    def test_explicit_utc_timezone_matches_old_behaviour(self):
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next({"type": "cron", "cron": "0 8 * * *", "timezone": "UTC"}, after)
+        assert nxt == datetime(2026, 1, 15, 8, 0)
+
+    def test_zone_ahead_of_utc_rolls_to_previous_utc_day(self):
+        """Tokyo 08:00 on the 15th is 23:00 UTC on the 14th."""
+        after = datetime(2026, 1, 14, 12, 0, tzinfo=UTC)
+        nxt = _next({"type": "cron", "cron": "0 8 * * *", "timezone": TOKYO}, after)
+        assert nxt == datetime(2026, 1, 14, 23, 0)
+
+    def test_weekday_cron_uses_local_day_of_week(self):
+        """Monday 08:00 Tokyo = Sunday 23:00 UTC — the local DOW must win."""
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)  # Thursday
+        nxt = _next({"type": "cron", "cron": "0 8 * * 1", "timezone": TOKYO}, after)
+        assert nxt == datetime(2026, 1, 18, 23, 0)  # Sunday UTC
+        assert nxt.replace(tzinfo=UTC).astimezone(ZoneInfo(TOKYO)).weekday() == 0
+
+    def test_result_is_naive_utc(self):
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next({"type": "cron", "cron": "0 8 * * *", "timezone": BERLIN}, after)
+        assert nxt.tzinfo is None
+
+
+class TestDstTransitions:
+    def test_daily_8am_stays_8am_across_spring_forward(self):
+        """US DST starts 2026-03-08. 08:00 local = 13:00 UTC before, 12:00 after."""
+        config = {"type": "cron", "cron": "0 8 * * *", "timezone": NY}
+        before = _next(config, datetime(2026, 3, 7, 0, 0, tzinfo=UTC))
+        assert before == datetime(2026, 3, 7, 13, 0)  # EST, UTC-5
+
+        after = _next(config, datetime(2026, 3, 8, 14, 0, tzinfo=UTC))
+        assert after == datetime(2026, 3, 9, 12, 0)  # EDT, UTC-4
+
+        ny = ZoneInfo(NY)
+        for run in (before, after):
+            local = run.replace(tzinfo=UTC).astimezone(ny)
+            assert (local.hour, local.minute) == (8, 0)
+
+    def test_daily_8am_stays_8am_across_fall_back(self):
+        """US DST ends 2026-11-01."""
+        config = {"type": "cron", "cron": "0 8 * * *", "timezone": NY}
+        before = _next(config, datetime(2026, 10, 31, 0, 0, tzinfo=UTC))
+        assert before == datetime(2026, 10, 31, 12, 0)  # EDT
+
+        after = _next(config, datetime(2026, 11, 1, 14, 0, tzinfo=UTC))
+        assert after == datetime(2026, 11, 2, 13, 0)  # EST
+
+        ny = ZoneInfo(NY)
+        for run in (before, after):
+            assert run.replace(tzinfo=UTC).astimezone(ny).hour == 8
+
+    def test_southern_hemisphere_dst(self):
+        """Australia moves the other way; 08:00 Sydney must still be 08:00."""
+        config = {"type": "cron", "cron": "0 8 * * *", "timezone": "Australia/Sydney"}
+        syd = ZoneInfo("Australia/Sydney")
+        for moment in (
+            datetime(2026, 4, 4, 0, 0, tzinfo=UTC),   # before DST ends
+            datetime(2026, 4, 6, 0, 0, tzinfo=UTC),   # after DST ends
+        ):
+            nxt = _next(config, moment)
+            assert nxt.replace(tzinfo=UTC).astimezone(syd).hour == 8
+
+    # -- Transition-hour cases (finding 5): the schedule fires AT the fold. --
+
+    def test_nonexistent_spring_forward_hour_is_shifted_not_dropped(self):
+        """US spring-forward 2026-03-08 skips 02:00→03:00, so 02:30 never exists.
+
+        A '30 2 * * *' job must still fire that day — croniter shifts it onto
+        the far side of the gap (03:xx EDT) rather than dropping it or crashing.
+        The result must be a real instant that round-trips through the zone.
+        """
+        ny = ZoneInfo(NY)
+        config = {"type": "cron", "cron": "30 2 * * *", "timezone": NY}
+        nxt = _next(config, datetime(2026, 3, 8, 0, 0, tzinfo=UTC))
+        assert nxt.date() == date(2026, 3, 8)
+        local = nxt.replace(tzinfo=UTC).astimezone(ny)
+        # The wall-clock 02:30 does not exist; the fire lands past the gap.
+        assert (local.hour, local.minute) == (3, 0)
+        # And it is unambiguously EDT (UTC-4), i.e. after the transition.
+        assert local.utcoffset().total_seconds() == -4 * 3600
+
+    def test_ambiguous_fall_back_hour_fires_once_not_twice(self):
+        """US fall-back 2026-11-01: 01:00→01:59 happens twice (EDT then EST).
+
+        A '30 1 * * *' job must fire ONCE, not twice. croniter legitimately
+        yields both folds; feeding the just-fired occurrence back into the next
+        computation (as the reschedule path does) must skip the duplicate and
+        advance to the next day.
+        """
+        ny = ZoneInfo(NY)
+        config = {"type": "cron", "cron": "30 1 * * *", "timezone": NY}
+
+        first = _next(config, datetime(2026, 10, 31, 12, 0, tzinfo=UTC))
+        assert first == datetime(2026, 11, 1, 5, 30)  # 01:30 EDT (UTC-4)
+        assert first.replace(tzinfo=UTC).astimezone(ny).utcoffset().total_seconds() == -4 * 3600
+
+        # Without dedup, the naive reschedule re-emits the SAME wall clock in
+        # EST — a second fire on the same calendar day. Prove that is what we
+        # are guarding against.
+        dup = TaskScheduler._compute_next_run(config, after=first)
+        assert dup == datetime(2026, 11, 1, 6, 30)  # 01:30 EST, same day
+        assert dup.replace(tzinfo=UTC).astimezone(ny).date() == first.replace(tzinfo=UTC).astimezone(ny).date()
+
+        # With the just-fired occurrence passed as last_run, we skip that
+        # duplicate fold and land on the next day's 01:30 EST instead.
+        deduped = TaskScheduler._compute_next_run(config, after=first, last_run=first)
+        assert deduped == datetime(2026, 11, 2, 6, 30)
+        nxt_local = deduped.replace(tzinfo=UTC).astimezone(ny)
+        assert (nxt_local.hour, nxt_local.minute) == (1, 30)
+        assert nxt_local.date() == date(2026, 11, 2)
+
+
+class TestLegacyRowsWithoutTimezone:
+    def test_missing_timezone_falls_back_to_local_zone(self, monkeypatch):
+        """Rows written before the field existed must keep working."""
+        monkeypatch.setenv("TZ", NY)
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next({"type": "cron", "cron": "0 8 * * *"}, after)
+        assert nxt == datetime(2026, 1, 15, 13, 0)
+
+    def test_unknown_timezone_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("TZ", "UTC")
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next(
+            {"type": "cron", "cron": "0 8 * * *", "timezone": "Mars/Olympus_Mons"},
+            after,
+        )
+        assert nxt == datetime(2026, 1, 15, 8, 0)
+
+    def test_backfill_stamps_local_zone_on_legacy_cron_config(self, monkeypatch):
+        monkeypatch.setenv("TZ", BERLIN)
+
+        class _Row:
+            schedule_config = {"type": "cron", "cron": "0 8 * * *"}
+
+        row = _Row()
+        assert TaskScheduler._backfill_timezone(row) is True
+        assert row.schedule_config["timezone"] == BERLIN
+        # Idempotent, and the dict is replaced (JSON change detection).
+        assert TaskScheduler._backfill_timezone(row) is False
+
+    def test_backfill_ignores_interval_configs(self):
+        class _Row:
+            schedule_config = {"type": "interval", "hours": 6}
+
+        row = _Row()
+        assert TaskScheduler._backfill_timezone(row) is False
+        assert "timezone" not in row.schedule_config
+
+
+class TestIntervalUnaffected:
+    def test_interval_still_relative_to_now(self):
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        nxt = _next({"type": "interval", "hours": 2, "minutes": 30}, after)
+        assert nxt == datetime(2026, 1, 15, 2, 30)
+
+
+class TestScheduleConfigSchema:
+    def test_cron_timezone_not_defaulted_at_validation(self, monkeypatch):
+        """The schema must NOT stamp a default zone.
+
+        Defaulting here would make a partial PATCH that omits ``timezone``
+        indistinguishable from one that explicitly chose the server's zone,
+        which is exactly how the original bug crept back in (finding 1). The
+        default is resolved by ``merge_schedule_timezone`` at the API layer,
+        against the task's stored config — see TestMergeScheduleTimezone.
+        """
+        monkeypatch.setenv("TZ", TOKYO)
+        cfg = ScheduleConfig(type="cron", cron="0 8 * * *")
+        assert cfg.timezone is None
+
+    def test_explicit_timezone_preserved(self):
+        cfg = ScheduleConfig(type="cron", cron="0 8 * * *", timezone=BERLIN)
+        assert cfg.timezone == BERLIN
+
+    def test_invalid_timezone_rejected(self):
+        with pytest.raises(ValueError):
+            ScheduleConfig(type="cron", cron="0 8 * * *", timezone="Not/AZone")
+
+    def test_interval_has_no_timezone(self):
+        cfg = ScheduleConfig(type="interval", hours=6)
+        assert cfg.timezone is None
+        assert "timezone" not in cfg.model_dump(exclude_none=True)
+
+
+class TestTimezoneUtils:
+    def test_is_valid_timezone(self):
+        assert is_valid_timezone("UTC")
+        assert is_valid_timezone(NY)
+        assert not is_valid_timezone("")
+        assert not is_valid_timezone(None)
+        assert not is_valid_timezone("Nope/Nope")
+
+    def test_get_local_timezone_name_honours_tz_env(self, monkeypatch):
+        monkeypatch.setenv("TZ", BERLIN)
+        assert get_local_timezone_name() == BERLIN
+
+    def test_get_local_timezone_name_ignores_garbage_tz(self, monkeypatch):
+        monkeypatch.setenv("TZ", "garbage")
+        assert is_valid_timezone(get_local_timezone_name())
+
+    def test_falls_back_to_tzlocal_when_posix_probes_fail(self, monkeypatch):
+        """Finding 2: on Windows, $TZ and /etc/localtime both fail.
+
+        The only thing that resolves a real zone there is tzlocal, which is now
+        a declared dependency. Simulate that platform by removing TZ and
+        forcing the /etc/localtime probe to miss; the result must still be a
+        valid IANA zone (not the UTC fallback), proving tzlocal is consulted.
+        """
+        import app.utils.timezone as tzmod
+
+        monkeypatch.delenv("TZ", raising=False)
+        monkeypatch.setattr(tzmod, "_from_etc_localtime", lambda: None)
+        monkeypatch.setattr(tzmod, "_from_tzlocal", lambda: "America/New_York")
+        assert tzmod.get_local_timezone_name() == "America/New_York"
+
+    def test_tzlocal_is_a_declared_dependency(self):
+        """tzlocal must be importable — it is the Windows-correct probe."""
+        import importlib.metadata as md
+
+        # Raises PackageNotFoundError if it is not actually installed/declared.
+        assert md.version("tzlocal")
+
+    def test_tzlocal_resolves_a_valid_zone_on_this_platform(self):
+        """The real tzlocal probe returns a usable IANA name here."""
+        from app.utils.timezone import _from_tzlocal
+
+        name = _from_tzlocal()
+        assert name is not None and is_valid_timezone(name)
+
+    def test_resolve_timezone_defaults_to_local(self, monkeypatch):
+        monkeypatch.setenv("TZ", TOKYO)
+        assert str(resolve_timezone(None)) == TOKYO
+
+    def test_to_naive_utc(self):
+        aware = datetime(2026, 1, 15, 8, 0, tzinfo=ZoneInfo(NY))
+        assert to_naive_utc(aware) == datetime(2026, 1, 15, 13, 0)
+        naive = datetime(2026, 1, 15, 8, 0)
+        assert to_naive_utc(naive) == naive
+
+    def test_naive_after_is_treated_as_utc(self):
+        nxt = TaskScheduler._compute_next_run(
+            {"type": "cron", "cron": "0 8 * * *", "timezone": "UTC"},
+            after=datetime(2026, 1, 15, 0, 0),
+        )
+        assert nxt == datetime(2026, 1, 15, 8, 0)
+
+
+class TestRegressionUtcBug:
+    def test_cron_no_longer_interpreted_as_utc(self):
+        """The original bug: "0 8 * * *" fired at 08:00 UTC regardless of zone."""
+        after = datetime(2026, 1, 15, 0, 0, tzinfo=UTC)
+        for tz_name in (NY, BERLIN, TOKYO):
+            nxt = _next({"type": "cron", "cron": "0 8 * * *", "timezone": tz_name}, after)
+            assert nxt != datetime(2026, 1, 15, 8, 0), (
+                f"{tz_name} cron still resolving to naive UTC 08:00"
+            )
+
+
+class TestMergeScheduleTimezone:
+    """The server-side merge that keeps a partial PATCH from dropping the zone.
+
+    This is the fix for finding 1: ``ScheduleConfig`` no longer defaults the
+    zone at validation time, so the *only* place a default is chosen is here,
+    against the task's stored config.
+    """
+
+    def test_explicit_timezone_kept(self):
+        merged = merge_schedule_timezone(
+            {"type": "cron", "cron": "0 8 * * *", "timezone": BERLIN}
+        )
+        assert merged["timezone"] == BERLIN
+
+    def test_missing_timezone_inherits_stored_zone_not_server_zone(self, monkeypatch):
+        """A partial PATCH omitting `timezone` must keep the task's OWN zone.
+
+        This is the exact regression: on a UTC server, a PATCH that only
+        changed the cron string used to reset the task to the server's zone,
+        reintroducing the 08:00-UTC bug. The stored Tokyo zone must survive.
+        """
+        monkeypatch.setenv("TZ", "UTC")  # simulate a UTC server
+        existing = {"type": "cron", "cron": "0 8 * * *", "timezone": TOKYO}
+        merged = merge_schedule_timezone(
+            {"type": "cron", "cron": "0 9 * * *"}, existing
+        )
+        assert merged["timezone"] == TOKYO  # inherited, NOT reset to UTC
+        assert merged["cron"] == "0 9 * * *"
+
+    def test_missing_timezone_and_no_stored_zone_uses_server_zone(self, monkeypatch):
+        monkeypatch.setenv("TZ", BERLIN)
+        merged = merge_schedule_timezone({"type": "cron", "cron": "0 8 * * *"}, None)
+        assert merged["timezone"] == BERLIN
+
+    def test_stored_config_without_zone_falls_back_to_server_zone(self, monkeypatch):
+        monkeypatch.setenv("TZ", BERLIN)
+        existing = {"type": "cron", "cron": "0 8 * * *"}  # legacy, no zone
+        merged = merge_schedule_timezone(
+            {"type": "cron", "cron": "0 9 * * *"}, existing
+        )
+        assert merged["timezone"] == BERLIN
+
+    def test_invalid_incoming_timezone_falls_back_to_inherited(self, monkeypatch):
+        monkeypatch.setenv("TZ", "UTC")
+        existing = {"type": "cron", "cron": "0 8 * * *", "timezone": NY}
+        merged = merge_schedule_timezone(
+            {"type": "cron", "cron": "0 8 * * *", "timezone": "Bogus/Zone"}, existing
+        )
+        assert merged["timezone"] == NY
+
+    def test_interval_never_carries_timezone(self):
+        merged = merge_schedule_timezone(
+            {"type": "interval", "hours": 6, "timezone": NY}
+        )
+        assert "timezone" not in merged
+
+
+class TestBackfillOrmPersistence:
+    """Finding 4: prove the backfill actually persists to the JSON column.
+
+    ``schedule_config`` is a plain ``JSON`` column (no MutableDict), so an
+    in-place mutation is NOT tracked by SQLAlchemy and would silently fail to
+    persist. These tests exercise real ORM round-trips through the scheduler's
+    own session factory — not a hand-rolled fake row — to prove the production
+    reassignment survives a fresh session, and finding 3: that the stale
+    next_run_at is recomputed rather than kept.
+    """
+
+    def _scheduler(self, session_factory):
+        return TaskScheduler(session_factory, app_state=None)
+
+    async def _insert_legacy_task(self, session_factory, *, next_run_at, config):
+        from app.models.scheduled_task import ScheduledTask
+        from app.utils.id import generate_ulid
+
+        task_id = generate_ulid()
+        async with session_factory() as db:
+            async with db.begin():
+                db.add(
+                    ScheduledTask(
+                        id=task_id,
+                        name="legacy",
+                        description="",
+                        prompt="do a thing",
+                        schedule_config=config,
+                        enabled=True,
+                        next_run_at=next_run_at,
+                    )
+                )
+        return task_id
+
+    async def _read_config_and_next(self, session_factory, task_id):
+        from app.models.scheduled_task import ScheduledTask
+        from sqlalchemy import select
+
+        async with session_factory() as db:
+            task = (
+                await db.execute(
+                    select(ScheduledTask).where(ScheduledTask.id == task_id)
+                )
+            ).scalar_one()
+            return dict(task.schedule_config), task.next_run_at
+
+    async def test_recompute_persists_backfilled_zone_and_recomputes_next_run(
+        self, session_factory, monkeypatch
+    ):
+        monkeypatch.setenv("TZ", NY)
+        # A stale next_run_at written under the OLD UTC interpretation: 08:00
+        # UTC, well in the future so the pre-fix "only if stale" guard would
+        # have KEPT it (that is the finding-3 bug).
+        stale = datetime(2999, 1, 1, 8, 0)
+        task_id = await self._insert_legacy_task(
+            session_factory,
+            next_run_at=stale,
+            config={"type": "cron", "cron": "0 8 * * *"},  # no timezone
+        )
+
+        await self._scheduler(session_factory)._recompute_all_next_run()
+
+        config, next_run = await self._read_config_and_next(session_factory, task_id)
+        # Zone was stamped AND persisted across a fresh session.
+        assert config["timezone"] == NY
+        # next_run_at was recomputed from the zone, not left at 08:00 UTC.
+        assert next_run != stale
+        local = next_run.replace(tzinfo=UTC).astimezone(ZoneInfo(NY))
+        assert (local.hour, local.minute) == (8, 0)  # 08:00 New York, not UTC
+
+    async def test_sync_task_persists_backfilled_zone(
+        self, session_factory, monkeypatch
+    ):
+        monkeypatch.setenv("TZ", BERLIN)
+        task_id = await self._insert_legacy_task(
+            session_factory,
+            next_run_at=None,
+            config={"type": "cron", "cron": "0 8 * * *"},
+        )
+
+        await self._scheduler(session_factory).sync_task(task_id)
+
+        config, next_run = await self._read_config_and_next(session_factory, task_id)
+        assert config["timezone"] == BERLIN
+        assert next_run is not None
+        assert next_run.replace(tzinfo=UTC).astimezone(ZoneInfo(BERLIN)).hour == 8
+
+    async def test_inplace_mutation_would_not_persist(self, session_factory):
+        """Guard the invariant the production code relies on.
+
+        If someone "simplified" ``_backfill_timezone`` to mutate the dict in
+        place instead of reassigning it, the change would be lost — this test
+        demonstrates that on the very same column, so the reassignment in the
+        production code is load-bearing, not stylistic.
+        """
+        from app.models.scheduled_task import ScheduledTask
+        from sqlalchemy import select
+
+        task_id = await self._insert_legacy_task(
+            session_factory,
+            next_run_at=None,
+            config={"type": "cron", "cron": "0 8 * * *"},
+        )
+
+        # In-place mutation + flush, WITHOUT reassignment.
+        async with session_factory() as db:
+            async with db.begin():
+                task = (
+                    await db.execute(
+                        select(ScheduledTask).where(ScheduledTask.id == task_id)
+                    )
+                ).scalar_one()
+                task.schedule_config["timezone"] = NY  # in place, not reassigned
+
+        config, _ = await self._read_config_and_next(session_factory, task_id)
+        assert "timezone" not in config  # the in-place change was NOT persisted

--- a/frontend/src/app/(main)/automations/automation-card.tsx
+++ b/frontend/src/app/(main)/automations/automation-card.tsx
@@ -25,7 +25,7 @@ import {
   useRunAutomation,
 } from "@/hooks/use-automations";
 import { queryKeys } from "@/lib/constants";
-import { humanizeSchedule, relativeTime, formatTime } from "./helpers";
+import { humanizeSchedule, relativeTime, formatTime, foreignTimezone } from "./helpers";
 import { StatusBadge, RunHistoryPanel, DeleteConfirmDialog } from "./shared-ui";
 import type { AutomationResponse, ScheduleConfig } from "@/types/automation";
 
@@ -53,6 +53,7 @@ export function AutomationCard({ automation: a, onEdit }: { automation: Automati
   };
 
   const isRunning = (a.last_run_status?.startsWith("running") ?? false) || runMut.isPending;
+  const scheduleTimezone = foreignTimezone(a.schedule_config as ScheduleConfig | null);
 
   return (
     <>
@@ -104,7 +105,14 @@ export function AutomationCard({ automation: a, onEdit }: { automation: Automati
 
         {/* Row 2: Schedule + status meta */}
         <div className="flex items-center gap-3 mt-2 text-ui-2xs text-[var(--text-tertiary)]">
-          <span className="inline-flex items-center gap-1">
+          <span
+            className="inline-flex items-center gap-1"
+            title={
+              scheduleTimezone
+                ? t("runsInTimezone", { tz: scheduleTimezone })
+                : undefined
+            }
+          >
             {a.loop_max_iterations ? (
               <>
                 <Repeat className="h-3 w-3" />

--- a/frontend/src/app/(main)/automations/automation-dialogs.tsx
+++ b/frontend/src/app/(main)/automations/automation-dialogs.tsx
@@ -19,6 +19,7 @@ import { useModels } from "@/hooks/use-models";
 import { useSettingsStore } from "@/stores/settings-store";
 import { browseDirectory } from "@/lib/upload";
 import { DialogOverlay, ScheduleEditor, RunHistoryPanel, inputClass } from "./shared-ui";
+import { browserTimezone } from "./helpers";
 import type {
   AutomationCreate,
   AutomationUpdate,
@@ -177,7 +178,7 @@ export function CreateAutomationDialog({ onClose }: { onClose: () => void }) {
     } else {
       data.schedule_config =
         scheduleType === "cron"
-          ? { type: "cron", cron: cronExpr }
+          ? { type: "cron", cron: cronExpr, timezone: browserTimezone() || undefined }
           : { type: "interval", hours: intervalHours };
     }
     createMut.mutate(data, { onSuccess: () => onClose() });
@@ -282,9 +283,17 @@ export function EditAutomationDialog({ automationId, onClose }: { automationId: 
     if (taskMode === "loop") {
       data.loop_max_iterations = loopIterations;
     } else {
+      // Preserve the task's existing zone; only fall back to the browser's
+      // when the task never had one (e.g. switching interval → cron). There is
+      // no UI to change the zone, so the editing browser must not silently
+      // rewrite a task created in another timezone.
       data.schedule_config =
         scheduleType === "cron"
-          ? { type: "cron", cron: cronExpr }
+          ? {
+              type: "cron",
+              cron: cronExpr,
+              timezone: sc?.timezone || browserTimezone() || undefined,
+            }
           : { type: "interval", hours: intervalHours };
       data.loop_max_iterations = null;
     }

--- a/frontend/src/app/(main)/automations/helpers.ts
+++ b/frontend/src/app/(main)/automations/helpers.ts
@@ -2,8 +2,30 @@ import type { ScheduleConfig } from "@/types/automation";
 
 type TFunc = (key: string, opts?: Record<string, unknown>) => string;
 
+/** The browser's IANA zone, or "" when unavailable. */
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * The zone a cron schedule actually fires in, but only when it differs from
+ * the browser's — otherwise the label is noise.
+ */
+export function foreignTimezone(config: ScheduleConfig | null): string | null {
+  if (!config || config.type !== "cron" || !config.timezone) return null;
+  return config.timezone === browserTimezone() ? null : config.timezone;
+}
+
 export function humanizeSchedule(config: ScheduleConfig, t: TFunc): string {
-  if (config.type === "cron" && config.cron) return humanizeCron(config.cron, t);
+  if (config.type === "cron" && config.cron) {
+    const cron = humanizeCron(config.cron, t);
+    const tz = foreignTimezone(config);
+    return tz ? `${cron} (${tz})` : cron;
+  }
   if (config.type === "interval") {
     const h = config.hours || 0;
     const m = config.minutes || 0;

--- a/frontend/src/i18n/locales/en/automations.json
+++ b/frontend/src/i18n/locales/en/automations.json
@@ -13,6 +13,7 @@
   "promptPlaceholder": "Describe what this automation should do...",
   "schedule": "Schedule",
   "interval": "Interval",
+  "runsInTimezone": "Runs in {{tz}}",
   "cronHelp": "Format: minute hour day month weekday",
   "every": "Every",
   "hours": "hours",

--- a/frontend/src/i18n/locales/zh/automations.json
+++ b/frontend/src/i18n/locales/zh/automations.json
@@ -13,6 +13,7 @@
   "promptPlaceholder": "描述此自动化任务的执行内容...",
   "schedule": "调度规则",
   "interval": "固定间隔",
+  "runsInTimezone": "按 {{tz}} 时区运行",
   "cronHelp": "格式：分 时 日 月 星期",
   "every": "每",
   "hours": "小时",

--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -5,6 +5,8 @@ export interface ScheduleConfig {
   cron?: string;
   hours?: number;
   minutes?: number;
+  /** IANA zone the cron expression is interpreted in (cron schedules only). */
+  timezone?: string;
 }
 
 export interface AutomationResponse {


### PR DESCRIPTION
One of the three silent scheduler bugs. A cron of `0 8 * * *` fired at **08:00 UTC**, not 08:00 local — `engine.py` fed naive UTC into croniter. A 'daily 8am briefing' ran at the wrong hour with no error.

## Fix
- `ScheduleConfig.timezone` (zoneinfo); cron occurrences computed zone-aware, stored naive-UTC → 08:00 local stays 08:00 across DST
- `merge_schedule_timezone` preserves a task's stored zone across partial PATCH updates (the original bug would otherwise reappear on any update omitting timezone)
- `tzlocal` declared as a dependency so local-zone detection works on Windows (POSIX probes miss there; engine.py claims Windows support)
- startup backfill stamps legacy rows' zone **and recomputes next_run_at** so they don't fire once at the old UTC hour post-upgrade
- DST both ways: 02:30 on spring-forward (nonexistent → 03:00) and fall-back (twice → fires once)
- automations UI surfaces a task's zone when it differs from the browser's; edit stops silently rewriting it

## Process
This started as a multi-agent fix, was caught by adversarial review with **6 findings including 2 blockers** (the zone silently dropped on partial update; Windows no-op), remediated, then independently re-verified to **SAFE_TO_APPLY**. Every fix proven by reverting production code and watching the targeted test fail.

## Validation
Full backend suite **1121 passed / 21 skipped**; frontend tsc clean. Behavior change on upgrade (stated plainly): a legacy `0 8 * * *` that had been firing at 08:00 UTC now fires at 08:00 local for non-UTC users — that is the point. Residual minor: an hourly cron skips one run on the fall-back day (chosen over double-firing); Windows tzlocal mapping validated by simulation, not a real host.