### PR TITLE
fix(session): context collapse stops deleting the user's transcript (ADR-0005)

### DIFF
--- a/backend/app/api/messages.py
+++ b/backend/app/api/messages.py
@@ -21,6 +21,7 @@ def _msg_to_response(msg: Message) -> MessageResponse:
         session_id=msg.session_id,
         time_created=msg.time_created,
         data=msg.data or {},
+        collapsed_at=msg.collapsed_at,
         parts=[
             PartResponse(
                 id=p.id,

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import ForeignKey, Index, JSON, String
+from sqlalchemy import DateTime, ForeignKey, Index, JSON, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -29,6 +30,13 @@ class Message(Base, TimestampMixin):
         ForeignKey("session.id", ondelete="CASCADE"), nullable=False
     )
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    # Set when context collapse dropped this message from the prompt. The row
+    # stays in the transcript (viewable, exportable) but is skipped when the
+    # history is rebuilt for the model — see
+    # docs/adr/0005-compaction-is-a-persistent-part.md.
+    collapsed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
 
     # Relationships
     session: Mapped[Session] = relationship(back_populates="messages")

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -153,6 +153,10 @@ class MessageResponse(BaseModel):
     session_id: str
     time_created: datetime
     data: dict[str, Any]
+    # Set when context collapse dropped this message from the prompt. The
+    # message is still part of the transcript — clients may render it dimmed
+    # or behind a "collapsed" marker, but must keep showing it.
+    collapsed_at: datetime | None = None
     parts: list[PartResponse] = []
 
     model_config = {"from_attributes": True}

--- a/backend/app/session/manager.py
+++ b/backend/app/session/manager.py
@@ -381,8 +381,12 @@ async def get_messages(
     stmt = (
         select(Message)
         .where(Message.session_id == session_id)
+        # id breaks time_created ties deterministically: ULIDs are monotonic
+        # by creation, so same-flush inserts keep their real insertion order
+        # (and the collapse boundary marker, dated 1us before the first kept
+        # row, sorts unambiguously ahead of it).
         .options(selectinload(Message.parts))
-        .order_by(Message.time_created.asc())
+        .order_by(Message.time_created.asc(), Message.id.asc())
     )
     if limit is not None:
         if offset < 0:
@@ -435,6 +439,70 @@ def _provider_uses_reasoning_content(provider_id: str | None, model_id: str | No
     return True
 
 
+def is_compaction_summary(msg: Message) -> bool:
+    """True when ``msg`` is a full-compaction summary message.
+
+    A summary carries both a ``compaction`` part and the ``[Context Summary]``
+    text that stands in for the history it replaced. It is the load-bearing
+    anchor of everything that came before it, so it must never be dropped
+    from the prompt — see :func:`collapsible_messages`.
+    """
+    has_compaction_part = any(
+        p.data and p.data.get("type") == "compaction"
+        for p in msg.parts
+    )
+    has_summary_text = any(
+        p.data
+        and p.data.get("type") == "text"
+        and str(p.data.get("text", "")).startswith("[Context Summary]")
+        for p in msg.parts
+    )
+    return has_compaction_part and has_summary_text
+
+
+def find_compaction_anchor(messages: list[Message]) -> int:
+    """Index of the newest compaction summary in ``messages`` (0 if none).
+
+    After a compaction summary is written, that summary becomes the new
+    history anchor: everything before it has already been summarized and
+    should not be fed back to the model again.
+    """
+    anchor = 0
+    for i, msg in enumerate(messages):
+        if is_compaction_summary(msg):
+            anchor = i
+    return anchor
+
+
+def prompt_visible_messages(messages: list[Message]) -> list[Message]:
+    """Narrow a full transcript to the messages that still go to the model.
+
+    Two persistent trims are applied, both of which keep the underlying rows
+    intact (see docs/adr/0005-compaction-is-a-persistent-part.md):
+
+    * context collapse marks dropped messages with ``collapsed_at``;
+    * full compaction anchors the history at the newest summary.
+    """
+    live = [m for m in messages if m.collapsed_at is None]
+    anchor = find_compaction_anchor(live)
+    return live[anchor:] if anchor else live
+
+
+def collapsible_messages(messages: list[Message]) -> list[Message]:
+    """The prompt-visible messages that context collapse is allowed to drop.
+
+    This is :func:`prompt_visible_messages` minus the compaction anchor. The
+    anchor summary stands in for every message before it, so collapsing it
+    would make :func:`find_compaction_anchor` return a row that prompt
+    assembly then skips — the summary, and with it all the pre-compaction
+    history it represents, would silently vanish from the prompt.
+    """
+    visible = prompt_visible_messages(messages)
+    if visible and is_compaction_summary(visible[0]):
+        return visible[1:]
+    return visible
+
+
 async def get_message_history_for_llm(
     db: AsyncSession,
     session_id: str,
@@ -455,29 +523,8 @@ async def get_message_history_for_llm(
     `deepseek-reasoner` R1 model are skipped — see
     ``_provider_uses_reasoning_content``.
     """
-    messages = await get_messages(db, session_id)
+    messages = prompt_visible_messages(await get_messages(db, session_id))
     llm_messages = []
-
-    # After a compaction summary is written, that summary becomes the new
-    # history anchor. Everything before it has already been summarized and
-    # should not be fed back to the model again.
-    compaction_anchor = 0
-    for i, msg in enumerate(messages):
-        has_compaction_part = any(
-            p.data and p.data.get("type") == "compaction"
-            for p in msg.parts
-        )
-        has_summary_text = any(
-            p.data
-            and p.data.get("type") == "text"
-            and str(p.data.get("text", "")).startswith("[Context Summary]")
-            for p in msg.parts
-        )
-        if has_compaction_part and has_summary_text:
-            compaction_anchor = i
-
-    if compaction_anchor:
-        messages = messages[compaction_anchor:]
 
     echo_reasoning = _provider_uses_reasoning_content(provider_id, model_id)
 

--- a/backend/app/session/microcompact.py
+++ b/backend/app/session/microcompact.py
@@ -238,6 +238,68 @@ def apply_tool_result_budget(
 # Layer 3: Context Collapse
 # ---------------------------------------------------------------------------
 
+def select_collapse_boundary(
+    roles: list[str],
+    *,
+    collapse_fraction: float = 0.33,
+    min_messages_to_keep: int = 6,
+) -> int:
+    """Return the index of the first message to keep, given message roles.
+
+    Shared by :func:`context_collapse` (which applies it to the LLM-formatted
+    history) and by the persistence layer (which applies it to the stored
+    Message rows) so both agree on where the collapse boundary falls.
+
+    Returns 0 when nothing should be collapsed.
+    """
+    total = len(roles)
+    if total <= min_messages_to_keep:
+        return 0
+
+    drop_count = int(total * collapse_fraction)
+
+    # Ensure we keep at least min_messages_to_keep
+    if total - drop_count < min_messages_to_keep:
+        drop_count = total - min_messages_to_keep
+    if drop_count <= 0:
+        return 0
+
+    # Find a safe boundary: don't split mid-turn.
+    # Walk forward from the target drop_count to find a user message
+    # boundary (so we don't leave orphaned tool results).
+    boundary = drop_count
+    while boundary < total - min_messages_to_keep:
+        if roles[boundary] == "user":
+            break
+        boundary += 1
+    else:
+        # Couldn't find a clean boundary — use the original count
+        boundary = drop_count
+
+    return boundary
+
+
+def format_collapse_boundary(
+    *,
+    dropped: int,
+    users: int,
+    assistants: int,
+    tools: int,
+    tokens_saved: int,
+) -> str:
+    """Render the synthetic boundary marker text for a context collapse.
+
+    Shared by :func:`context_collapse` and by the persistence layer so the
+    user-visible counts always describe the trim that was actually applied.
+    """
+    return (
+        f"[Context collapsed: {dropped} earlier messages removed "
+        f"({users} user, {assistants} assistant, "
+        f"{tools} tool results — ~{tokens_saved:,} tokens freed). "
+        f"If you need earlier context, ask the user or re-read relevant files.]"
+    )
+
+
 def context_collapse(
     messages: list[dict[str, Any]],
     *,
@@ -263,29 +325,17 @@ def context_collapse(
         A tuple of (new_messages, tokens_saved) where tokens_saved is an
         estimate of the tokens freed.
     """
-    if not messages or len(messages) <= min_messages_to_keep:
+    if not messages:
         return messages, 0
 
     total = len(messages)
-    drop_count = int(total * collapse_fraction)
-
-    # Ensure we keep at least min_messages_to_keep
-    if total - drop_count < min_messages_to_keep:
-        drop_count = total - min_messages_to_keep
-    if drop_count <= 0:
+    boundary = select_collapse_boundary(
+        [str(m.get("role", "")) for m in messages],
+        collapse_fraction=collapse_fraction,
+        min_messages_to_keep=min_messages_to_keep,
+    )
+    if boundary <= 0:
         return messages, 0
-
-    # Find a safe boundary: don't split mid-turn.
-    # Walk forward from the target drop_count to find a user message
-    # boundary (so we don't leave orphaned tool results).
-    boundary = drop_count
-    while boundary < total - min_messages_to_keep:
-        if messages[boundary].get("role") == "user":
-            break
-        boundary += 1
-    else:
-        # Couldn't find a clean boundary — use the original count
-        boundary = drop_count
 
     dropped = messages[:boundary]
     kept = messages[boundary:]
@@ -298,11 +348,12 @@ def context_collapse(
     dropped_assistant_msgs = [m for m in dropped if m.get("role") == "assistant"]
     dropped_tool_msgs = [m for m in dropped if m.get("role") == "tool"]
 
-    boundary_text = (
-        f"[Context collapsed: {len(dropped)} earlier messages removed "
-        f"({len(dropped_user_msgs)} user, {len(dropped_assistant_msgs)} assistant, "
-        f"{len(dropped_tool_msgs)} tool results — ~{tokens_saved:,} tokens freed). "
-        f"If you need earlier context, ask the user or re-read relevant files.]"
+    boundary_text = format_collapse_boundary(
+        dropped=len(dropped),
+        users=len(dropped_user_msgs),
+        assistants=len(dropped_assistant_msgs),
+        tools=len(dropped_tool_msgs),
+        tokens_saved=tokens_saved,
     )
 
     boundary_msg: dict[str, Any] = {

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
 from app.agent.agent import AgentRegistry
 from app.agent.permission import (
@@ -574,26 +575,21 @@ class SessionPrompt:
         """
         from app.session.compaction import run_compaction
         from app.session.manager import get_message_history_for_llm
-        from app.session.microcompact import context_collapse
 
         # --- Layer 3: Try context collapse first (zero LLM cost) ---
         # Drop the oldest 1/3 of messages. If that frees enough tokens,
-        # skip the expensive LLM-based full compaction.
+        # skip the expensive LLM-based full compaction. The persistence layer
+        # is the single authority on which rows collapse, so the gate reads
+        # the tokens it actually freed — no separate LLM-side selection that
+        # could disagree with what got persisted.
         skip_full_compaction = False
         if not self._context_collapse_exhausted:
             try:
-                async with self.session_factory() as db:
-                    async with db.begin():
-                        collapse_msgs = await get_message_history_for_llm(
-                            db, self.job.session_id
-                        )
-                collapsed, tokens_saved = context_collapse(collapse_msgs)
+                tokens_saved = await _persist_context_collapse(
+                    self.job.session_id,
+                    session_factory=self.session_factory,
+                )
                 if tokens_saved > 0:
-                    await _persist_context_collapse(
-                        self.job.session_id,
-                        collapsed,
-                        session_factory=self.session_factory,
-                    )
                     logger.info(
                         "Context collapse freed ~%d tokens, "
                         "skipping full compaction",
@@ -931,65 +927,141 @@ class SessionPrompt:
         )
 
 
+def _collapsed_row_stats(rows: list[Message]) -> tuple[int, int, int, int]:
+    """(tokens_saved, users, assistants, tool_results) for collapsed rows.
+
+    Derived from the *stored* rows that are actually being collapsed so the
+    gate decision, the logged token count, and the user-visible boundary text
+    all describe the same trim. Counts mirror how ``get_message_history_for_llm``
+    expands a row: one entry per user/assistant row, plus one ``tool`` result
+    per tool part.
+    """
+    from app.utils.token import estimate_tokens
+
+    users = assistants = tool_results = 0
+    tokens = 0
+    for msg in rows:
+        role = str((msg.data or {}).get("role", "user"))
+        if role == "user":
+            users += 1
+        elif role == "assistant":
+            assistants += 1
+        for part in msg.parts:
+            pdata = part.data or {}
+            ptype = pdata.get("type")
+            if ptype == "text":
+                tokens += estimate_tokens(str(pdata.get("text", "")))
+            elif ptype == "reasoning":
+                tokens += estimate_tokens(str(pdata.get("text", "")))
+            elif ptype == "tool":
+                tool_results += 1
+                state = pdata.get("state", {}) or {}
+                tokens += estimate_tokens(str(state.get("input", "")))
+                tokens += estimate_tokens(str(state.get("output", "")))
+    return tokens, users, assistants, tool_results
+
+
 async def _persist_context_collapse(
     session_id: str,
-    collapsed_messages: list[dict[str, Any]],
     *,
     session_factory: async_sessionmaker[AsyncSession],
-) -> None:
-    """Persist context collapse by deleting old messages and inserting a boundary.
+) -> int:
+    """Collapse the oldest prompt-visible rows; return tokens freed.
 
-    The first message in ``collapsed_messages`` is expected to be the
-    synthetic boundary marker from ``context_collapse()``.
+    The trim is a *stored event*, not data loss: the collapsed Messages keep
+    their rows (and Parts) so the transcript stays viewable and export-safe,
+    and are merely stamped with ``collapsed_at`` so prompt assembly skips
+    them. See docs/adr/0005-compaction-is-a-persistent-part.md.
+
+    This function is the single authority on *which* rows collapse. The row
+    selection cannot be aligned by counting against the LLM-formatted history,
+    because one Message can expand into several LLM messages (an assistant turn
+    plus one entry per tool result). So the boundary text, the ``tokens_saved``
+    gate, and the logged counts are all derived here from the rows actually
+    collapsed — never from a separately-computed LLM-side list — otherwise the
+    gate could fire on a different set than the one persisted and the
+    user-visible numbers could disagree with reality.
+
+    Returns the estimated tokens freed (0 when nothing was collapsed).
     """
-    if not collapsed_messages:
-        return
-
-    boundary = collapsed_messages[0]
+    from app.session.manager import collapsible_messages
+    from app.session.microcompact import (
+        format_collapse_boundary,
+        select_collapse_boundary,
+    )
 
     async with session_factory() as db:
         async with db.begin():
-            # Get all existing messages ordered by time
+            # Get all existing messages ordered by time (id breaks ties so
+            # same-timestamp inserts order deterministically — ULIDs are
+            # monotonic by creation).
             stmt = (
                 select(Message)
                 .where(Message.session_id == session_id)
-                .order_by(Message.time_created.asc())
+                .options(selectinload(Message.parts))
+                .order_by(Message.time_created.asc(), Message.id.asc())
             )
             result = await db.execute(stmt)
             db_messages = list(result.scalars().all())
 
-            if not db_messages:
-                return
+            # Candidates are the prompt-visible rows minus the compaction
+            # anchor: already-collapsed rows stay collapsed, anything before
+            # the newest summary is already excluded by the anchor, and the
+            # anchor summary itself must NEVER collapse (collapsing it would
+            # make the anchor point at a hidden row and drop the summary — and
+            # all the history it stands for — from the prompt).
+            candidates = collapsible_messages(db_messages)
+            if not candidates:
+                return 0
 
-            # Calculate how many DB messages to delete.
-            # collapsed_messages = [boundary_marker] + kept_messages
-            # Original had len(db_messages) messages total.
-            # kept_messages count = len(collapsed_messages) - 1 (boundary marker)
-            kept_count = len(collapsed_messages) - 1
-            delete_count = len(db_messages) - kept_count
-            if delete_count <= 0:
-                return
+            cut = select_collapse_boundary(
+                [str((m.data or {}).get("role", "user")) for m in candidates]
+            )
+            if cut <= 0:
+                return 0
 
-            # Delete the oldest messages (and their parts via cascade)
-            for msg in db_messages[:delete_count]:
-                await db.delete(msg)
+            collapsed_rows = candidates[:cut]
+            tokens_saved, users, assistants, tool_results = _collapsed_row_stats(
+                collapsed_rows
+            )
 
-            # Insert the boundary marker as a synthetic user message
-            if boundary.get("content"):
-                boundary_msg = Message(
-                    session_id=session_id,
-                    data={"role": "user", "agent": "system", "system": True},
-                )
-                db.add(boundary_msg)
-                await db.flush()
+            now = datetime.now(timezone.utc)
+            for msg in collapsed_rows:
+                msg.collapsed_at = now
 
-                boundary_part = Part(
-                    message_id=boundary_msg.id,
-                    session_id=session_id,
-                    data={
-                        "type": "text",
-                        "text": boundary["content"],
-                        "synthetic": True,
-                    },
-                )
-                db.add(boundary_part)
+            # Insert the boundary marker as a synthetic user message, dated
+            # just before the oldest surviving message so it renders (and
+            # replays) at the point where the trim happened.
+            first_kept = candidates[cut]
+            boundary_text = format_collapse_boundary(
+                dropped=len(collapsed_rows),
+                users=users,
+                assistants=assistants,
+                tools=tool_results,
+                tokens_saved=tokens_saved,
+            )
+            boundary_msg = Message(
+                session_id=session_id,
+                data={
+                    "role": "user",
+                    "agent": "system",
+                    "system": True,
+                    "collapse_boundary": True,
+                },
+                time_created=first_kept.time_created - timedelta(microseconds=1),
+            )
+            db.add(boundary_msg)
+            await db.flush()
+
+            boundary_part = Part(
+                message_id=boundary_msg.id,
+                session_id=session_id,
+                data={
+                    "type": "text",
+                    "text": boundary_text,
+                    "synthetic": True,
+                },
+            )
+            db.add(boundary_part)
+
+    return tokens_saved

--- a/backend/tests/test_session/test_context_collapse_persistence.py
+++ b/backend/tests/test_session/test_context_collapse_persistence.py
@@ -1,0 +1,440 @@
+"""Context collapse must be a *stored event*, never data loss.
+
+docs/adr/0005-compaction-is-a-persistent-part.md: the pre-collapse history
+stays in the database; only the prompt is trimmed. These tests pin both
+halves of that invariant, and — crucially — exercise the case the bug lived
+in: a single assistant Message row that expands into several LLM messages
+(one per tool result), so the stored rows and the LLM-formatted history do
+*not* line up 1:1. A prior compaction summary is seeded too, so the row that
+anchors history is in play and must survive a collapse.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.message import Message
+from app.session.manager import (
+    create_message,
+    create_part,
+    create_session,
+    get_message_history_for_llm,
+    get_messages,
+)
+from app.session.prompt import _persist_context_collapse
+
+BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+async def _user(db: AsyncSession, session_id: str, text: str, t: datetime) -> Message:
+    m = await create_message(db, session_id=session_id, data={"role": "user"})
+    m.time_created = t
+    await create_part(
+        db, message_id=m.id, session_id=session_id,
+        data={"type": "text", "text": text},
+    )
+    return m
+
+
+async def _assistant(
+    db: AsyncSession,
+    session_id: str,
+    text: str,
+    t: datetime,
+    tools: list[tuple[str, str]] | None = None,
+) -> Message:
+    """An assistant turn, optionally carrying several tool parts.
+
+    Each tool part becomes its own ``role: tool`` entry in the LLM history, so
+    a single row here expands into ``1 + len(tools)`` LLM messages — this is
+    the row/LLM-entry divergence the collapse bug hinged on.
+    """
+    m = await create_message(db, session_id=session_id, data={"role": "assistant"})
+    m.time_created = t
+    await create_part(
+        db, message_id=m.id, session_id=session_id,
+        data={"type": "text", "text": text},
+    )
+    for i, (name, output) in enumerate(tools or []):
+        await create_part(
+            db, message_id=m.id, session_id=session_id,
+            data={
+                "type": "tool",
+                "tool": name,
+                "call_id": f"{m.id}-{i}",
+                "state": {"status": "completed", "input": {"q": name}, "output": output},
+            },
+        )
+    return m
+
+
+async def _compaction_summary(
+    db: AsyncSession, session_id: str, text: str, t: datetime
+) -> Message:
+    """A full-compaction summary row, matching app.session.compaction output."""
+    m = await create_message(
+        db,
+        session_id=session_id,
+        data={"role": "user", "agent": "compaction", "system": True},
+    )
+    m.time_created = t
+    await create_part(
+        db, message_id=m.id, session_id=session_id,
+        data={"type": "text", "text": f"[Context Summary]\n\n{text}", "synthetic": True},
+    )
+    await create_part(
+        db, message_id=m.id, session_id=session_id,
+        data={"type": "compaction", "auto": True},
+    )
+    return m
+
+
+async def _seed_tool_conversation(
+    db: AsyncSession, session_id: str, turns: int
+) -> list[str]:
+    """``turns`` user/assistant pairs where assistants carry tool parts.
+
+    Returns the user/assistant text labels in order. DB rows and LLM entries
+    deliberately diverge: every assistant row expands into 1 + (#tools) LLM
+    messages.
+    """
+    texts: list[str] = []
+    clock = 0
+    for i in range(turns):
+        await _user(db, session_id, f"user-{i}", BASE_TIME + timedelta(minutes=clock))
+        clock += 1
+        await _assistant(
+            db, session_id, f"assistant-{i}", BASE_TIME + timedelta(minutes=clock),
+            tools=[(f"grep-{i}", f"tool-out-{i}-a"), (f"read-{i}", f"tool-out-{i}-b")],
+        )
+        clock += 1
+        texts.extend([f"user-{i}", f"assistant-{i}"])
+    await db.flush()
+    return texts
+
+
+async def _collapse(db: AsyncSession, session_factory, session_id: str) -> int:
+    """Run the real collapse path; returns tokens saved. Commits pending seed."""
+    await db.commit()
+    return await _persist_context_collapse(session_id, session_factory=session_factory)
+
+
+def _prompt_text(history: list[dict]) -> str:
+    parts: list[str] = []
+    for m in history:
+        content = m.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+    return " ".join(parts)
+
+
+class TestContextCollapsePersistence:
+    @pytest.mark.asyncio
+    async def test_rows_and_llm_entries_actually_diverge(
+        self, db: AsyncSession, session_factory
+    ):
+        """Guard the premise: the two lists are NOT 1:1, so counting is wrong."""
+        session = await create_session(db, title="Divergence")
+        await _seed_tool_conversation(db, session.id, turns=10)
+        await db.commit()
+
+        async with session_factory() as fresh:
+            rows = await get_messages(fresh, session.id)
+            history = await get_message_history_for_llm(fresh, session.id)
+
+        # 20 rows (10 user + 10 assistant), but each assistant expands into
+        # 1 assistant + 2 tool entries → far more LLM messages than rows.
+        assert len(rows) == 20
+        assert len(history) > len(rows)
+
+    @pytest.mark.asyncio
+    async def test_collapse_keeps_every_row(self, db: AsyncSession, session_factory):
+        """The user's transcript survives a collapse — nothing is deleted."""
+        session = await create_session(db, title="Collapse")
+        await _seed_tool_conversation(db, session.id, turns=10)
+
+        before = [m.id for m in await get_messages(db, session.id)]
+        assert len(before) == 20
+
+        tokens_saved = await _collapse(db, session_factory, session.id)
+        assert tokens_saved > 0
+
+        async with session_factory() as fresh:
+            after = await get_messages(fresh, session.id)
+        after_ids = [m.id for m in after]
+
+        # Every original row is still there (plus the new boundary marker).
+        assert set(before) <= set(after_ids)
+        assert len(after_ids) == len(before) + 1
+
+        # ...and their parts were not cascade-deleted.
+        collapsed = [m for m in after if m.collapsed_at is not None]
+        assert collapsed, "expected some messages to be marked collapsed"
+        assert all(m.parts for m in collapsed)
+
+    @pytest.mark.asyncio
+    async def test_collapse_excludes_marked_rows_from_prompt(
+        self, db: AsyncSession, session_factory
+    ):
+        """Collapsed messages, including their tool output, stop being sent."""
+        session = await create_session(db, title="Collapse Prompt")
+        await _seed_tool_conversation(db, session.id, turns=10)
+
+        await _collapse(db, session_factory, session.id)
+
+        async with session_factory() as fresh:
+            stored = await get_messages(fresh, session.id)
+            history = await get_message_history_for_llm(fresh, session.id)
+
+        collapsed_texts = {
+            p.data["text"]
+            for m in stored
+            if m.collapsed_at is not None
+            for p in m.parts
+            if p.data.get("type") == "text"
+        }
+        # Tool outputs from collapsed assistant rows must also leave the prompt.
+        collapsed_tool_outputs = {
+            (p.data.get("state") or {}).get("output")
+            for m in stored
+            if m.collapsed_at is not None
+            for p in m.parts
+            if p.data.get("type") == "tool"
+        }
+        assert collapsed_texts
+        assert collapsed_tool_outputs
+
+        prompt_text = _prompt_text(history)
+        for text in collapsed_texts:
+            assert text not in prompt_text
+        for out in collapsed_tool_outputs:
+            assert out and out not in prompt_text
+
+        # The surviving tail is still in the prompt, and the boundary marker
+        # explains the gap.
+        assert "user-9" in prompt_text
+        assert "[Context collapsed:" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_boundary_counts_match_collapsed_rows(
+        self, db: AsyncSession, session_factory
+    ):
+        """The user-visible boundary number describes the rows really dropped."""
+        session = await create_session(db, title="Collapse Counts")
+        await _seed_tool_conversation(db, session.id, turns=10)
+
+        await _collapse(db, session_factory, session.id)
+
+        async with session_factory() as fresh:
+            stored = await get_messages(fresh, session.id)
+
+        collapsed_rows = [m for m in stored if m.collapsed_at is not None]
+        users = sum(1 for m in collapsed_rows if (m.data or {}).get("role") == "user")
+        assistants = sum(
+            1 for m in collapsed_rows if (m.data or {}).get("role") == "assistant"
+        )
+        tool_parts = sum(
+            1
+            for m in collapsed_rows
+            for p in m.parts
+            if p.data.get("type") == "tool"
+        )
+
+        marker_text = next(
+            p.data["text"]
+            for m in stored
+            if (m.data or {}).get("collapse_boundary")
+            for p in m.parts
+            if p.data.get("type") == "text"
+        )
+        # Boundary is phrased from DB rows: "N earlier messages removed
+        # (U user, A assistant, T tool results ...)".
+        assert f"{len(collapsed_rows)} earlier messages removed" in marker_text
+        assert f"{users} user" in marker_text
+        assert f"{assistants} assistant" in marker_text
+        assert f"{tool_parts} tool results" in marker_text
+
+    @pytest.mark.asyncio
+    async def test_boundary_marker_precedes_surviving_history(
+        self, db: AsyncSession, session_factory
+    ):
+        """The marker renders at the trim point, not appended after the tail."""
+        session = await create_session(db, title="Collapse Order")
+        await _seed_tool_conversation(db, session.id, turns=10)
+
+        await _collapse(db, session_factory, session.id)
+
+        async with session_factory() as fresh:
+            stored = await get_messages(fresh, session.id)
+
+        marker_idx = next(
+            i for i, m in enumerate(stored)
+            if (m.data or {}).get("collapse_boundary")
+        )
+        live_after = [m for m in stored[marker_idx + 1:] if m.collapsed_at is None]
+        assert live_after, "boundary marker must come before the kept messages"
+        assert all(m.collapsed_at is not None for m in stored[:marker_idx])
+
+    @pytest.mark.asyncio
+    async def test_prior_compaction_summary_survives_collapse(
+        self, db: AsyncSession, session_factory
+    ):
+        """BLOCKER: a collapse must never drop the compaction anchor.
+
+        The summary anchors all pre-compaction history. If collapse marks it
+        ``collapsed_at``, ``find_compaction_anchor`` then points at a hidden
+        row and the summary — with everything it stands for — vanishes from
+        the prompt. It must still be sent after a collapse.
+        """
+        session = await create_session(db, title="Anchor Survives")
+
+        # Pre-compaction turns, then the summary that replaced them, then a
+        # long tail so there is plenty for collapse to bite into.
+        clock = 0
+        await _user(db, session.id, "ancient-user", BASE_TIME + timedelta(minutes=clock))
+        clock += 1
+        await _assistant(
+            db, session.id, "ancient-assistant", BASE_TIME + timedelta(minutes=clock)
+        )
+        clock += 1
+        await _compaction_summary(
+            db, session.id, "SUMMARY-OF-ANCIENT-HISTORY",
+            BASE_TIME + timedelta(minutes=clock),
+        )
+        clock += 1
+        for i in range(9):
+            await _user(db, session.id, f"post-{i}", BASE_TIME + timedelta(minutes=clock))
+            clock += 1
+            await _assistant(
+                db, session.id, f"post-asst-{i}",
+                BASE_TIME + timedelta(minutes=clock),
+                tools=[(f"tool-{i}", f"post-out-{i}")],
+            )
+            clock += 1
+        await db.flush()
+
+        tokens_saved = await _collapse(db, session_factory, session.id)
+        assert tokens_saved > 0, "collapse should have fired on the post-summary tail"
+
+        async with session_factory() as fresh:
+            stored = await get_messages(fresh, session.id)
+            history = await get_message_history_for_llm(fresh, session.id)
+
+        summary_row = next(
+            m for m in stored
+            for p in m.parts
+            if p.data.get("type") == "compaction"
+        )
+        # The anchor itself was never collapsed...
+        assert summary_row.collapsed_at is None
+        # ...and it is still sent to the model.
+        prompt_text = _prompt_text(history)
+        assert "SUMMARY-OF-ANCIENT-HISTORY" in prompt_text
+        # Some post-summary rows were collapsed out of the prompt.
+        assert "post-0" not in prompt_text
+        # The recent tail is retained.
+        assert "post-8" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_same_timestamp_rows_order_deterministically(
+        self, db: AsyncSession, session_factory
+    ):
+        """Same-flush inserts (identical time_created) must order stably.
+
+        Without a secondary sort key, colliding timestamps leave row order
+        (and the boundary marker's position) up to the DB's whim. The id
+        tiebreak pins it: reads are repeatable and the marker still lands
+        ahead of every surviving row.
+        """
+        session = await create_session(db, title="Collision")
+        # Every row shares one timestamp — the worst case for ordering.
+        collide = BASE_TIME
+        for i in range(12):
+            await _user(db, session.id, f"user-{i}", collide)
+            await _assistant(db, session.id, f"assistant-{i}", collide)
+        await db.commit()
+
+        tokens_saved = await _persist_context_collapse(
+            session.id, session_factory=session_factory
+        )
+        assert tokens_saved > 0
+
+        async with session_factory() as fresh:
+            order_a = [m.id for m in await get_messages(fresh, session.id)]
+        async with session_factory() as fresh:
+            order_b = [m.id for m in await get_messages(fresh, session.id)]
+            stored = await get_messages(fresh, session.id)
+
+        # Repeated reads agree — no non-determinism.
+        assert order_a == order_b
+
+        marker_idx = next(
+            i for i, m in enumerate(stored)
+            if (m.data or {}).get("collapse_boundary")
+        )
+        # Every surviving (non-collapsed) real row is after the marker.
+        for m in stored[:marker_idx]:
+            assert m.collapsed_at is not None
+        live_after = [m for m in stored[marker_idx + 1:] if m.collapsed_at is None]
+        assert live_after
+
+    @pytest.mark.asyncio
+    async def test_second_collapse_does_not_re_collapse(
+        self, db: AsyncSession, session_factory
+    ):
+        """Already-collapsed rows are not candidates again, and stay intact."""
+        session = await create_session(db, title="Collapse Twice")
+        await _seed_tool_conversation(db, session.id, turns=20)
+
+        await _collapse(db, session_factory, session.id)
+        async with session_factory() as fresh:
+            first = {
+                m.id: m.collapsed_at
+                for m in await get_messages(fresh, session.id)
+                if m.collapsed_at is not None
+            }
+
+        await _persist_context_collapse(session.id, session_factory=session_factory)
+
+        async with session_factory() as fresh:
+            rows = await get_messages(fresh, session.id)
+        second = {m.id: m.collapsed_at for m in rows if m.collapsed_at is not None}
+
+        # First batch keeps its original stamp; the second collapse only adds.
+        for msg_id, stamp in first.items():
+            assert second[msg_id] == stamp
+        assert len(second) > len(first)
+        assert len(rows) >= 40  # no row was ever removed
+
+    @pytest.mark.asyncio
+    async def test_api_still_returns_collapsed_messages(
+        self, db: AsyncSession, session_factory
+    ):
+        """Collapsed rows remain visible to the history endpoint layer."""
+        session = await create_session(db, title="Collapse API")
+        await _seed_tool_conversation(db, session.id, turns=10)
+        await _collapse(db, session_factory, session.id)
+
+        async with session_factory() as fresh:
+            stmt = (
+                select(Message)
+                .where(Message.session_id == session.id)
+                .options(selectinload(Message.parts))
+                .order_by(Message.time_created.asc())
+            )
+            rows = list((await fresh.execute(stmt)).scalars().all())
+
+        from app.api.messages import _msg_to_response
+
+        responses = [_msg_to_response(m) for m in rows]
+        assert any(r.collapsed_at is not None for r in responses)
+        assert all(r.parts for r in responses if r.collapsed_at is not None)

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -150,6 +150,9 @@ export interface MessageResponse {
   session_id: string;
   time_created: string;
   data: MessageInfo;
+  /** Set when context collapse dropped this message from the prompt. The
+   * message remains part of the transcript and must still be rendered. */
+  collapsed_at?: string | null;
   parts: PartResponse[];
 }
 


### PR DESCRIPTION
Third of the three silent backend bugs, and the one that destroyed user data. The context-collapse compression layer called `DELETE` on the oldest Message rows (and Parts via cascade). Per **ADR-0005** compaction is a *persistent* record of what was trimmed — full compaction honored that; only this cheaper layer deleted.

## Fix
- nullable `message.collapsed_at` marker; prompt assembly excludes collapsed rows, but they stay in the DB — viewable and export-safe
- **never collapse the compaction anchor** — the summary that roots history was itself eligible to be marked collapsed, which would drop it from the prompt (the BLOCKER review caught)
- collapse marks the same rows the token accounting counts, so the 'N earlier messages removed' boundary number matches reality
- messages API + frontend type carry `collapsed_at` so history rendering isn't surprised by rows that used to be deleted

## Migration
No alembic revision: `alembic/versions/` is empty and unused here — `main.py` migrates via `create_all` + `_add_missing_columns()`, which adds the nullable column as `DEFAULT NULL` on existing DBs (verified from a fresh + an existing-DB path). The patch's stray alembic file was inert and removed to avoid implying a workflow that doesn't exist.

## Process
Multi-agent fix → adversarial review found the anchor-collapse blocker + a count mismatch → remediated → independently re-verified **SAFE_TO_APPLY**, with a test that seeds tool parts and a prior compaction so the DB and LLM row sets genuinely diverge (the earlier test had them 1:1 and couldn't surface the bug). Full backend suite **1092 passed**.