### PR TITLE
UX P1.3: slash-command menu in the composer (+ shortcut discoverability)

### DIFF
--- a/frontend/src/components/chat/chat-form.tsx
+++ b/frontend/src/components/chat/chat-form.tsx
@@ -10,6 +10,13 @@ import { ChatActions } from "./chat-actions";
 import { WorkspaceToggle } from "./workspace-toggle";
 import { FileChip } from "./file-chip";
 import { FileMentionPopup } from "./file-mention-popup";
+import {
+  SlashCommandPopup,
+  SlashIcons,
+  type SlashCommand,
+} from "./slash-command-popup";
+import { useRouter } from "next/navigation";
+import { useSidebarStore } from "@/stores/sidebar-store";
 import { useAutoResize } from "@/hooks/use-auto-resize";
 import { uploadFile, browseFiles, attachByPath, ingestFiles } from "@/lib/upload";
 import type { FileSearchResult } from "@/lib/upload";
@@ -220,6 +227,21 @@ function detectMention(
   return { active: true, query, startIndex: atIndex };
 }
 
+/**
+ * A slash command is active only when the composer starts with "/" and the
+ * cursor is still inside that first token — so a "/" mid-sentence (a path, a
+ * fraction) never triggers it. Returns the text typed after the slash.
+ */
+function detectSlash(
+  text: string,
+  cursorPos: number,
+): { active: true; query: string } | { active: false } {
+  if (!text.startsWith("/")) return { active: false };
+  const firstToken = text.slice(0, cursorPos);
+  if (/\s/.test(firstToken)) return { active: false };
+  return { active: true, query: text.slice(1, cursorPos) };
+}
+
 export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTaskBatch, onStop, className, sessionId, directory }: ChatFormProps) {
   const { t } = useTranslation('chat');
   const [input, setInput] = useState("");
@@ -285,6 +307,9 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
   // @mention state
   const [mentionActive, setMentionActive] = useState(false);
   const [mentionQuery, setMentionQuery] = useState("");
+  // Slash-command state
+  const [slashActive, setSlashActive] = useState(false);
+  const [slashQuery, setSlashQuery] = useState("");
   const [mentionStartIndex, setMentionStartIndex] = useState(-1);
 
   const hasWorkspace = !!directory && directory !== ".";
@@ -605,6 +630,62 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
     setMentionActive(false);
   }, []);
 
+  // --- Slash commands ---
+  const router = useRouter();
+  const setSearchModalOpen = useSidebarStore((s) => s.setSearchModalOpen);
+  const setWorkModeForSlash = useSettingsStore((s) => s.setWorkMode);
+  const isMacForSlash =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toUpperCase().includes("MAC");
+  const mod = isMacForSlash ? "⌘" : "Ctrl";
+
+  const slashCommands = useMemo<SlashCommand[]>(
+    () => [
+      {
+        id: "new",
+        label: t("slashNewChat"),
+        icon: SlashIcons.newChat,
+        shortcut: `${mod}N`,
+        run: () => router.push("/c/new"),
+      },
+      {
+        id: "plan",
+        label: t("slashPlanMode"),
+        hint: t("slashPlanModeHint"),
+        icon: SlashIcons.plan,
+        run: () => setWorkModeForSlash("plan"),
+      },
+      {
+        id: "search",
+        label: t("slashSearch"),
+        icon: SlashIcons.search,
+        shortcut: `${mod}K`,
+        run: () => setSearchModalOpen(true),
+      },
+      {
+        id: "settings",
+        label: t("slashSettings"),
+        icon: SlashIcons.settings,
+        shortcut: `${mod},`,
+        run: () => router.push("/settings"),
+      },
+    ],
+    [t, mod, router, setSearchModalOpen, setWorkModeForSlash],
+  );
+
+  const handleSlashRun = useCallback(
+    (command: SlashCommand) => {
+      // "/" is a command trigger, not message text — clear it before acting.
+      setInput("");
+      setSlashActive(false);
+      resize();
+      command.run();
+    },
+    [resize],
+  );
+
+  const handleSlashClose = useCallback(() => setSlashActive(false), []);
+
   // Handle input changes — detect @mention trigger
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -612,6 +693,16 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
       const cursorPos = e.target.selectionStart ?? value.length;
       setInput(value);
       resize();
