### PR TITLE
fix: green the suite on Windows and cover it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,25 @@ name: Tests & Type Check
 on:
   push:
     branches: [main]
+  # Not restricted to PRs against main: stacked PRs target their parent branch
+  # and would otherwise merge with no checks having run at all.
   pull_request:
-    branches: [main]
 
 jobs:
   backend:
-    name: Backend Tests
-    runs-on: ubuntu-latest
+    name: Backend Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Report every platform's result rather than cancelling siblings on the
+      # first failure, which is the whole point of testing more than one.
+      fail-fast: false
+      matrix:
+        # OpenYak ships a desktop app on Windows, and parts of the backend are
+        # platform-specific (native Computer Use, subprocess and path handling).
+        # Linux-only CI let a module-scope `ctypes.windll` reach main-adjacent
+        # branches, and equally would not have caught a POSIX-only assumption
+        # breaking Windows users.
+        os: [ubuntu-latest, windows-latest]
     defaults:
       run:
         working-directory: backend
@@ -23,6 +35,7 @@ jobs:
           cache-dependency-path: backend/pyproject.toml
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libcairo2-dev pkg-config
 
       - name: Install dependencies
@@ -32,6 +45,7 @@ jobs:
         run: pytest -x --tb=short -q --ignore=tests/test_tool/test_code_execute.py
 
       - name: Run offline agent smoke suite
+        if: runner.os == 'Linux'
         working-directory: .
         run: >-
           PYTHONPATH=backend:.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,13 @@ jobs:
       # first failure, which is the whole point of testing more than one.
       fail-fast: false
       matrix:
-        # OpenYak ships a desktop app on Windows, and parts of the backend are
+        # OpenYak ships a desktop app on all three, and parts of the backend are
         # platform-specific (native Computer Use, subprocess and path handling).
         # Linux-only CI let a module-scope `ctypes.windll` reach main-adjacent
         # branches, and equally would not have caught a POSIX-only assumption
-        # breaking Windows users.
-        os: [ubuntu-latest, windows-latest]
+        # breaking Windows users. release.yml already builds and signs on
+        # macos-latest, so the runner and the dependency set are proven there.
+        os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
       run:
         working-directory: backend

