### PR TITLE
fix: preserve release draft state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           body_path: CHECKSUMS.md
           append_body: true
@@ -478,4 +479,6 @@ jobs:
       - name: Upload manifest as release asset
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: latest.json

--- a/backend/tests/test_scripts/test_release_workflow.py
+++ b/backend/tests/test_scripts/test_release_workflow.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(__file__).parents[3] / ".github" / "workflows" / "release.yml"
+
+
+def test_every_release_upload_preserves_draft_and_prerelease_state() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text())
+    publish_steps = workflow["jobs"]["publish"]["steps"]
+    release_steps = [
+        step
+        for step in publish_steps
+        if step.get("uses") == "softprops/action-gh-release@v2"
+    ]
+
+    assert len(release_steps) == 2
+    for step in release_steps:
+        assert step["with"]["draft"] is True, step["name"]
+        assert step["with"]["prerelease"] == "${{ contains(github.ref_name, '-') }}"


### PR DESCRIPTION
## What

- keep both GitHub Release upload steps in draft mode
- automatically mark semver tags containing a prerelease suffix as prereleases
- add a regression test covering both `softprops/action-gh-release` invocations

## Root cause

The workflow created a draft in its first release step, then invoked the same action again to upload `latest.json` without passing `draft: true`. That second invocation published the release as a normal release. For v1.5.0-rc.2 this required a manual correction to prerelease state.

## Validation

- regression test failed against the previous workflow
- release workflow tests: 3 passed
- release YAML parsed successfully
- GitHub `/releases/latest` remains on stable v1.4.0 after correcting rc.2