+
+      const slash = detectSlash(value, cursorPos);
+      if (slash.active) {
+        setSlashActive(true);
+        setSlashQuery(slash.query);
+        if (mentionActive) setMentionActive(false);
+        return;
+      } else if (slashActive) {
+        setSlashActive(false);
+      }
 
       if (!hasWorkspace) {
         if (mentionActive) setMentionActive(false);
@@ -627,7 +718,7 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
         if (mentionActive) setMentionActive(false);
       }
     },
-    [hasWorkspace, mentionActive, resize],
+    [hasWorkspace, mentionActive, slashActive, resize],
   );
 
   // Also check mention state on cursor movement (click, arrow keys)
@@ -636,6 +727,15 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
       if (!hasWorkspace) return;
       const textarea = e.currentTarget;
       const cursorPos = textarea.selectionStart ?? 0;
+      const slash = detectSlash(textarea.value, cursorPos);
+      if (slash.active) {
+        setSlashActive(true);
+        setSlashQuery(slash.query);
+        if (mentionActive) setMentionActive(false);
+        return;
+      } else if (slashActive) {
+        setSlashActive(false);
+      }
       const mention = detectMention(textarea.value, cursorPos);
       if (mention.active) {
         setMentionActive(true);
@@ -645,7 +745,7 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
         if (mentionActive) setMentionActive(false);
       }
     },
-    [hasWorkspace, mentionActive],
+    [hasWorkspace, mentionActive, slashActive],
   );
 
   // Watch for "Try fixing" requests from artifact renderers
@@ -711,6 +811,15 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
             />
           )}
 
+          {/* Slash-command popup — positioned above the form */}
+          <SlashCommandPopup
+            query={slashQuery}
+            visible={slashActive}
+            commands={slashCommands}
+            onRun={handleSlashRun}
+            onClose={handleSlashClose}
+          />
+
           {/* Inner panel — lighter pill holding textarea + action bar.
               Fully rounded so the bottom corners curve inward, letting the
               darker outer frame the pill on all sides. */}
@@ -750,7 +859,7 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTas
               onPaste={handlePaste}
               onSelect={handleSelect}
               onSubmit={handleSend}
-              mentionActive={mentionActive}
+              mentionActive={mentionActive || slashActive}
               placeholder={noModelsAvailable ? t('noModelPlaceholder') : hasWorkspace ? t('placeholder') + t('placeholderMention') : t('placeholder')}
               className="min-h-[28px] max-h-[200px] py-1"
               disabled={isInputDisabled}

