### PR TITLE
fix: sign all macOS backend executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,15 +163,6 @@ jobs:
         run: |
           BUNDLE_BACKEND="desktop-tauri/src-tauri/target/${{ matrix.target }}/release/bundle/macos/OpenYak.app/Contents/Resources/backend"
 
-          # Sign all .dylib and .so files
-          find "$BUNDLE_BACKEND" -type f \( -name "*.dylib" -o -name "*.so" \) \
-            -exec codesign --force --options runtime --timestamp \
-            --sign "$SIGNING_IDENTITY" {} \;
-
-          # Sign backend executable
-          codesign --force --options runtime --timestamp \
-            --sign "$SIGNING_IDENTITY" "$BUNDLE_BACKEND/openyak-backend"
-
           # Fix Python.framework symlink structure (Tauri resolves symlinks to regular files)
           FW_PATH="$BUNDLE_BACKEND/_internal/Python.framework"
           if [ -d "$FW_PATH" ]; then
@@ -187,10 +178,6 @@ jobs:
               fi
               ln -s Versions/Current/Python "$FW_PATH/Python"
             fi
-
-            # Sign the actual versioned binary
-            codesign --force --options runtime --timestamp \
-              --sign "$SIGNING_IDENTITY" "$FW_PATH/Versions/3.12/Python"
           fi
 
           # Fix _internal/Python symlink
@@ -199,6 +186,13 @@ jobs:
             rm "$PYTHON_BIN"
             ln -s Python.framework/Versions/Current/Python "$PYTHON_BIN"
           fi
+
+          # Sign by binary format rather than filename. Playwright embeds an
+          # extensionless Node Mach-O, and any unsigned nested executable makes
+          # Apple reject the entire app during notarization.
+          python3 scripts/sign_macos_backend.py \
+            "$BUNDLE_BACKEND" \
+            --identity "$SIGNING_IDENTITY"
 
       # Re-sign the .app after modifying backend binaries
       - name: Re-sign app bundle
@@ -221,11 +215,29 @@ jobs:
         run: |
           APP_PATH="desktop-tauri/src-tauri/target/${{ matrix.target }}/release/bundle/macos/OpenYak.app"
           ditto -c -k --keepParent "$APP_PATH" /tmp/OpenYak-notarize.zip
+
+          set +e
           xcrun notarytool submit /tmp/OpenYak-notarize.zip \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait
+            --wait \
+            --output-format json | tee /tmp/OpenYak-notary-result.json
+          SUBMIT_STATUS=${PIPESTATUS[0]}
+          set -e
+
+          SUBMISSION_ID=$(python3 -c \
+            'import json; print(json.load(open("/tmp/OpenYak-notary-result.json")).get("id", ""))')
+          if [ "$SUBMIT_STATUS" -ne 0 ]; then
+            if [ -n "$SUBMISSION_ID" ]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" || true
+            fi
+            exit "$SUBMIT_STATUS"
+          fi
+
           xcrun stapler staple "$APP_PATH"
 
       - name: Verify backend inside signed .app