--- a/backend/app/api/automations.py
+++ b/backend/app/api/automations.py
@@ -273,12 +273,17 @@ async def list_recent_runs(
 
     Joins each run to its task so the caller gets the task name without an
     N+1 lookup. Runs whose task was deleted are excluded by the inner join.
+
+    Ties on `time_created` are broken by id. Several runs can start within the
+    same timestamp tick, and without a tiebreaker their order in the feed is
+    whatever the database happens to return. Run ids are ULIDs, so ordering by
+    id descending keeps the newest first within a tick.
     """
     limit = max(1, min(limit, 100))
     result = await db.execute(
         select(TaskRun, ScheduledTask.name)
         .join(ScheduledTask, TaskRun.task_id == ScheduledTask.id)
-        .order_by(TaskRun.time_created.desc())
+        .order_by(TaskRun.time_created.desc(), TaskRun.id.desc())
         .limit(limit)
     )
     rows = result.all()

--- a/backend/tests/platform_support.py
+++ b/backend/tests/platform_support.py
@@ -1,0 +1,56 @@
+"""Skip markers for tests that depend on POSIX-only filesystem semantics.
+
+These guard behaviour the operating system either provides or does not, rather
+than behaviour OpenYak controls, so the assertions are kept and skipped where
+they cannot hold instead of being weakened everywhere.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _symlinks_available() -> bool:
+    """Whether this process may create a symlink.
+
+    Windows requires Developer Mode or SeCreateSymbolicLinkPrivilege, so this
+    probes rather than assuming: a developer with Developer Mode enabled still
+    gets the coverage.
+    """
+    if not IS_WINDOWS:
+        return True
+    with tempfile.TemporaryDirectory() as directory:
+        link = Path(directory) / "probe-link"
+        try:
+            os.symlink(Path(directory), link, target_is_directory=True)
+        except (OSError, NotImplementedError, AttributeError):
+            return False
+        return True
+
+
+SYMLINKS_AVAILABLE = _symlinks_available()
+
+requires_symlinks = pytest.mark.skipif(
+    not SYMLINKS_AVAILABLE,
+    reason=(
+        "creating symlinks needs Developer Mode or SeCreateSymbolicLinkPrivilege "
+        "on Windows"
+    ),
+)
+
+requires_posix_permissions = pytest.mark.skipif(
+    IS_WINDOWS,
+    reason="NTFS has no execute bit; os.chmod only toggles the read-only flag",
+)
+
+requires_posix_shebang = pytest.mark.skipif(
+    IS_WINDOWS,
+    reason="Windows cannot execute a '#!/bin/sh' script as a program",
+)

--- a/backend/tests/test_agent/test_swarm.py
+++ b/backend/tests/test_agent/test_swarm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -60,9 +61,15 @@ async def swarm_session_factory(tmp_path):
 class _ConcurrentProvider(BaseProvider):
     """Deterministic Provider adapter that records overlapping child runs."""
 
-    def __init__(self) -> None:
+    def __init__(self, expect_overlap: int | None = None) -> None:
         self.active = 0
         self.max_active = 0
+        # Holding each child open for a fixed sleep and hoping they overlap is
+        # timer-resolution dependent, and serialized on Windows. When a test
+        # asserts real concurrency it passes the number of children it expects
+        # to run at once, and the barrier makes that deterministic: a sequential
+        # implementation fails on the timeout instead of flaking.
+        self._paired = asyncio.Barrier(expect_overlap) if expect_overlap else None
 
     @property
     def id(self) -> str:
@@ -98,8 +105,11 @@ class _ConcurrentProvider(BaseProvider):
         self.active += 1
         self.max_active = max(self.max_active, self.active)
         try:
-            # A sequential implementation can never observe max_active == 2.
-            await asyncio.sleep(0.03)
+            # A sequential implementation can never clear the barrier.
+            if self._paired is not None:
+                await asyncio.wait_for(self._paired.wait(), timeout=10)
+            else:
+                await asyncio.sleep(0.01)
             prompt = str(messages[-1].get("content", ""))
             yield StreamChunk(type="text-delta", data={"text": f"result for {prompt}"})
             yield StreamChunk(type="finish", data={"reason": "stop"})
@@ -246,7 +256,8 @@ async def test_swarm_runs_child_agents_concurrently_and_persists_one_state_part(
     tmp_path,
 ) -> None:
     session_factory = swarm_session_factory
-    provider = _ConcurrentProvider()
+    # Two SwarmTaskSpecs below; both must be in flight at once.
+    provider = _ConcurrentProvider(expect_overlap=2)
     providers = ProviderRegistry()
     providers.register(provider)
     await providers.refresh_models()
@@ -1185,16 +1196,21 @@ async def test_parent_abort_signal_promptly_cancels_blocked_swarm_children(
             ),
         )
     )
-    for _ in range(100):
-        if provider.active == 2:
-            break
+    # Wait against a wall-clock deadline rather than a fixed iteration count:
+    # 100 * 10ms assumed the children spin up within a second, which does not
+    # hold on a slower machine or where the event loop's timer granularity is
+    # coarser. This is setup, not the behaviour under test.
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline and provider.active != 2:
         await asyncio.sleep(0.01)
     assert provider.active == 2
 
     parent_job.abort()
 
+    # Generous relative to the 10s each child would otherwise block for, so
+    # this still proves the abort is prompt.
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(coordinator_task, timeout=1)
+        await asyncio.wait_for(coordinator_task, timeout=5)
     assert provider.active == 0
     async with swarm_session_factory() as db:
         messages = await get_messages(db, "abort-parent")

--- a/backend/tests/test_api/test_remote.py
+++ b/backend/tests/test_api/test_remote.py
@@ -11,11 +11,13 @@ from httpx import ASGITransport, AsyncClient
 
 from app.api.remote import router
 from app.auth.tunnel import TunnelManager
+from tests.platform_support import requires_posix_shebang
 
 pytestmark = pytest.mark.asyncio
 
 
 class TestEnableRemote:
+    @requires_posix_shebang
     async def test_recovers_when_bundled_cloudflared_is_invalid(self, monkeypatch, tmp_path: Path):
         bad_bin_dir = tmp_path / "data" / "bin"
         bad_bin_dir.mkdir(parents=True)

--- a/backend/tests/test_ollama/test_manager.py
+++ b/backend/tests/test_ollama/test_manager.py
@@ -8,6 +8,7 @@ import zipfile
 
 from app.ollama import manager as manager_module
 from app.ollama.manager import OllamaManager
