### PR TITLE
fix(a11y): keep loading spinners alive under prefers-reduced-motion

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1154,6 +1154,22 @@ pre code {
     animation: none;
     -webkit-text-fill-color: var(--text-secondary);
   }
+
+  /* Functional loading indicators must keep indicating. WCAG reduced-motion
+     targets large/vestibular motion, not in-place status spinners — a frozen
+     spinner reads as a hung app. Restore each indicator's own timing (the
+     universal reset flattens duration to 0.01ms and iteration to 1). These
+     are Tailwind's built-in animate-spin (1s) and animate-pulse (2s); the
+     values are restated explicitly rather than via `revert`, which would roll
+     back past Tailwind's layer to the UA default of 0s and freeze them. */
+  .animate-spin {
+    animation-duration: 1s !important;
+    animation-iteration-count: infinite !important;
+  }
+  .animate-pulse {
+    animation-duration: 2s !important;
+    animation-iteration-count: infinite !important;
+  }
 }
 
 /* ─── Enter/exit animation utilities (P0 motion revival) ───

--- a/frontend/tests/ui/openyak-reduced-motion.spec.ts
+++ b/frontend/tests/ui/openyak-reduced-motion.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+import { mockOpenYakApi, seedOpenYakStorage } from "./fixtures/openyak-api";
+
+// NB: Playwright's config-level `reducedMotion` is not reliably reflected in
+// window.matchMedia here, so each test emulates it imperatively before
+// navigation — verified below by asserting the media query is actually true.
+
+test("under reduced motion: content loads, decorative motion is suppressed, loaders keep looping", async ({
+  page,
+}) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/c/new");
+
+  // The app is functional — content is not gated behind a suppressed
+  // animation (the actual bug that was suspected under reduced motion).
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  const probe = await page.evaluate(() => {
+    const mk = (cls: string) => {
+      const el = document.createElement("div");
+      el.className = cls;
+      document.body.appendChild(el);
+      const cs = getComputedStyle(el);
+      const out = {
+        dur: cs.animationDuration,
+        iter: cs.animationIterationCount,
+        name: cs.animationName,
+      };
+      el.remove();
+      return out;
+    };
+    return {
+      mqReduce: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      spin: mk("animate-spin"),
+      enter: mk("animate-in fade-in-0"),
+    };
+  });
+
+  // Emulation is genuinely active (guards against silently testing nothing).
+  expect(probe.mqReduce).toBe(true);
+
+  // Decorative enter animation collapses to the reduced-motion floor.
+  expect(probe.enter.dur).toBe("0.001s");
+
+  // A functional loading spinner keeps spinning — not frozen at 0s/0.01ms.
+  expect(probe.spin.iter).toBe("infinite");
+  expect(probe.spin.name).toBe("spin");
+  expect(probe.spin.dur).toBe("1s");
+});
+
+test("a real streaming flow completes under reduced motion", async ({
+  page,
+}) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/c/new");
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page
+    .getByPlaceholder(/Describe the result you want/i)
+    .fill("Say hello under reduced motion");
+  await page
+    .locator('button[aria-label="Send message"]:not([disabled])')
+    .click();
+
+  // The assistant reply renders — nothing hangs waiting on an animation.
+  await expect(
+    page.getByText(/Say hello under reduced motion/).first(),
+  ).toBeVisible();
+  await expect(
+    page.locator('button[aria-label="Send message"]'),
+  ).toBeVisible({ timeout: 20_000 });
+});


### PR DESCRIPTION
The last of the filed chips. The global reduced-motion CSS block flattened **every** animation (`animation-duration: 0.01ms` + `animation-iteration-count: 1 !important`), which froze functional loading spinners on a single frame — a frozen spinner reads as a hung app. WCAG reduced-motion targets vestibular/large motion, not in-place status indicators.

## Fix
Restore `animate-spin` (1s) and `animate-pulse` (2s) timing + infinite looping inside the reduced-motion block, restated explicitly — **not** via `revert`, which rolls back past Tailwind's cascade layer to the UA default of 0s and re-freezes them (verified). Decorative enter/exit stays suppressed.

## Honest reckoning on the original report
The chip said 'app breaks under reduced motion' and listed three failing tests. Investigating with **genuine** emulation:
- The functional break did **not** reproduce — a real streaming flow completes and content loads (new spec asserts this end-to-end).
- Those three test 'failures' were the separate stale UI tests already fixed in #157, not a reduced-motion product bug.
- The one **real** reduced-motion defect was the frozen spinner — fixed here.

## A verification trap I hit and closed
Playwright's config-level `reducedMotion: "reduce"` was **not** reflected in `window.matchMedia` in this setup — my first 'full suite passes under reduced motion' run was silently testing nothing. The new spec emulates imperatively with `page.emulateMedia` **and asserts `matchMedia(...).matches === true`** before checking anything, so it can't pass vacuously. Guard proven by removing the spinner-restore rules → spinner reverts to iteration-count 1 → test fails.