### PR TITLE
release: OpenYak v1.5.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 ## [Unreleased]
 
-## [1.5.0-rc.2] - 2026-08-04
+## [1.5.0-rc.3] - 2026-08-05
 
 ### Added
 
@@ -26,6 +26,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 - **shared Browser runtime:** Serialized Agent actions, user interactions, and snapshots so a queued Agent action cannot leak through after the user takes control.
 - **workspace UX:** Kept Computer and Browser workspace state scoped per Session and synchronized target changes, control ownership, activity summaries, and responsive panel behavior.
+- **wide-screen live workspace:** Pinned Computer and Browser beside the conversation instead of allowing the live surface to overlap messages or stack above the compact Workspace summary.
 - **macOS packaging:** Developer-ID sign and strictly verify every Mach-O in the frozen backend, including Playwright's extensionless Node executable, before notarizing the outer app.
 
 ### Validation

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openyak"
-version = "1.5.0-rc.2"
+version = "1.5.0-rc.3"
 description = "Your local AI assistant — private, powerful, personal"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -2611,7 +2611,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openyak-desktop"
-version = "1.5.0-rc.2"
+version = "1.5.0-rc.3"
 dependencies = [
  "env_logger",
  "log",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openyak-desktop"
-version = "1.5.0-rc.2"
+version = "1.5.0-rc.3"
 description = "OpenYak — local-first AI agent for desktop work"
 license = "Apache-2.0"
 edition = "2021"

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenYak",
   "identifier": "com.openyak.desktop",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0-rc.3",
   "build": {
     "frontendDist": "../../frontend/out",
     "devUrl": "http://localhost:3000",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak-frontend",
-      "version": "1.5.0-rc.2",
+      "version": "1.5.0-rc.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0-rc.3",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak",
-      "version": "1.5.0-rc.2",
+      "version": "1.5.0-rc.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "concurrently": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0-rc.3",
   "private": true,
   "license": "Apache-2.0",
   "description": "OpenYak — local-first AI agent for desktop work",


### PR DESCRIPTION
## Release candidate 3

Bumps every desktop, backend, frontend, and lockfile version to `1.5.0-rc.3`.

This RC includes the wide-screen Computer/Browser workspace fix from #179 and the updated Computer Use documentation/demo.

## Validation

- version consistency across root, frontend, backend, Tauri config, and Cargo metadata
- release diff check
- full build and packaging will run from the signed `v1.5.0-rc.3` tag after merge