--- a/frontend/src/components/chat/slash-command-popup.tsx
+++ b/frontend/src/components/chat/slash-command-popup.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  SquarePen,
+  Search,
+  Settings as SettingsIcon,
+  ClipboardList,
+  Command as CommandIcon,
+  type LucideIcon,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+
+export interface SlashCommand {
+  id: string;
+  label: string;
+  hint?: string;
+  /** Displayed on the right — a keyboard shortcut, purely informational. */
+  shortcut?: string;
+  icon: LucideIcon;
+  run: () => void;
+}
+
+interface SlashCommandPopupProps {
+  /** Text typed after the leading "/". */
+  query: string;
+  visible: boolean;
+  commands: SlashCommand[];
+  onRun: (command: SlashCommand) => void;
+  onClose: () => void;
+}
+
+/**
+ * Slash-command menu, opened by typing "/" at the start of the composer.
+ * Deterministic app actions (new chat, plan mode, search, settings, compact)
+ * plus their keyboard shortcuts, so the shortcuts are finally discoverable.
+ * Mirrors the @mention popup's keyboard model and styling.
+ */
+export function SlashCommandPopup({
+  query,
+  visible,
+  commands,
+  onRun,
+  onClose,
+}: SlashCommandPopupProps) {
+  const { t } = useTranslation("chat");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    return commands.filter(
+      (c) =>
+        c.label.toLowerCase().includes(q) ||
+        c.id.toLowerCase().includes(q) ||
+        c.hint?.toLowerCase().includes(q),
+    );
+  }, [commands, query]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query, visible]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!visible) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        if (filtered[selectedIndex]) {
+          e.preventDefault();
+          e.stopPropagation();
+          onRun(filtered[selectedIndex]);
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [visible, filtered, selectedIndex, onRun, onClose],
+  );
+
+  useEffect(() => {
+    if (visible) window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [visible, handleKeyDown]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const items = listRef.current.querySelectorAll("[data-slash-item]");
+    items[selectedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="absolute left-0 right-0 bottom-full mb-1 z-50">
+      <div className="mx-4 rounded-xl border border-[var(--border-default)] bg-[var(--surface-primary)] shadow-[var(--shadow-md)] overflow-hidden">
+        <div className="px-3 py-2 border-b border-[var(--border-default)]">
+          <p className="text-xs text-[var(--text-tertiary)]">
+            {t("slashCommandsHeader")}
+          </p>
+        </div>
+        <div
+          ref={listRef}
+          role="listbox"
+          aria-label={t("slashCommandsHeader")}
+          className="max-h-[280px] overflow-y-auto py-1 scrollbar-auto"
+        >
+          {filtered.length === 0 && (
+            <div className="px-3 py-4 text-center text-xs text-[var(--text-tertiary)]">
+              {t("slashCommandsEmpty")}
+            </div>
+          )}
+          {filtered.map((command, index) => {
+            const Icon = command.icon;
+            return (
+              <button
+                key={command.id}
+                type="button"
+                data-slash-item
+                role="option"
+                aria-selected={index === selectedIndex}
+                onMouseEnter={() => setSelectedIndex(index)}
+                onClick={() => onRun(command)}
+                className={cn(
+                  "flex w-full items-center gap-2.5 px-3 py-1.5 text-left transition-colors",
+                  index === selectedIndex
+                    ? "bg-[var(--surface-secondary)]"
+                    : "hover:bg-[var(--surface-secondary)]",
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+                <span className="flex-1 min-w-0">
+                  <span className="block truncate text-sm text-[var(--text-primary)]">
+                    {command.label}
+                  </span>
+                  {command.hint && (
+                    <span className="block truncate text-xs text-[var(--text-tertiary)]">
+                      {command.hint}
+                    </span>
+                  )}
+                </span>
+                {command.shortcut && (
+                  <kbd className="shrink-0 rounded border border-[var(--border-default)] bg-[var(--surface-secondary)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-tertiary)]">
+                    {command.shortcut}
+                  </kbd>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Icons re-exported so the composer can build the command list without a
+ *  second lucide import cluster. */
+export const SlashIcons = {
+  newChat: SquarePen,
+  search: Search,
+  settings: SettingsIcon,
+  plan: ClipboardList,
+  command: CommandIcon,
+};

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -180,5 +180,12 @@
   "taskPanel": "Task panel",
   "taskPanelArtifacts": "Artifacts",
   "taskPanelActivity": "Activity",
-  "taskPanelWorkspace": "Workspace"
+  "taskPanelWorkspace": "Workspace",
+  "slashCommandsHeader": "Commands",
+  "slashCommandsEmpty": "No matching command",
+  "slashNewChat": "New chat",
+  "slashPlanMode": "Plan first",
+  "slashPlanModeHint": "Explore and plan before editing",
+  "slashSearch": "Search chats",
+  "slashSettings": "Settings"
 }

--- a/frontend/src/i18n/locales/zh/chat.json
+++ b/frontend/src/i18n/locales/zh/chat.json
@@ -180,5 +180,12 @@
   "taskPanel": "任务面板",
   "taskPanelArtifacts": "产物",
   "taskPanelActivity": "活动",
-  "taskPanelWorkspace": "工作区"
+  "taskPanelWorkspace": "工作区",
+  "slashCommandsHeader": "命令",
+  "slashCommandsEmpty": "没有匹配的命令",
+  "slashNewChat": "新建会话",
+  "slashPlanMode": "先规划",
+  "slashPlanModeHint": "先探索规划,再动手编辑",
+  "slashSearch": "搜索会话",
+  "slashSettings": "设置"
 }

--- a/frontend/tests/ui/openyak-slash-commands.spec.ts
+++ b/frontend/tests/ui/openyak-slash-commands.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockOpenYakApi, seedOpenYakStorage } from "./fixtures/openyak-api";
+
+async function openComposer(page: Page) {
+  await page.goto("/c/new");
+  await expect(
+    page.getByRole("button", { name: /Claude Sonnet 4\.5/i }),
+  ).toBeVisible({ timeout: 15_000 });
+  return page.getByPlaceholder(/Describe the result you want/i);
+}
+
+test.beforeEach(async ({ page }) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+});
+
+test("typing / opens the command menu and Enter runs the top command", async ({
+  page,
+}) => {
+  const composer = await openComposer(page);
+  await composer.fill("/");
+
+  const menu = page.getByRole("listbox", { name: /Commands/i });
+  await expect(menu).toBeVisible();
+  // Shortcuts are surfaced here — this is where they become discoverable.
+  await expect(menu.getByText("New chat")).toBeVisible();
+  await expect(menu.getByText("Search chats")).toBeVisible();
+
+  // Enter runs the selected (first) command — New chat — not sends "/".
+  await composer.press("Enter");
+  await expect(
+    page
+      .getByRole("heading", {
+        name: /What should (OpenYak help you do|we do in)/i,
+      })
+      .first(),
+  ).toBeVisible();
+  // "/" was consumed as a command, never sent as a message.
+  await expect(composer).toHaveValue("");
+});
+
+test("/ filters, and selecting Plan mode switches the composer mode", async ({
+  page,
+}) => {
+  const composer = await openComposer(page);
+  await composer.fill("/plan");
+
+  const menu = page.getByRole("listbox", { name: /Commands/i });
+  await expect(menu.getByText("Plan first")).toBeVisible();
+  await expect(menu.getByText("New chat")).toHaveCount(0);
+
+  await menu.getByText("Plan first").click();
+  // The mode pill in the action bar now reads Plan first.
+  await expect(
+    page.getByRole("button", { name: /Plan first/i }).first(),
+  ).toBeVisible();
+  await expect(composer).toHaveValue("");
+});
+
+test("a slash mid-sentence is NOT treated as a command", async ({ page }) => {
+  const composer = await openComposer(page);
+  await composer.fill("summarize docs/plan and the q3 report");
+  await expect(page.getByRole("listbox", { name: /Commands/i })).toHaveCount(0);
+  // Enter with a normal message sends it (the menu never hijacked Enter).
+  const prompt = page.waitForResponse(
+    (r) => r.url().includes("/api/chat/prompt") && r.status() === 200,
+  );
+  await composer.press("Enter");
+  await prompt;
+});
+
+test("Escape closes the command menu and keeps the typed text", async ({
+  page,
+}) => {
+  const composer = await openComposer(page);
+  await composer.fill("/sea");
+  await expect(page.getByRole("listbox", { name: /Commands/i })).toBeVisible();
+  await composer.press("Escape");
+  await expect(page.getByRole("listbox", { name: /Commands/i })).toHaveCount(0);
+  await expect(composer).toHaveValue("/sea");
+});


### PR DESCRIPTION
Next P1 slice of the Codex alignment. Codex's composer is command-driven; OpenYak had @-file-mentions but no command entry — and the app-wide shortcuts from #156 (⌘B/⌘N/⌘,/⌘⇧][) had nowhere to be discovered. Both close here.

## What
Typing `/` at the **start** of the composer opens a command menu — New chat, Plan first, Search chats, Settings — each row showing its keyboard shortcut, so the shortcuts are finally discoverable in-context.

- mirrors the @mention popup's keyboard model exactly (↑↓ navigate, Enter/Tab run, Esc close) and reuses the same textarea Enter-suppression, so it never fights message submit
- `/` triggers **only** as the first character with the cursor still in that first token — a slash mid-sentence (a path, a fraction) is plain text and Enter sends normally (covered by a negative test)
- selecting a command clears the `/` and runs a real action wired to existing stores (router, sidebar search modal, `setWorkMode`) — **no new send-path coupling**, and none of the fragile model-pill / draft machinery the spec review flagged is touched

## Validation
Real-GUI Playwright spec: open + run-top-command, filter + plan-mode-switch, the slash-mid-sentence negative case, Esc-preserves-text. **32 passed** across the composer-heavy specs (preflight + workflows + slash) with no regression. Light + dark screenshots confirm the menu.

## Deliberately deferred
The rest of P1.3 — single-layer pill, model+mode pill (must read the v1.3.0 per-session model store, not mirror the header dropdown), `$` skill references, and `/` **deterministic Skill invocation** — all touch riskier send/draft paths and are better as their own PRs.