+from tests.platform_support import requires_posix_permissions
 
 
 def test_download_urls_match_current_release_assets():
@@ -26,6 +27,7 @@ def test_archive_type_helpers_cover_ollama_release_formats():
     assert manager_module._download_filename("https://example.com/releases/latest/download/ollama-darwin.tgz", "ollama") == "ollama-darwin.tgz"
 
 
+@requires_posix_permissions
 def test_extract_tgz_makes_root_binary_executable(tmp_path, monkeypatch):
     monkeypatch.setattr(manager_module.sys, "platform", "darwin")
     mgr = OllamaManager(tmp_path)

--- a/backend/tests/test_rapid_mlx/test_rapid_mlx_manager.py
+++ b/backend/tests/test_rapid_mlx/test_rapid_mlx_manager.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.rapid_mlx import manager as manager_module
 from app.rapid_mlx.manager import RapidMLXManager
+from tests.platform_support import requires_symlinks
 
 
 def test_rapid_mlx_binary_detection_checks_homebrew_paths(monkeypatch, tmp_path: Path):
@@ -227,6 +228,7 @@ def _make_cached_repo(hub: Path, repo: str, blob_sizes: list[int]) -> Path:
     return model_dir
 
 
+@requires_symlinks
 @pytest.mark.asyncio
 async def test_uninstall_filters_symlinks_when_counting_freed_bytes(
     monkeypatch, tmp_path: Path
@@ -294,6 +296,7 @@ async def test_uninstall_skips_uncached_models(monkeypatch, tmp_path: Path):
     assert summary["freed_bytes"] == 0
 
 
+@requires_symlinks
 @pytest.mark.asyncio
 async def test_uninstall_keeps_models_when_flag_false(monkeypatch, tmp_path: Path):
     """delete_models=False should leave HF cache untouched."""

--- a/backend/tests/test_streaming/test_manager.py
+++ b/backend/tests/test_streaming/test_manager.py
@@ -316,6 +316,12 @@ class TestStreamManagerCleanup:
         parent = GenerationJob("parent-stream", "parent-session")
         active = 0
         max_active = 0
+        # Holding the slot for a fixed sleep and hoping two children overlap is
+        # timer-resolution dependent, and serialized on Windows. A barrier makes
+        # the overlap deterministic: two children must be inside the slot at
+        # once for either to proceed, so a regression to one permit fails on the
+        # timeout instead of flaking.
+        paired = asyncio.Barrier(2)
 
         async with sm.generation_slot(owner=parent):
             async def run_child(index: int) -> None:
@@ -331,8 +337,10 @@ class TestStreamManagerCleanup:
                 ):
                     active += 1
                     max_active = max(max_active, active)
-                    await asyncio.sleep(0.01)
-                    active -= 1
+                    try:
+                        await asyncio.wait_for(paired.wait(), timeout=5)
+                    finally:
+                        active -= 1
 
             await asyncio.gather(*(run_child(index) for index in range(8)))
 

--- a/backend/tests/test_tool/test_bash.py
+++ b/backend/tests/test_tool/test_bash.py
@@ -1,5 +1,6 @@
 """Bash tool tests."""
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -57,12 +58,30 @@ class TestBashTool:
         assert "err" in result.output
 
     @pytest.mark.asyncio
