### PR TITLE
release: OpenYak v1.5.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 ## [Unreleased]
 
-## [1.5.0-rc.1] - 2026-08-04
+## [1.5.0-rc.2] - 2026-08-04
 
 ### Added
 
@@ -26,6 +26,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 - **shared Browser runtime:** Serialized Agent actions, user interactions, and snapshots so a queued Agent action cannot leak through after the user takes control.
 - **workspace UX:** Kept Computer and Browser workspace state scoped per Session and synchronized target changes, control ownership, activity summaries, and responsive panel behavior.
+- **macOS packaging:** Developer-ID sign and strictly verify every Mach-O in the frozen backend, including Playwright's extensionless Node executable, before notarizing the outer app.
 
 ### Validation
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openyak"
-version = "1.5.0-rc.1"
+version = "1.5.0-rc.2"
 description = "Your local AI assistant — private, powerful, personal"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -2611,7 +2611,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openyak-desktop"
-version = "1.5.0-rc.1"
+version = "1.5.0-rc.2"
 dependencies = [
  "env_logger",
  "log",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openyak-desktop"
-version = "1.5.0-rc.1"
+version = "1.5.0-rc.2"
 description = "OpenYak — local-first AI agent for desktop work"
 license = "Apache-2.0"
 edition = "2021"

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenYak",
   "identifier": "com.openyak.desktop",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "build": {
     "frontendDist": "../../frontend/out",
     "devUrl": "http://localhost:3000",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak-frontend",
-      "version": "1.5.0-rc.1",
+      "version": "1.5.0-rc.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak",
-      "version": "1.5.0-rc.1",
+      "version": "1.5.0-rc.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "concurrently": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "private": true,
   "license": "Apache-2.0",
   "description": "OpenYak — local-first AI agent for desktop work",


### PR DESCRIPTION
## What

- advance all application metadata from `1.5.0-rc.1` to `1.5.0-rc.2`
- include the macOS nested Mach-O signing fix in the release notes

## Why

The rc.1 build exposed an extensionless Playwright Node executable that retained an ad-hoc signature and caused Apple notarization to reject the app. The signing workflow now detects, Developer-ID signs, and strictly verifies every Mach-O payload before notarization. rc.2 preserves the immutable rc.1 tag while producing corrected native artifacts.

## Validation

- macOS signing regression tests: 2 passed
- real local Developer ID signing: 156/156 Mach-O files passed strict verification
- Playwright Node reports hardened runtime and the expected TeamIdentifier
- Tauri Rust `cargo check --locked` passed as v1.5.0-rc.2
- all JSON, TOML, Cargo lock, and desktop versions synchronized to 1.5.0-rc.2
