### PR TITLE
UX P1.4: automations activity feed (cross-task run inbox)

### DIFF
--- a/backend/app/api/automations.py
+++ b/backend/app/api/automations.py
@@ -15,6 +15,7 @@ from app.schemas.automation import (
     AutomationCreate,
     AutomationResponse,
     AutomationUpdate,
+    RecentRunResponse,
     TaskRunResponse,
     TemplateResponse,
 )
@@ -261,6 +262,41 @@ async def run_automation_now(
         name=f"automation-run-{task_id[:12]}",
     )
     return {"status": "started"}
+
+
+@router.get("/automations/runs/recent", response_model=list[RecentRunResponse])
+async def list_recent_runs(
+    db: AsyncSession = Depends(get_db),
+    limit: int = 30,
+) -> list[RecentRunResponse]:
+    """Recent runs across ALL automations, newest first — the inbox feed.
+
+    Joins each run to its task so the caller gets the task name without an
+    N+1 lookup. Runs whose task was deleted are excluded by the inner join.
+    """
+    limit = max(1, min(limit, 100))
+    result = await db.execute(
+        select(TaskRun, ScheduledTask.name)
+        .join(ScheduledTask, TaskRun.task_id == ScheduledTask.id)
+        .order_by(TaskRun.time_created.desc())
+        .limit(limit)
+    )
+    rows = result.all()
+    return [
+        RecentRunResponse(
+            id=run.id,
+            task_id=run.task_id,
+            task_name=name,
+            session_id=run.session_id,
+            status=run.status,
+            error_message=run.error_message,
+            started_at=run.started_at,
+            finished_at=run.finished_at,
+            triggered_by=run.triggered_by,
+            time_created=run.time_created,
+        )
+        for run, name in rows
+    ]
 
 
 @router.get("/automations/{task_id}/runs", response_model=list[TaskRunResponse])

--- a/backend/app/schemas/automation.py
+++ b/backend/app/schemas/automation.py
@@ -116,6 +116,22 @@ class TaskRunResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class RecentRunResponse(BaseModel):
+    """A task run enriched with its parent task's name, for the global inbox
+    feed across all automations."""
+
+    id: str
+    task_id: str
+    task_name: str
+    session_id: str | None
+    status: str
+    error_message: str | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    triggered_by: str
+    time_created: datetime
+
+
 class TemplateResponse(BaseModel):
     id: str
     name: str