-    async def test_unicode_output(self, tool: BashTool):
-        """Non-ASCII output should not be garbled."""
-        result = await tool.execute(
-            {"command": 'python3 -c "print(\'hello world\')"'}, _make_ctx()
+    async def test_unicode_output(self, tool: BashTool, tmp_path: Path):
+        """Non-ASCII output should not be garbled.
+
+        Runs the interpreter under test rather than a bare ``python3``: Windows
+        ships a ``python3`` alias that resolves to a Microsoft Store stub, so
+        the command failed there and the assertion never exercised decoding.
+        The payload is non-ASCII so the test earns its name.
+        """
+        expected = "héllo wörld 中文"
+        script = tmp_path / "emit_unicode.py"
+        script.write_text(
+            "import sys\n"
+            "sys.stdout.reconfigure(encoding='utf-8')\n"
+            f"print({expected!r})\n",
+            encoding="utf-8",
         )
-        assert "hello" in result.output
+        # PowerShell needs the call operator for a quoted executable path.
+        prefix = "& " if IS_WINDOWS else ""
+        result = await tool.execute(
+            {"command": f'{prefix}"{sys.executable}" "{script}"'}, _make_ctx()
+        )
+
+        assert result.error is None, result.output
+        assert expected in result.output
 
     @pytest.mark.asyncio
     async def test_reports_workspace_root_without_exposing_its_path(

--- a/backend/tests/test_tool/test_subprocess_compat.py
+++ b/backend/tests/test_tool/test_subprocess_compat.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from app.tool.subprocess_compat import (
@@ -54,7 +56,12 @@ class TestFindShell:
     @pytest.mark.skipif(not IS_WINDOWS, reason="Windows-only")
     def test_windows_uses_powershell(self):
         result = find_shell()
-        assert result[0] == "powershell.exe"
+        # find_shell prefers PowerShell 7 when installed, which shutil.which
+        # resolves to an absolute path, and falls back to the built-in 5.1.
+        # Asserting the literal "powershell.exe" fails on any machine that has
+        # PowerShell 7, including the GitHub Windows runners.
+        assert Path(result[0]).stem.casefold() in {"pwsh", "powershell"}
+        assert result[1:] == ["-NoProfile", "-Command"]
 
     @pytest.mark.skipif(IS_WINDOWS, reason="Non-Windows only")
     def test_non_windows_uses_bash_or_sh(self):

--- a/backend/tests/test_tool/test_workspace.py
+++ b/backend/tests/test_tool/test_workspace.py
@@ -12,6 +12,7 @@ from app.tool.workspace import (
     resolve_for_write,
     validate_cwd,
 )
+from tests.platform_support import requires_symlinks
 
 
 class TestResolveAndValidate:
@@ -38,10 +39,14 @@ class TestResolveAndValidate:
         result = resolve_and_validate("/tmp/test.txt", None)
         assert result == str(Path("/tmp/test.txt").resolve())
 
+    @requires_symlinks
     def test_symlink_escape_raises(self, tmp_path: Path):
-        target = Path("/tmp")
+        # A real directory beside the workspace rather than "/tmp", which is not
+        # a meaningful path on Windows.
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir(exist_ok=True)
         link = tmp_path / "escape"
-        link.symlink_to(target)
+        link.symlink_to(outside, target_is_directory=True)
         with pytest.raises(WorkspaceViolation):
             resolve_and_validate(str(link / "outside.txt"), str(tmp_path))
 

--- a/frontend/src/components/interactive/permission-dialog.tsx
+++ b/frontend/src/components/interactive/permission-dialog.tsx
@@ -624,7 +624,16 @@ export function PermissionDialog({ permission, onRespond }: PermissionDialogProp
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => void handleRespond(false, false)}
+                      // Honour the Remember switch, the same way Allow does. The
+                      // Computer app variant below renders its own explicit
+                      // once/always buttons and hides the switch, so only that
+                      // case overrides the choice.
+                      onClick={() =>
+                        void handleRespond(
+                          false,
+                          isComputerAppPermission ? false : undefined,
+                        )
+                      }
                       disabled={submitting}
                       className="gap-1.5 flex-1"
                     >

--- a/frontend/tests/ui/openyak-preflight.spec.ts
+++ b/frontend/tests/ui/openyak-preflight.spec.ts
@@ -12,6 +12,47 @@ test.beforeEach(async ({ page }) => {
   mockState = await mockOpenYakApi(page);
 });
 
+interface PermissionRule {
+  action: string;
+  permission: string;
+  pattern: string;
+}
+
+/**
+ * Permission rules a prompt carries for the bash tool.
+ *
+ * A prompt body also carries capability deny rules for Computer and Browser
+ * whenever those are switched off in Settings. Those are unrelated to whether a
+ * permission choice was remembered, so the tests below assert on bash alone
+ * rather than on the exact contents of the array.
+ */
+function savedBashRules(body: unknown): PermissionRule[] {
+  const rules = (body as { permission_rules?: PermissionRule[] | null } | undefined)
+    ?.permission_rules;
+  return (rules ?? []).filter((rule) => rule.permission === "bash");
+}
+
+/**
+ * Ask the dialog to remember this choice for the whole tool.
+ *
+ * PermissionDialog resets its Remember switch and scope whenever a new
+ * permission request arrives (`permission.callId` changes), which is correct
+ * for a genuinely new request but races a test that sets them beforehand. Retry
+ * until both stick so the click below acts on the state we asked for.
+ */
+async function rememberForAllCommands(page: Page) {
+  const remember = page.getByRole("switch", {
+    name: /Remember this choice for bash/i,
+  });
+  const scope = page.locator("#remember-scope");
+  await expect(async () => {
+    await remember.setChecked(true);
+    await scope.selectOption("all");
+    await expect(remember).toBeChecked();
+    await expect(scope).toHaveValue("all");
+  }).toPass({ timeout: 15_000 });
+}
+
 async function openNewChat(page: Page, workspace = false) {
   const path = workspace
     ? `/c/new?directory=${encodeURIComponent("/Users/alex/openyak-demo")}`
@@ -516,9 +557,7 @@ test.describe("OpenYak UI preflight", () => {
 
     await openNewChat(page);
     await sendPrompt(page, "Create a follow-up checklist");
-    expect(mockState.promptBodies.at(-1)).toMatchObject({
-      permission_rules: null,
-    });
+    expect(savedBashRules(mockState.promptBodies.at(-1))).toEqual([]);
   });
 
   test("desktop interactive path: always allow persists permission rules to future prompts", async ({
@@ -530,12 +569,9 @@ test.describe("OpenYak UI preflight", () => {
 
     await sendPrompt(page, "Trigger permission flow for always allow");
     await expect(page.getByText("Permission Required")).toBeVisible();
-    await page
-      .getByRole("switch", { name: /Remember this choice for bash/i })
-      .setChecked(true);
     // Tool-wide allow is this test's subject; the scope selector defaults to
     // the safest option (this exact command), so widen it explicitly.
-    await page.locator("#remember-scope").selectOption("all");
+    await rememberForAllCommands(page);
 
     const respond = page.waitForResponse(
       (res) => res.url().includes("/api/chat/respond") && res.status() === 200,
@@ -554,15 +590,9 @@ test.describe("OpenYak UI preflight", () => {
 
     await openNewChat(page);
     await sendPrompt(page, "Create a follow-up checklist");
-    expect(mockState.promptBodies.at(-1)).toMatchObject({
-      permission_rules: [
-        {
-          action: "allow",
-          permission: "bash",
-          pattern: "*",
-        },
-      ],
-    });
+    expect(savedBashRules(mockState.promptBodies.at(-1))).toEqual([
+      { action: "allow", permission: "bash", pattern: "*" },
+    ]);
   });
 
   test("desktop interactive path: deny once does not persist a permission rule", async ({
@@ -592,9 +622,7 @@ test.describe("OpenYak UI preflight", () => {
 
     await openNewChat(page);
     await sendPrompt(page, "Create a follow-up checklist");
-    expect(mockState.promptBodies.at(-1)).toMatchObject({
-      permission_rules: null,
-    });
+    expect(savedBashRules(mockState.promptBodies.at(-1))).toEqual([]);
   });
 
   test("desktop interactive path: always deny persists permission rules to future prompts", async ({
@@ -606,12 +634,9 @@ test.describe("OpenYak UI preflight", () => {
 
     await sendPrompt(page, "Trigger permission flow for always deny");
     await expect(page.getByText("Permission Required")).toBeVisible();
-    await page
-      .getByRole("switch", { name: /Remember this choice for bash/i })
-      .setChecked(true);
     // This test covers the tool-wide deny path; the scope selector defaults
     // to the safest option (this exact command), so widen it explicitly.
-    await page.locator("#remember-scope").selectOption("all");
+    await rememberForAllCommands(page);
 
     const respond = page.waitForResponse(
       (res) => res.url().includes("/api/chat/respond") && res.status() === 200,
@@ -630,15 +655,9 @@ test.describe("OpenYak UI preflight", () => {
 
     await openNewChat(page);
     await sendPrompt(page, "Create a follow-up checklist");
-    expect(mockState.promptBodies.at(-1)).toMatchObject({
-      permission_rules: [
-        {
-          action: "deny",
-          permission: "bash",
-          pattern: "*",
-        },
-      ],
-    });
+    expect(savedBashRules(mockState.promptBodies.at(-1))).toEqual([
+      { action: "deny", permission: "bash", pattern: "*" },
+    ]);
   });
 
   test("desktop interactive path: agent question is answered through the GUI", async ({


### PR DESCRIPTION
Independent of #182/#183 — branches off `main`, no overlap.

Getting the backend and UI suites to actually pass on Windows turned up two product bugs. The rest is test assumptions that were POSIX-only or timing-dependent.

## Product bugs

**Deny threw away "Remember this choice".** [`permission-dialog.tsx:627`](https://github.com/openyak/openyak/blob/main/frontend/src/components/interactive/permission-dialog.tsx#L627) passed `rememberOverride = false`, so the shared Deny button ignored the switch every time — while Allow (`handleRespond(true)`) honoured it. Turn on *Remember this choice for bash*, pick *All shell commands*, click Deny, and nothing is persisted; the next request asks again.

The asymmetry matters: remembered allows stuck, remembered denies did not. Only the Computer-app variant should override the choice, because it renders its own explicit once/always buttons and hides the switch.

```diff
-  onClick={() => void handleRespond(false, false)}
+  onClick={() =>
+    void handleRespond(false, isComputerAppPermission ? false : undefined)
+  }
```

Found by chasing a preflight test that failed only when another permission test ran before it. It wasn't ordering at all — the test simply asserted `remember: true` and the button could never produce it. Isolating it took a DOM probe: exactly one dialog, switch checked, scope `all`, and the response still came back `remember: false`.

**Recent-runs ordering was ambiguous.** `list_recent_runs` ordered only by `time_created.desc()`. Several runs can start within one tick, and their order in the inbox feed was then whatever SQLite returned. `TaskRun.id` is a ULID, so it is a correct tiebreaker. This also fixes a test that failed ~5 runs in 6 on `main`.

## POSIX-only assumptions

Each keeps its assertion and is skipped only where the OS cannot satisfy it, via a small `tests/platform_support.py`:

- **Symlinks** — `requires_symlinks` *probes* whether this process may create one rather than skipping by platform, so a Windows machine with Developer Mode enabled still gets the coverage. The workspace-escape test also linked to `/tmp`, which is not a meaningful path on Windows; it now links to a real directory beside the workspace.
- **Execute bit** — NTFS has none, and `os.chmod` there only toggles read-only.
- **`#!/bin/sh`** — the cloudflared recovery test executes a shell script as a program.

## Races

- Two concurrency tests held a slot for a fixed `sleep` and hoped the work overlapped. That is timer-resolution dependent and serialized on Windows (`max_active == 1`). Both now use an `asyncio.Barrier`, so the overlap is deterministic — and a regression to one permit fails on the timeout rather than flaking.
- The swarm abort test waited `100 * 10ms` for children to start, assuming they spin up within a second. Now a wall-clock deadline; that is setup, not the behaviour under test.
- `test_unicode_output` shelled out to a bare `python3`, which on Windows hits the Microsoft Store alias stub — and asserted on `"hello world"`, pure ASCII, so it never exercised decoding even on Linux. It now runs `sys.executable` and asserts on `héllo wörld 中文`.

## Stale assertions

The four preflight permission specs asserted the exact contents of `permission_rules`. That array now also carries capability deny rules for Computer and Browser whenever those are off in Settings, so the assertions broke on a change unrelated to their subject. They assert on the bash rule specifically instead.

## CI

- Backend tests now run on **ubuntu-latest, windows-latest and macos-latest**, `fail-fast: false`. Linux-only CI let a module-scope `ctypes.windll` reach a PR branch (caught in #182 only after opening it), and would equally not have caught a POSIX-only assumption breaking Windows users. The Linux leg keeps the eval smoke suite; the other two skip it.
- `pull_request` is no longer restricted to `main`. Stacked PRs target their parent branch and were getting **no checks at all** — #183 currently shows none.

All three platforms are green. macOS is in fact the fastest backend leg (1m43s vs 3m13s on Windows).

The new Windows leg earned its keep immediately: it failed on `test_windows_uses_powershell`, which asserted the literal `"powershell.exe"` while `find_shell` deliberately prefers `pwsh` when installed. It had passed locally only because this machine has no PowerShell 7.

## Verification (Windows 11)

| Suite | Before | After |
|---|---|---|
| Backend | 1320 passed, **9 failed** | **1304 passed, 0 failed**, 28 skipped |
| Chromium UI | 120 passed, **6 failed** | **126 passed, 0 failed**, 8 skipped |
| Frontend unit | 63/63 | 63/63 |
| tsc / eslint | clean | clean |

The previously-flaky recent-runs test now passes 8/8 consecutive runs; the preflight interactive group passes 15/15 twice in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
