### PR TITLE
release: OpenYak v1.5.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 ## [Unreleased]
 
+## [1.5.0-rc.1] - 2026-08-04
+
+### Added
+
+- **Computer workspace:** Added native Computer Use on macOS and Windows with live screen sharing, app/window targeting, mouse, keyboard, scrolling, drag, screenshot, and wait actions.
+- **shared control:** Added explicit user takeover and hand-back controls. Agent actions pause while the user owns the Computer or Browser workspace and resume only after control is returned.
+- **Browser workspace:** Added an in-app Playwright browser with live snapshots, navigation, element interaction, tabs, downloads, and the same shared-control contract as native Computer Use.
+- **permissions:** Added first-class Computer and Browser permission prompts, remembered policies, macOS Screen Recording and Accessibility guidance, and capability/status APIs for desktop clients.
+- **agent evaluation:** Added a versioned runtime evaluation harness, repeatable task suites, scoring, live-provider execution, benchmark reports, and CI smoke coverage for core Agent tools.
+
+### Changed
+
+- **agent runtime:** Aligned Computer and Browser execution with OpenAI-style tool loops, structured action results, live workspace events, cancellation, permission enforcement, and bounded screenshot handling.
+- **desktop packaging:** Bundled the native automation and browser runtime dependencies required by frozen macOS and Windows builds.
+- **updates:** Desktop updater artifacts and `latest.json` are now served from the same immutable GitHub Release.
+
+### Fixed
+
+- **shared Browser runtime:** Serialized Agent actions, user interactions, and snapshots so a queued Agent action cannot leak through after the user takes control.
+- **workspace UX:** Kept Computer and Browser workspace state scoped per Session and synchronized target changes, control ownership, activity summaries, and responsive panel behavior.
+
+### Validation
+
+- Backend suite: 1,341 passed, 23 skipped; focused Computer/Browser contract suite: 50 passed.
+- Frontend unit tests: 63 passed; related Chromium workspace tests: 10 passed with 2 intentional mobile skips.
+- GitHub checks passed for the merged Computer Use implementation: backend tests, offline Agent smoke suite, TypeScript, and ESLint.
+- Real macOS Agent runs completed against TextEdit and Calendar, including live native control and application switching.
+- Windows runtime contracts are covered in CI; the signed RC installer still requires final smoke testing on a physical Windows machine before the stable 1.5.0 release.
+
 ## [1.4.0] - 2026-07-23
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openyak"
-version = "1.4.0"
+version = "1.5.0-rc.1"
 description = "Your local AI assistant — private, powerful, personal"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -2611,7 +2611,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openyak-desktop"
-version = "1.4.0"
+version = "1.5.0-rc.1"
 dependencies = [
  "env_logger",
  "log",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openyak-desktop"
-version = "1.4.0"
+version = "1.5.0-rc.1"
 description = "OpenYak — local-first AI agent for desktop work"
 license = "Apache-2.0"
 edition = "2021"

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenYak",
   "identifier": "com.openyak.desktop",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "build": {
     "frontendDist": "../../frontend/out",
     "devUrl": "http://localhost:3000",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak-frontend",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak-frontend",
-      "version": "1.4.0",
+      "version": "1.5.0-rc.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak-frontend",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak",
-      "version": "1.4.0",
+      "version": "1.5.0-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "concurrently": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "private": true,
   "license": "Apache-2.0",
   "description": "OpenYak — local-first AI agent for desktop work",


### PR DESCRIPTION
## What

- bump all OpenYak application metadata to `1.5.0-rc.1`
- document native Computer Use, Browser workspace, shared control, permissions, and Agent evaluation changes
- record the remaining physical Windows installer smoke test as an RC exit criterion

## Why

Computer Use is a substantial user-facing capability spanning the native desktop runtime, Browser workspace, permission model, live shared control, and packaged dependencies. A release candidate lets us validate the signed macOS and Windows artifacts before promoting 1.5.0 to stable.

## User impact

- produces signed macOS Apple Silicon, macOS Intel, and Windows x64 release-candidate installers
- keeps stable users on v1.4.0 until the RC is explicitly promoted
- provides a concrete artifact set for final native permission, takeover, app switching, Browser, and updater smoke tests

## Validation

- backend: 1,341 passed, 23 skipped
- frontend unit: 63 passed
- TypeScript: clean
- ESLint: clean
- production frontend: 15/15 static pages
- Tauri Rust: `cargo check --locked` passed as v1.5.0-rc.1
- all JSON, TOML, Cargo lock, and desktop versions synchronized to 1.5.0-rc.1
