### PR TITLE
release: OpenYak v1.5.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 ## [Unreleased]
 
+## [1.5.0-rc.4] - 2026-08-08
+
+This RC closes the item v1.5.0-rc.3 left open: "the signed RC installer still
+requires final smoke testing on a physical Windows machine before the stable
+1.5.0 release." That testing found native Computer Use non-functional on
+Windows, and this release is the fix.
+
 ### Fixed
 
 - **Computer Use (Windows):** Native Computer Use was non-functional on Windows.
@@ -59,6 +66,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
   `OPENYAK_RUN_COMPUTER_USE_INTEGRATION=1`. The previous Windows unit tests
   bypassed `__init__`, stubbed `SetForegroundWindow` to succeed and monkeypatched
   window capture, which is why CI stayed green throughout.
+- **CI:** Backend tests run on ubuntu-latest, windows-latest and macos-latest,
+  and on pull requests against any branch so stacked PRs are no longer merged
+  with no checks having run.
+
+### Fixed (non-Computer Use)
+
+- **permissions:** The Deny button discarded the "Remember this choice" switch
+  every time, while Allow honoured it, so choosing to remember a denial
+  persisted nothing and the same request was asked again.
+- **automations:** The recent-runs inbox ordered only by creation time, leaving
+  runs that started within the same tick in an arbitrary order. Ties now break
+  on the run id.
+
+### Validation
+
+- Backend suite: 1,324 passed, 50 skipped on Windows 11; green on ubuntu-latest,
+  windows-latest and macos-latest in CI.
+- Windows visible Computer Use matrix: 22 passed against real Notepad, Explorer
+  and Settings windows on physical hardware, with no runtime fakes.
+- Frontend unit tests: 63 passed; TypeScript and ESLint clean.
+- Chromium UI regression: 126 passed, 8 skipped, 0 failed.
+- Live end-to-end pass against the running desktop app: 16 checks, 0 failures.
+- Not re-run on physical Apple hardware: the macOS visible matrix
+  (`test_computer_macos_integration.py`). The macOS runtime changes in this
+  release are additive (`resolve_app`, an `executable` field) and covered by the
+  unit suites on macos-latest, but a Mac smoke test is still worth doing before
+  stable 1.5.0.
 
 ## [1.5.0-rc.3] - 2026-08-05
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openyak"
-version = "1.5.0-rc.3"
+version = "1.5.0-rc.4"
 description = "Your local AI assistant — private, powerful, personal"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -2611,7 +2611,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openyak-desktop"
-version = "1.5.0-rc.3"
+version = "1.5.0-rc.4"
 dependencies = [
  "env_logger",
  "log",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openyak-desktop"
-version = "1.5.0-rc.3"
+version = "1.5.0-rc.4"
 description = "OpenYak — local-first AI agent for desktop work"
 license = "Apache-2.0"
 edition = "2021"

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "OpenYak",
   "identifier": "com.openyak.desktop",
-  "version": "1.5.0-rc.3",
+  "version": "1.5.0-rc.4",
   "build": {
     "frontendDist": "../../frontend/out",
     "devUrl": "http://localhost:3000",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.3",
+  "version": "1.5.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak-frontend",
-      "version": "1.5.0-rc.3",
+      "version": "1.5.0-rc.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak-frontend",
-  "version": "1.5.0-rc.3",
+  "version": "1.5.0-rc.4",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.3",
+  "version": "1.5.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openyak",
-      "version": "1.5.0-rc.3",
+      "version": "1.5.0-rc.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "concurrently": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openyak",
-  "version": "1.5.0-rc.3",
+  "version": "1.5.0-rc.4",
   "private": true,
   "license": "Apache-2.0",
   "description": "OpenYak — local-first AI agent for desktop work",


### PR DESCRIPTION
Version bump and changelog for **v1.5.0-rc.4**. Same file set as #180.

## Why an RC rather than stable

v1.5.0-rc.3's changelog gated stable on one item:

> Windows runtime contracts are covered in CI; the signed RC installer still requires final smoke testing on a physical Windows machine before the stable 1.5.0 release.

That smoke test has now been done, on physical Windows 11 hardware. It found native Computer Use **completely non-functional**: every UI Automation call failed with `CoInitialize has not been called`, and the live workspace returned HTTP 500 on every poll. The Computer workspace rendered a bare "Internal Server Error" with a Retry that could never succeed.

The gate is closed, but the fix was a substantial rewrite (#182, #183) verified on exactly one machine, so this ships as rc.4 rather than straight to stable.

## What's in it

- **#182** — native Computer Use works on Windows: COM confined to one dedicated thread, foreground acquisition that actually succeeds, `PrintWindow` capture instead of a screen-region grab, RuntimeId-keyed element indices, real `ScrollAmount` enums, executable-based blocking of consoles, plus the Windows visible integration matrix.
- **#183** — one UIA cache request instead of per-property cross-process calls: snapshot 245 ms → 77 ms, live workspace endpoint 246 ms → 90 ms.
- **#184** — backend and UI suites green on Windows, two product bugs fixed along the way (Deny discarded "Remember this choice"; recent-runs ordering was ambiguous), and CI extended to ubuntu + windows + macOS.

Net effect for a Windows user: Computer Use goes from returning HTTP 500 on every action to a working live workspace at roughly 11 fps.

## Validation

| | |
|---|---|
| Backend (Windows 11) | 1,324 passed, 50 skipped |
| Backend CI | green on ubuntu-latest, windows-latest, macos-latest |
| Windows visible matrix | 22 passed against real Notepad / Explorer / Settings, no runtime fakes |
| Frontend unit | 63/63, tsc + eslint clean |
| Chromium UI | 126 passed, 8 skipped, 0 failed |
| Live end-to-end vs the running app | 16 checks, 0 failures |

**Not covered:** the macOS visible matrix (`test_computer_macos_integration.py`) has not been re-run on physical Apple hardware. The macOS runtime changes here are additive (`resolve_app`, an `executable` field) and the unit suites pass on macos-latest, but a real Mac smoke test is worth doing before stable 1.5.0 — the same way this RC's Windows gate was worth doing.

## After merge

Tagging `v1.5.0-rc.4` triggers `release.yml`, which builds and signs Windows/macOS/Linux bundles and publishes the GitHub Release. Existing installs pick it up through the updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