--- a/backend/tests/test_scripts/test_sign_macos_backend.py
+++ b/backend/tests/test_scripts/test_sign_macos_backend.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "sign_macos_backend.py"
+SPEC = importlib.util.spec_from_file_location("sign_macos_backend", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+sign_macos_backend = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(sign_macos_backend)
+
+
+def test_signs_extensionless_playwright_node_and_other_macho_files(tmp_path: Path) -> None:
+    backend_dir = tmp_path / "backend"
+    playwright_node = backend_dir / "_internal" / "playwright" / "driver" / "node"
+    dylib = backend_dir / "_internal" / "libexample.dylib"
+    text_file = backend_dir / "README"
+    for path in (playwright_node, dylib, text_file):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture")
+
+    descriptions = {
+        playwright_node: "Mach-O 64-bit executable arm64",
+        dylib: "Mach-O 64-bit dynamically linked shared library arm64",
+        text_file: "ASCII text",
+    }
+    commands: list[list[str]] = []
+
+    signed = sign_macos_backend.sign_macho_files(
+        backend_dir,
+        "Developer ID Application: Example (TEAMID)",
+        describe=descriptions.__getitem__,
+        run=lambda command: commands.append(list(command)),
+    )
+
+    assert signed == [dylib, playwright_node]
+    sign_commands = [command for command in commands if "--sign" in command]
+    verify_commands = [command for command in commands if "--verify" in command]
+    assert [Path(command[-1]) for command in sign_commands] == signed
+    assert [Path(command[-1]) for command in verify_commands] == signed
+    assert all("runtime" in command for command in sign_commands)
+
+
+def test_rejects_a_bundle_without_macho_payloads(tmp_path: Path) -> None:
+    backend_dir = tmp_path / "backend"
+    backend_dir.mkdir()
+    (backend_dir / "README").write_text("fixture")
+
+    with pytest.raises(RuntimeError, match="no Mach-O files"):
+        sign_macos_backend.sign_macho_files(
+            backend_dir,
+            "Developer ID Application: Example (TEAMID)",
+            describe=lambda _path: "ASCII text",
+            run=lambda _command: None,
+        )

--- a/scripts/sign_macos_backend.py
+++ b/scripts/sign_macos_backend.py
@@ -1,0 +1,88 @@
+"""Sign every Mach-O payload embedded in the frozen macOS backend bundle."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+
+DescribeFile = Callable[[Path], str]
+RunCommand = Callable[[Sequence[str]], None]
+
+
+def describe_file(path: Path) -> str:
+    result = subprocess.run(
+        ["file", "--brief", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def discover_macho_files(
+    backend_dir: Path,
+    *,
+    describe: DescribeFile = describe_file,
+) -> list[Path]:
+    if not backend_dir.is_dir():
+        raise ValueError(f"backend bundle does not exist: {backend_dir}")
+
+    macho_files: list[Path] = []
+    for candidate in sorted(backend_dir.rglob("*")):
+        if candidate.is_symlink() or not candidate.is_file():
+            continue
+        if describe(candidate).startswith("Mach-O"):
+            macho_files.append(candidate)
+    return macho_files
+
+
+def run_command(command: Sequence[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def sign_macho_files(
+    backend_dir: Path,
+    identity: str,
+    *,
+    describe: DescribeFile = describe_file,
+    run: RunCommand = run_command,
+) -> list[Path]:
+    if not identity.strip():
+        raise ValueError("a non-empty Developer ID signing identity is required")
+
+    macho_files = discover_macho_files(backend_dir, describe=describe)
+    if not macho_files:
+        raise RuntimeError(f"no Mach-O files found in backend bundle: {backend_dir}")
+
+    for path in macho_files:
+        run(
+            [
+                "codesign",
+                "--force",
+                "--options",
+                "runtime",
+                "--timestamp",
+                "--sign",
+                identity,
+                str(path),
+            ]
+        )
+        run(["codesign", "--verify", "--strict", str(path)])
+    return macho_files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("backend_dir", type=Path)
+    parser.add_argument("--identity", required=True)
+    args = parser.parse_args()
+
+    signed = sign_macho_files(args.backend_dir, args.identity)
+    print(f"Signed and verified {len(signed)} Mach-O files")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- detect and Developer-ID sign every Mach-O file in the frozen macOS backend bundle, regardless of filename extension
- strictly verify each nested signature before re-signing the outer app
- print the Apple notarization report automatically when a submission is rejected
- add a regression test covering Playwright's extensionless embedded Node executable

## Root cause

Computer Use added Playwright to the frozen backend. Playwright embeds `_internal/playwright/driver/node`, an extensionless Mach-O executable. The release workflow only re-signed `.dylib`, `.so`, the main backend executable, and the Python framework binary, so this Node executable kept its ad-hoc signature. Apple accepted the upload but rejected the complete app as `Invalid` during notarization.

## Validation

- regression tests: 2 passed
- release workflow YAML parsed successfully
- real frozen backend discovery found 156 Mach-O files, including Playwright Node
- local Developer ID signing and strict verification succeeded for all 156 files
- Playwright Node now reports hardened-runtime flags and TeamIdentifier `46KF5Z549N`
