### PR TITLE
ci: serve updater releases directly from GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,7 +430,10 @@ jobs:
             exit 1
           fi
 
-          DOWNLOAD_BASE="https://open-yak.com/downloads"
+          # Release assets are immutable and GitHub serves them globally. Keep
+          # the manifest and the signed artifacts on the same release so the
+          # desktop updater has no dependency on the marketing website.
+          DOWNLOAD_BASE="https://github.com/openyak/openyak/releases/download/${TAG}"
 
           cat > latest.json <<EOF
           {

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -91,8 +91,7 @@
     },
     "updater": {
       "endpoints": [
-        "https://open-yak.com/update/latest.json",
-        "https://open-yak.com/downloads/latest.json"
+        "https://github.com/openyak/openyak/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI2NzhEQTg4RUE2NjhDRjQKUldUMGpHYnFpTnA0dGtwdE5YK3dJT0N2Z0tUcHNXNStIcVU2bEpmZ3lpRUo1UEZYTWNaVWhDUEkK"
     },


### PR DESCRIPTION
Moves the updater manifest endpoint and signed artifact URLs off the EC2-hosted website and onto immutable GitHub Release assets.