### PR TITLE
fix(desktop): stop stale payload from breaking Windows upgrades

### DIFF
--- a/backend/openyak.spec
+++ b/backend/openyak.spec
@@ -254,7 +254,12 @@ a = Analysis(
     ),
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=[
+        # Keeps a collected native payload from being importable as the
+        # freetype-py module; see the hook for why startup died without it.
+        os.path.join(backend_dir, 'pyinstaller_hooks',
+                     'rthook_block_stub_freetype.py'),
+    ],
     excludes=[
         # ── Testing & dev ────────────────────────────────────────────
         'tkinter',

--- a/backend/pyinstaller_hooks/rthook_block_stub_freetype.py
+++ b/backend/pyinstaller_hooks/rthook_block_stub_freetype.py
@@ -1,0 +1,39 @@
+"""Stop a bundled native payload from masquerading as the freetype-py module.
+
+PyInstaller collects freetype's native library into a top-level directory named
+``freetype`` inside ``_internal``, which is on ``sys.path``. Python therefore
+resolves ``import freetype`` to that directory as an implicit namespace package:
+the import succeeds but the module is empty.
+
+reportlab probes for freetype-py with a plain ``import freetype`` and, seeing it
+succeed, goes on to use it -- so the frozen backend died during startup with
+
+    AttributeError: module 'freetype' has no attribute 'FT_LOAD_DEFAULT'
+
+before it had served a single request. From source there is no ``freetype``
+module at all, the probe fails cleanly, and reportlab takes its fallback path;
+this hook restores that behaviour in the bundle.
+
+Binding the name to None in sys.modules makes ``import freetype`` raise
+ImportError, which is exactly what the probe expects. The real freetype DLL is
+unaffected: it is loaded by the C extensions that link it, not through this
+Python module name.
+"""
+
+import importlib.util
+import sys
+
+
+def _is_stub_namespace_package(name: str) -> bool:
+    """True when `name` resolves only to a directory with no module code."""
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return False
+    return spec is not None and spec.origin is None and spec.loader is None
+
+
+if "freetype" not in sys.modules and _is_stub_namespace_package("freetype"):
+    # A real freetype-py install would have a loader, so this only fires for
+    # the collected-data directory.
+    sys.modules["freetype"] = None

--- a/desktop-tauri/src-tauri/installer-hooks.nsh
+++ b/desktop-tauri/src-tauri/installer-hooks.nsh
@@ -45,4 +45,36 @@
   ; Give Windows a moment to release the file handles the killed
   ; processes were holding before we start overwriting files.
   Sleep 1000
+
+  ; Remove the previous backend payload outright rather than extracting over
+  ; it. NSIS only overwrites the files it is installing, so anything a former
+  ; version shipped and this one does not stays on disk forever.
+  ;
+  ; That is not merely untidy. _internal is on the frozen interpreter's
+  ; sys.path, so an orphaned directory there can shadow a module name: a
+  ; stale "freetype" folder left by an older build made "import freetype"
+  ; resolve to an empty namespace package, and reportlab -- which probes for
+  ; freetype-py and only guards against ImportError -- then died on
+  ; AttributeError during startup. The backend never came up, so the whole
+  ; app was dead after upgrading while a clean install worked fine.
+  ;
+  ; Only application payload lives here; user data is under AppData.
+  ${If} ${FileExists} "$INSTDIR\backend\*.*"
+    DetailPrint "Removing previous backend payload..."
+    RMDir /r "$INSTDIR\backend"
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\nodejs\*.*"
+    DetailPrint "Removing previous Node.js runtime..."
+    RMDir /r "$INSTDIR\nodejs"
+  ${EndIf}
+!macroend
+
+; Uninstalling left 179 files behind, which is how the stale payload above
+; survives a reinstall as well as an upgrade. Remove the bundled runtimes
+; explicitly; user data under AppData is deliberately untouched.
+!macro NSIS_HOOK_POSTUNINSTALL
+  DetailPrint "Removing bundled runtimes..."
+  RMDir /r "$INSTDIR\backend"
+  RMDir /r "$INSTDIR\nodejs"
+  RMDir "$INSTDIR"
 !macroend

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -159,6 +159,58 @@ if (problems.length > 0) {
 
 console.log(`[verify-bundle] static: ${required.length} required assets present in ${dist}`);
 
+// ── Module-shadowing check ───────────────────────────────────────────
+//
+// _internal is on the frozen interpreter's sys.path, so any directory
+// there is importable as an implicit namespace package. A data-only
+// directory — one holding native libraries and no Python at all — that
+// happens to share a name with a module some dependency probes for will
+// make that probe succeed and hand back an empty module.
+//
+// That is how a stale `freetype/` broke startup: reportlab probes for
+// freetype-py with a bare `import freetype`, guards only against
+// ImportError, and died on AttributeError reaching for FT_LOAD_DEFAULT.
+// Catch the shape here so a build can never introduce one.
+
+const PROBED_MODULE_NAMES = new Set([
+  // Optional dependencies that libraries we bundle probe for by import.
+  "freetype",
+  "cairo",
+  "cairocffi",
+  "cairosvg",
+  "rlPyCairo",
+  "renderPM",
+  "pycairo",
+]);
+
+const shadowing = [];
+for (const entry of readdirSync(internal, { withFileTypes: true })) {
+  if (!entry.isDirectory() || !PROBED_MODULE_NAMES.has(entry.name)) continue;
+  const contents = readdirSync(join(internal, entry.name));
+  const hasPython = contents.some((f) => /\.(py|pyc|pyd|so)$/i.test(f));
+  if (!hasPython) {
+    shadowing.push(
+      `${join(internal, entry.name)}  (contains ${contents.length} file(s), no Python module)`,
+    );
+  }
+}
+
+if (shadowing.length > 0) {
+  console.error(
+    "\n[verify-bundle] Data-only directory shadowing an importable module name:",
+  );
+  for (const s of shadowing) console.error(`  ✗ ${s}`);
+  console.error(
+    "\n`import <name>` will resolve to this directory as an empty namespace\n" +
+      "package, so any dependency probing for it will get a broken module\n" +
+      "instead of a clean ImportError. Relocate the payload out of _internal/\n" +
+      "or exclude it in openyak.spec.\n",
+  );
+  exit(1);
+}
+
+console.log("[verify-bundle] static: no data-only directory shadows a probed module name");
+
 // ── Runtime smoke test ───────────────────────────────────────────────
 //
 // Static checks can't tell whether pure-python packages that live


### PR DESCRIPTION
Found while smoke-testing the **packaged** v1.5.0-rc.4 installer on physical Windows 11 — the step #185 exists to close.

## The bug

Upgrading the Windows app leaves it dead. The shell window opens, `openyak-backend.exe` sits there titled *"Unhandled exception in script"*, and every API call fails:

```
run.py → app.main → app.api.router → app.api.artifacts → app.api.pdf
       → xhtml2pdf → reportlab/graphics/utils.py:69
AttributeError: module 'freetype' has no attribute 'FT_LOAD_DEFAULT'
```

A **clean install of the same version works perfectly**, which is exactly why CI never saw it — `verify-bundle.mjs` already runs a real startup smoke test and it passed on the Windows runner (`smoke: /m served successfully`).

## Root cause

The NSIS installer overwrites the files it ships but never prunes. Anything a former version placed in the install directory survives forever. On this machine, upgraded through several builds since April:

```
_internal\freetype\libfreetype.dll   2026-04-29   ← stale
_internal\freetype.dll               2026-04-29   ← stale
openyak-backend.exe                  2026-08-05   ← rc.3 build
_internal\setuptools                 2026-03-29   ← also stale
```

`_internal` is on the frozen interpreter's `sys.path`, so `freetype/` is importable as an **implicit namespace package**:

```
spec found : True
origin     : None
loader     : None
imported OK, has FT_LOAD_DEFAULT: False
```

[reportlab/graphics/utils.py:62-69](https://github.com/reportlab/reportlab) probes for freetype-py and guards only against `ImportError`:

```python
if tp == 'freetype':
    try:
        import freetype        # ← "succeeds", returns an empty namespace package
    except ImportError:
        continue
    class FTTextPath:
        ftLFlags = freetype.FT_LOAD_DEFAULT | ...   # ← AttributeError
```

From source there is no `freetype` module at all, the probe fails cleanly, and reportlab takes its fallback path. So it only ever breaks when frozen *and* upgraded.

Uninstalling left **179 files** behind, which is how the payload survives a reinstall too.

## Fix, in three layers

1. **Installer prunes.** `NSIS_HOOK_PREINSTALL` removes the previous `backend` and `nodejs` payloads before extracting; a new `NSIS_HOOK_POSTUNINSTALL` removes them on the way out. Only application payload lives there — user data is under AppData and is untouched.
2. **Runtime hook.** `rthook_block_stub_freetype.py` binds `freetype` to `None` in `sys.modules` *only* when it resolves to a loader-less namespace package, restoring the clean `ImportError` the probe expects. A real freetype-py install has a loader and is unaffected. This matters because it fixes machines that are **already** in the broken state, without waiting for them to reinstall.
3. **Build guard.** `verify-bundle.mjs` now fails if a data-only directory in `_internal` shadows a module name a bundled dependency probes for.

## Verification (Windows 11)

| Check | Result |
|---|---|
| Shipped rc.3 bundle, upgraded machine | crashes |
| Shipped rc.4 bundle, upgraded machine | crashes, identically |
| rc.3 with the stale dir renamed away | **starts** — isolates the cause |
| Local rebuild + runtime hook, stale dir present | **starts** |
| Computer Use against that rebuild | UIA snapshot 86 ms, foreground input, shared control all working |
| **Clean install of shipped rc.4** | **starts, Computer Use works** |
| verify-bundle with the directory | rejects |
| verify-bundle without it | passes |

## Two corrections to what I reported earlier

I initially concluded rc.3 and rc.4 were broken for all Windows users. **That is wrong** — fresh installs were always fine. The defect is upgrade-only. It still matters more than it sounds: existing users are precisely the ones auto-update reaches.

I also added `comtypes` to the spec's Windows runtime packages, believing its absence as an extracted directory would break UI Automation. **Also wrong** — comtypes is pure Python and already ships inside `PYZ-00.pyz`; Computer Use works in a clean rc.4 without it. That change has been reverted rather than left in as harmless noise.

## Release impact

`v1.5.0-rc.4` is still an unpublished draft. It should not be published as-is: every existing Windows user who auto-updates into it lands on a dead app. Recommend cutting rc.5 with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