--- a/backend/tests/test_api/test_automation_runs.py
+++ b/backend/tests/test_api/test_automation_runs.py
@@ -1,0 +1,88 @@
+"""Tests for the cross-task recent-runs inbox feed."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.scheduled_task import ScheduledTask
+from app.models.task_run import TaskRun
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mk_task(session_factory, name: str) -> str:
+    async with session_factory() as s:
+        task = ScheduledTask(
+            name=name,
+            prompt=f"do {name}",
+            schedule_config={"type": "manual"},
+            enabled=True,
+        )
+        s.add(task)
+        await s.commit()
+        return task.id
+
+
+async def _mk_run(
+    session_factory, task_id: str, status: str, triggered_by: str = "schedule"
+) -> str:
+    async with session_factory() as s:
+        run = TaskRun(task_id=task_id, status=status, triggered_by=triggered_by)
+        s.add(run)
+        await s.commit()
+        return run.id
+
+
+async def test_recent_runs_are_cross_task_newest_first_with_task_name(
+    app_client, session_factory
+):
+    a = await _mk_task(session_factory, "Morning brief")
+    b = await _mk_task(session_factory, "Invoice sweep")
+    await _mk_run(session_factory, a, "success")
+    await _mk_run(session_factory, b, "error", triggered_by="manual")
+
+    resp = await app_client.get("/api/automations/runs/recent")
+    assert resp.status_code == 200
+    runs = resp.json()
+    assert len(runs) == 2
+    # Newest first: the error run (created last) leads.
+    assert runs[0]["status"] == "error"
+    assert runs[0]["task_name"] == "Invoice sweep"
+    assert runs[0]["triggered_by"] == "manual"
+    assert runs[1]["task_name"] == "Morning brief"
+    # The feed spans multiple tasks.
+    assert {r["task_name"] for r in runs} == {"Morning brief", "Invoice sweep"}
+
+
+async def test_recent_runs_excludes_runs_whose_task_was_deleted(app_client, session_factory):
+    from sqlalchemy import delete
+
+    a = await _mk_task(session_factory, "Keeper")
+    b = await _mk_task(session_factory, "Doomed")
+    await _mk_run(session_factory, a, "success")
+    await _mk_run(session_factory, b, "success")
+
+    # Deleting the task cascades to its runs; the inner join also drops any orphan.
+    async with session_factory() as s:
+        await s.execute(delete(ScheduledTask).where(ScheduledTask.id == b))
+        await s.commit()
+
+    resp = await app_client.get("/api/automations/runs/recent")
+    assert resp.status_code == 200
+    names = [r["task_name"] for r in resp.json()]
+    assert names == ["Keeper"]
+
+
+async def test_recent_runs_limit_is_clamped(app_client, session_factory):
+    a = await _mk_task(session_factory, "Busy")
+    for _ in range(5):
+        await _mk_run(session_factory, a, "success")
+
+    resp = await app_client.get("/api/automations/runs/recent?limit=2")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    # Over-large limits are clamped, not honored blindly.
+    resp = await app_client.get("/api/automations/runs/recent?limit=9999")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 5

--- a/frontend/src/app/(main)/automations/content.tsx
+++ b/frontend/src/app/(main)/automations/content.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   FolderSync,
   GitPullRequest,
+  Inbox,
   Loader2,
   Mail,
   Plus,
@@ -17,19 +18,23 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   useAutomations,
+  useRecentRuns,
   useTemplates,
   useCreateFromTemplate,
 } from "@/hooks/use-automations";
 import { humanizeSchedule } from "./helpers";
 import { AutomationCard } from "./automation-card";
 import { CreateAutomationDialog, EditAutomationDialog } from "./automation-dialogs";
-import type { AutomationResponse, ScheduleConfig } from "@/types/automation";
+import type { AutomationResponse, ScheduleConfig, RecentRun } from "@/types/automation";
+import { getChatRoute } from "@/lib/routes";
+import { useRouter } from "next/navigation";
+import { formatRelativeTime } from "@/lib/utils";
 
 /* ------------------------------------------------------------------ */
 /* Constants                                                           */
 /* ------------------------------------------------------------------ */
 
-type Tab = "active" | "all" | "templates";
+type Tab = "active" | "all" | "activity" | "templates";
 
 const ICON_MAP: Record<string, React.ElementType> = {
   Sunrise, CalendarCheck, Mail, GitPullRequest, FolderSync, Timer, Clock, Repeat,
@@ -62,7 +67,7 @@ export function AutomationsTabContent() {
 
       {/* Tabs */}
       <div className="flex items-center gap-1 border-b border-[var(--border-default)]">
-        {(["active", "all", "templates"] as Tab[]).map((tabKey) => (
+        {(["active", "all", "activity", "templates"] as Tab[]).map((tabKey) => (
           <button
             key={tabKey}
             onClick={() => setTab(tabKey)}
@@ -77,7 +82,13 @@ export function AutomationsTabContent() {
         ))}
       </div>
 
-      {tab === "templates" ? <TemplatesTab onCreated={() => setTab("active")} /> : <AutomationsList filter={tab === "active" ? "enabled" : "all"} onEdit={setEditingId} />}
+      {tab === "templates" ? (
+        <TemplatesTab onCreated={() => setTab("active")} />
+      ) : tab === "activity" ? (
+        <ActivityFeed />
+      ) : (
+        <AutomationsList filter={tab === "active" ? "enabled" : "all"} onEdit={setEditingId} />
+      )}
 
       {showCreate && <CreateAutomationDialog onClose={() => setShowCreate(false)} />}
       {editingId && <EditAutomationDialog automationId={editingId} onClose={() => setEditingId(null)} />}
@@ -114,6 +125,80 @@ function AutomationsList({ filter, onEdit }: { filter: "enabled" | "all"; onEdit
   return (
     <div className="space-y-3">
       {items.map((a: AutomationResponse) => <AutomationCard key={a.id} automation={a} onEdit={onEdit} />)}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Activity feed — recent runs across all automations                  */
+/* ------------------------------------------------------------------ */
+
+function runStatusColor(status: string): string {
+  if (status === "success") return "var(--color-success)";
+  if (status === "error") return "var(--color-destructive)";
+  if (status === "running" || status === "pending") return "var(--tool-pending)";
+  return "var(--text-tertiary)";
+}
+
+function ActivityFeed() {
+  const { t } = useTranslation("automations");
+  const router = useRouter();
+  const { data: runs, isLoading } = useRecentRuns();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-[var(--text-tertiary)]" />
+      </div>
+    );
+  }
+
+  if (!runs || runs.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-12 text-center text-[var(--text-tertiary)]">
+        <Inbox className="h-6 w-6" />
+        <p className="text-sm">{t("activityEmpty")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--border-default)]">
+      {runs.map((run: RecentRun, index) => {
+        const clickable = !!run.session_id;
+        return (
+          <button
+            key={run.id}
+            type="button"
+            disabled={!clickable}
+            onClick={() =>
+              run.session_id && router.push(getChatRoute(run.session_id))
+            }
+            className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+              index > 0 ? "border-t border-[var(--border-default)]" : ""
+            } ${clickable ? "hover:bg-[var(--surface-secondary)]" : "cursor-default"}`}
+          >
+            <span
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ background: runStatusColor(run.status) }}
+              aria-hidden="true"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm text-[var(--text-primary)]">
+                {run.task_name}
+              </p>
+              <p className="truncate text-xs text-[var(--text-tertiary)]">
+                {t(`runStatus_${run.status}`, { defaultValue: run.status })}
+                {run.triggered_by === "manual" ? ` · ${t("triggerManual")}` : ""}
+                {run.error_message ? ` · ${run.error_message}` : ""}
+              </p>
+            </div>
+            <span className="shrink-0 text-xs tabular-nums text-[var(--text-tertiary)]">
+              {formatRelativeTime(run.time_created)}
+            </span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/hooks/use-automations.ts
+++ b/frontend/src/hooks/use-automations.ts
@@ -9,8 +9,25 @@ import type {
   AutomationCreate,
   AutomationUpdate,
   TaskRunResponse,
+  RecentRun,
   TemplateResponse,
 } from "@/types/automation";
+
+/** Cross-task recent-run feed (the automations inbox). */
+export function useRecentRuns() {
+  return useQuery({
+    queryKey: queryKeys.automations.recentRuns,
+    queryFn: () => api.get<RecentRun[]>(API.AUTOMATIONS.RECENT_RUNS),
+    staleTime: 5_000,
+    refetchInterval: (query) => {
+      const data = query.state.data as RecentRun[] | undefined;
+      const hasRunning = data?.some(
+        (r) => r.status === "running" || r.status === "pending",
+      );
+      return hasRunning ? 3_000 : 30_000;
+    },
+  });
+}
 
 export function useAutomations() {
   return useQuery({

--- a/frontend/src/i18n/locales/en/automations.json
+++ b/frontend/src/i18n/locales/en/automations.json
@@ -40,7 +40,7 @@
   "workspace": "Workspace",
   "workspaceNone": "Unrestricted (global)",
   "triggerSchedule": "Scheduled",
-  "triggerManual": "Manual",
+  "triggerManual": "run manually",
   "triggerCatchup": "Catchup",
   "presetDaily8am": "Daily 8:00",
   "presetWeekdays9am": "Weekdays 9:00",
@@ -69,5 +69,12 @@
     "everyday": "Daily",
     "weekdays": "Weekdays",
     "weekends": "Weekends"
-  }
+  },
+  "activity": "Activity",
+  "activityEmpty": "No automation runs yet",
+  "runStatus_success": "Completed",
+  "runStatus_error": "Failed",
+  "runStatus_running": "Running",
+  "runStatus_pending": "Queued",
+  "runStatus_skipped": "Skipped"
 }

--- a/frontend/src/i18n/locales/zh/automations.json
+++ b/frontend/src/i18n/locales/zh/automations.json
@@ -40,7 +40,7 @@
   "workspace": "工作区",
   "workspaceNone": "不限制（全局）",
   "triggerSchedule": "定时",
-  "triggerManual": "手动",
+  "triggerManual": "手动运行",
   "triggerCatchup": "补执行",
   "presetDaily8am": "每天 8:00",
   "presetWeekdays9am": "工作日 9:00",
@@ -69,5 +69,12 @@
     "everyday": "每天",
     "weekdays": "工作日",
     "weekends": "周末"
-  }
+  },
+  "activity": "活动",
+  "activityEmpty": "还没有自动化运行记录",
+  "runStatus_success": "已完成",
+  "runStatus_error": "失败",
+  "runStatus_running": "运行中",
+  "runStatus_pending": "排队中",
+  "runStatus_skipped": "已跳过"
 }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -352,6 +352,7 @@ export const API = {
     DELETE: (id: string) => `/api/automations/${id}` as const,
     RUN: (id: string) => `/api/automations/${id}/run` as const,
     RUNS: (id: string) => `/api/automations/${id}/runs` as const,
+    RECENT_RUNS: "/api/automations/runs/recent",
     TEMPLATES: "/api/automations/templates",
     FROM_TEMPLATE: "/api/automations/from-template",
     LOOP_PRESETS: "/api/automations/loop-presets",
@@ -417,6 +418,7 @@ export const queryKeys = {
     detail: (id: string) => ["automations", id] as const,
     runs: (id: string) => ["automations", id, "runs"] as const,
     templates: ["automations", "templates"] as const,
+    recentRuns: ["automations","recent-runs"] as const,
   },
   workspaceMemory: (workspace: string) =>
     ["workspaceMemory", workspace] as const,

--- a/frontend/src/types/automation.ts
+++ b/frontend/src/types/automation.ts
@@ -73,6 +73,19 @@ export interface TaskRunResponse {
   time_created: string;
 }
 
+export interface RecentRun {
+  id: string;
+  task_id: string;
+  task_name: string;
+  session_id: string | null;
+  status: string;
+  error_message: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  triggered_by: string;
+  time_created: string;
+}
+
 export interface TemplateResponse {
   id: string;
   name: string;

--- a/frontend/tests/ui/fixtures/openyak-api.ts
+++ b/frontend/tests/ui/fixtures/openyak-api.ts
@@ -2277,6 +2277,34 @@ export async function mockOpenYakApi(
       automationList.unshift(automation);
       return fulfillJson(route, automation);
     }
+    if (path === "/api/automations/runs/recent") {
+      return fulfillJson(route, [
+        {
+          id: "run-2",
+          task_id: "task-b",
+          task_name: "Invoice sweep",
+          session_id: "session-alpha",
+          status: "error",
+          error_message: "Provider timed out",
+          started_at: "2026-04-26T08:00:00Z",
+          finished_at: "2026-04-26T08:01:00Z",
+          triggered_by: "manual",
+          time_created: "2026-04-26T08:00:00Z",
+        },
+        {
+          id: "run-1",
+          task_id: "task-a",
+          task_name: "Morning brief",
+          session_id: "session-artifacts",
+          status: "success",
+          error_message: null,
+          started_at: "2026-04-26T07:00:00Z",
+          finished_at: "2026-04-26T07:02:00Z",
+          triggered_by: "schedule",
+          time_created: "2026-04-26T07:00:00Z",
+        },
+      ]);
+    }
     if (path === "/api/automations/templates") {
       return fulfillJson(route, [
         {

--- a/frontend/tests/ui/openyak-automation-activity.spec.ts
+++ b/frontend/tests/ui/openyak-automation-activity.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { mockOpenYakApi, seedOpenYakStorage } from "./fixtures/openyak-api";
+
+test.beforeEach(async ({ page }) => {
+  await seedOpenYakStorage(page);
+  await mockOpenYakApi(page);
+});
+
+test("the Activity tab shows a cross-task run feed and links to the run's session", async ({
+  page,
+}) => {
+  await page.goto("/automations");
+  await page.getByRole("button", { name: "Activity" }).click();
+
+  // Runs from two different tasks appear, newest first.
+  const failed = page.getByText("Invoice sweep");
+  const ok = page.getByText("Morning brief");
+  await expect(failed).toBeVisible();
+  await expect(ok).toBeVisible();
+
+  // The failed run surfaces its status and error inline.
+  await expect(page.getByText(/Failed/)).toBeVisible();
+  await expect(page.getByText(/Provider timed out/)).toBeVisible();
+
+  // Clicking a run with a session opens that conversation.
+  await failed.click();
+  await expect.poll(() => page.url()).toMatch(/\/c\//);
+});
+
+test("Activity empty state renders when there are no runs", async ({ page }) => {
+  // Override the feed to be empty for this test.
+  await page.route("**/api/automations/runs/recent", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    }),
+  );
+
+  await page.goto("/automations");
+  await page.getByRole("button", { name: "Activity" }).click();
+  await expect(page.getByText("No automation runs yet")).toBeVisible();
+});

--- a/frontend/tests/ui/openyak-deep-surfaces.spec.ts
+++ b/frontend/tests/ui/openyak-deep-surfaces.spec.ts
@@ -251,7 +251,7 @@ test.describe("OpenYak deep claimed-feature GUI surfaces", () => {
     await onboarding.goto("/c/new");
     await expect(onboarding.getByRole("heading", { name: "Welcome to OpenYak" })).toBeVisible();
 
-    await onboarding.getByRole("button", { name: "Set Up Provider" }).click();
+    await onboarding.getByRole("button", { name: "Set up a model provider" }).click();
     await expect(onboarding).toHaveURL(/\/settings\?tab=providers$/);
     await expect(onboarding.getByRole("heading", { name: "Providers" })).toBeVisible();
     await expectNoAppCrash(onboarding);


### PR DESCRIPTION
Closes the last major P1 item. The unattended-automation story had a hole — you could see each task's own run history, but nothing showed what ran recently **across** all automations. This is the Codex triage-inbox idea translated to OpenYak's automations, and it pairs with the sidebar attention badge from #157.

## Backend
`GET /api/automations/runs/recent` — recent `TaskRun`s across all tasks, newest first, each joined to its task name (no N+1). Inner join drops runs whose task was deleted; `limit` clamped to 1..100. **3 API tests**: cross-task ordering + name join, deleted-task exclusion, limit clamping.

## Frontend
A new **Activity** tab on the automations page renders the feed — status dot (success/error/running via semantic tokens), task name, inline status + manual-trigger note + error message, relative time. Rows with a session link into that conversation. Polls 3s while anything runs, else 30s. en + zh.

Placed on the automations page rather than as a new sidebar triage section — real value with no IA churn; the sidebar-inbox placement + unread tracking are a follow-up.

## Also
Fixes a test regression **I introduced in #163**: the onboarding primary button label changed (Set Up Provider → Set up a model provider) and `deep-surfaces:231` still clicked the old text, so it was red on main. Now updated. (Called out honestly — my onboarding PR should have caught this.)

## Validation
Backend **1144 passed**; new activity spec (feed + session link + empty state) and the fixed onboarding-route test green; light/dark screenshot confirms the feed.