### PR TITLE
fix(session): eight defects found reading DeepSeek Harness against OpenYak

### DIFF
--- a/backend/app/agent/permission.py
+++ b/backend/app/agent/permission.py
@@ -44,6 +44,22 @@ def evaluate(permission: str, pattern: str, ruleset: Ruleset) -> str:
     return result
 
 
+def agent_verdict(permission: str, pattern: str, agent_permissions: Ruleset) -> str:
+    """Evaluate an agent's own ruleset the way it is actually layered.
+
+    An agent's rules never apply alone — they sit on top of
+    :data:`GLOBAL_DEFAULTS` in every real merge. Evaluating them in isolation
+    instead reads "this agent says nothing about tool X" as ``deny``, because
+    :func:`evaluate` returns ``deny`` when no rule matches. That turns an agent
+    declared without a ``permissions`` block (the default for a user-defined
+    agent in ``.openyak/agents/*.md``) into one that is refused every tool.
+
+    Use this wherever the agent layer is consulted on its own — as a ceiling on
+    what later layers may re-open, or as the pre-execution policy gate.
+    """
+    return evaluate(permission, pattern, merge_rulesets(GLOBAL_DEFAULTS, agent_permissions))
+
+
 def merge_rulesets(*rulesets: Ruleset) -> Ruleset:
     """Merge multiple rulesets in priority order (last wins).
 

--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -18,6 +18,7 @@ import queue as _queue
 from pathlib import Path
 from typing import Any
 
+from app.utils.atomic_write import atomic_write_text, file_lock
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -89,10 +90,15 @@ def _load_config_dict() -> dict:
 
 
 def _save_config_dict(data: dict) -> None:
-    """Save raw channels.json config."""
+    """Save raw channels.json config.
+
+    This file holds the bot token for every connected channel, so it is written
+    atomically and owner-only: a partial write disconnects all of them at once,
+    and two concurrent /configure calls must not lose one another's channel.
+    """
     path = _get_channels_config_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    with file_lock(path):
+        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from app.config import get_custom_endpoints
 from app.dependencies import ProviderRegistryDep, SettingsDep
+from app.utils.atomic_write import atomic_write_text, file_lock
 from app.provider.catalog import PROVIDER_CATALOG
 from app.provider.factory import create_provider as create_desktop_provider
 from app.provider.local import (
@@ -113,34 +114,43 @@ def _update_env_file(key: str, value: str) -> None:
 
     Values are single-quoted to prevent python-dotenv from interpreting
     special characters (``#`` as inline comments, whitespace stripping, etc.).
+
+    This file holds every configured API key, so the whole read-modify-write
+    runs under a lock and lands atomically: two callers must not clobber each
+    other's keys, and an interrupted write must not truncate the file.
     """
-    lines: list[str] = []
-    found = False
-    # Single-quote the value; escape any embedded single quotes.
-    escaped = value.replace("'", "'\\''")
-    entry = f"{key}='{escaped}'"
+    with file_lock(_ENV_PATH):
+        lines: list[str] = []
+        found = False
+        # Single-quote the value; escape any embedded single quotes.
+        escaped = value.replace("'", "'\\''")
+        entry = f"{key}='{escaped}'"
 
-    if _ENV_PATH.exists():
-        lines = _ENV_PATH.read_text(encoding="utf-8").splitlines()
-        for i, line in enumerate(lines):
-            if line.startswith(f"{key}=") or line.startswith(f"{key} ="):
-                lines[i] = entry
-                found = True
-                break
+        if _ENV_PATH.exists():
+            lines = _ENV_PATH.read_text(encoding="utf-8").splitlines()
+            for i, line in enumerate(lines):
+                if line.startswith(f"{key}=") or line.startswith(f"{key} ="):
+                    lines[i] = entry
+                    found = True
+                    break
 
-    if not found:
-        lines.append(entry)
+        if not found:
+            lines.append(entry)
 
-    _ENV_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        atomic_write_text(_ENV_PATH, "\n".join(lines) + "\n")
 
 
 def _remove_env_key(key: str) -> None:
     """Remove a key from the backend .env file entirely."""
-    if not _ENV_PATH.exists():
-        return
-    lines = _ENV_PATH.read_text(encoding="utf-8").splitlines()
-    lines = [l for l in lines if not l.startswith(f"{key}=") and not l.startswith(f"{key} =")]
-    _ENV_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with file_lock(_ENV_PATH):
+        if not _ENV_PATH.exists():
+            return
+        lines = _ENV_PATH.read_text(encoding="utf-8").splitlines()
+        lines = [
+            l for l in lines
+            if not l.startswith(f"{key}=") and not l.startswith(f"{key} =")
+        ]
+        atomic_write_text(_ENV_PATH, "\n".join(lines) + "\n")
 
 
 class LocalProviderStatus(BaseModel):

--- a/backend/app/channels/config.py
+++ b/backend/app/channels/config.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.utils.atomic_write import atomic_write_text, file_lock
+
 logger = logging.getLogger(__name__)
 
 # Default path for channels configuration
@@ -48,11 +50,15 @@ def load_channels_config(config_path: Path | None = None) -> ChannelsConfig:
 
 
 def save_channels_config(config: ChannelsConfig, config_path: Path | None = None) -> None:
-    """Save channels configuration to JSON file."""
+    """Save channels configuration to JSON file.
+
+    Holds bot tokens for every connected channel, so it is written atomically
+    and owner-only — a partial write here disconnects all of them at once.
+    """
     path = config_path or _DEFAULT_CONFIG_PATH
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(config.model_dump(), indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
+    with file_lock(path):
+        atomic_write_text(
+            path,
+            json.dumps(config.model_dump(), indent=2, ensure_ascii=False),
+        )
     logger.info("Saved channels config to %s", path)

--- a/backend/app/channels/config.py
+++ b/backend/app/channels/config.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from app.utils.atomic_write import atomic_write_text, file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -49,16 +48,3 @@ def load_channels_config(config_path: Path | None = None) -> ChannelsConfig:
         return ChannelsConfig()
 
 
-def save_channels_config(config: ChannelsConfig, config_path: Path | None = None) -> None:
-    """Save channels configuration to JSON file.
-
-    Holds bot tokens for every connected channel, so it is written atomically
-    and owner-only — a partial write here disconnects all of them at once.
-    """
-    path = config_path or _DEFAULT_CONFIG_PATH
-    with file_lock(path):
-        atomic_write_text(
-            path,
-            json.dumps(config.model_dump(), indent=2, ensure_ascii=False),
-        )
-    logger.info("Saved channels config to %s", path)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -128,6 +128,7 @@ class Settings(BaseSettings):
     min_output_tokens: int = 256  # minimum output tokens floor
     tool_timeout: int = 300  # seconds — per-tool execution timeout
     max_concurrent_generations: int = 20  # max parallel generation jobs
+    max_parallel_tool_calls: int = 10  # concurrency-safe tools running at once
 
     # --- Tool Limits ---
     bash_timeout: int = 120  # default bash command timeout (seconds)

--- a/backend/app/mcp/token_store.py
+++ b/backend/app/mcp/token_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from app.mcp.oauth import AuthServerMeta, TokenSet
+from app.utils.atomic_write import atomic_write_text, file_lock
 
 logger = logging.getLogger(__name__)
 
@@ -148,10 +149,7 @@ class McpTokenStore:
 
     def _persist(self) -> None:
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            self._path.write_text(
-                json.dumps(self._data, indent=2),
-                encoding="utf-8",
-            )
+            with file_lock(self._path):
+                atomic_write_text(self._path, json.dumps(self._data, indent=2))
         except OSError as e:
             logger.warning("Cannot persist MCP tokens: %s", e)

--- a/backend/app/provider/anthropic_provider.py
+++ b/backend/app/provider/anthropic_provider.py
@@ -102,6 +102,10 @@ class AnthropicDesktopProvider(BaseProvider):
                     pricing=ModelPricing(
                         prompt=pricing.get("prompt", 0),
                         completion=pricing.get("completion", 0),
+                        # models.dev already parses these; without them the
+                        # cost calculator cannot price a cached read at all.
+                        cache_read=pricing.get("cache_read_price") or None,
+                        cache_write=pricing.get("cache_write_price") or None,
                     ),
                     metadata=meta,
                 ))

--- a/backend/app/provider/base.py
+++ b/backend/app/provider/base.py
@@ -8,6 +8,29 @@ from typing import Any, AsyncIterator
 from app.schemas.provider import ModelInfo, ProviderStatus, StreamChunk
 
 
+class ProviderStreamError(RuntimeError):
+    """An error a provider reported while streaming.
+
+    Providers signal stream failures by raising, never by yielding a chunk, so
+    that a single consumer path handles every failure. This matters because
+    ``app.session.retry`` classifies retryability from the raised exception: an
+    error delivered as a chunk instead bypasses backoff, the 429/5xx retry
+    budget, and context-overflow recovery.
+
+    Raise this when the failure originates in the provider's own protocol (an
+    error event in the response body, a non-200 status). Re-raise the original
+    exception unchanged when one exists — ``retry_delay`` reads ``Retry-After``
+    off its ``.response.headers``, which a wrapper would discard.
+
+    ``code`` carries a provider-specific signal (e.g. ``needs_reauth``) for
+    callers that can act on it.
+    """
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
 class BaseProvider(ABC):
     """Abstract LLM provider."""
 

--- a/backend/app/provider/gemini_provider.py
+++ b/backend/app/provider/gemini_provider.py
@@ -99,6 +99,10 @@ class GeminiDesktopProvider(BaseProvider):
                     pricing=ModelPricing(
                         prompt=pricing.get("prompt", 0),
                         completion=pricing.get("completion", 0),
+                        # models.dev already parses these; without them the
+                        # cost calculator cannot price a cached read at all.
+                        cache_read=pricing.get("cache_read_price") or None,
+                        cache_write=pricing.get("cache_write_price") or None,
                     ),
                     metadata=meta,
                 ))

--- a/backend/app/provider/generic_openai.py
+++ b/backend/app/provider/generic_openai.py
@@ -133,6 +133,10 @@ class GenericOpenAIProvider(OpenAICompatProvider):
                     pricing=ModelPricing(
                         prompt=pricing.get("prompt", 0),
                         completion=pricing.get("completion", 0),
+                        # models.dev already parses these; without them the
+                        # cost calculator cannot price a cached read at all.
+                        cache_read=pricing.get("cache_read_price") or None,
+                        cache_write=pricing.get("cache_write_price") or None,
                     ),
                     metadata=m.get("metadata", {}),
                 ))

--- a/backend/app/provider/openai_compat.py
+++ b/backend/app/provider/openai_compat.py
@@ -249,8 +249,11 @@ class OpenAICompatProvider(BaseProvider):
                 )
 
         except Exception as e:
+            # Re-raise unchanged rather than converting to an error chunk: the
+            # retry classifier reads the exception (including Retry-After off
+            # ``e.response.headers``), and a chunk would skip it entirely.
             logger.error("Stream error for model %s: %s", model, e, exc_info=True)
-            yield StreamChunk(type="error", data={"message": str(e)})
+            raise
 
     def _build_messages(
         self,

--- a/backend/app/provider/openai_subscription.py
+++ b/backend/app/provider/openai_subscription.py
@@ -15,7 +15,7 @@ from typing import Any, AsyncIterator
 import httpx
 
 from app.config import get_settings
-from app.provider.base import BaseProvider
+from app.provider.base import BaseProvider, ProviderStreamError
 from app.schemas.provider import (
     ModelCapabilities,
     ModelInfo,
@@ -221,9 +221,12 @@ class OpenAISubscriptionProvider(BaseProvider):
                             async with self._refresh_lock:
                                 await self._do_refresh()
                             headers["Authorization"] = f"Bearer {self._access_token}"
-                        except Exception:
-                            yield StreamChunk(type="error", data={"message": "Authentication failed. Please re-authorize your ChatGPT subscription.", "code": "needs_reauth"})
-                            return
+                        except Exception as refresh_error:
+                            raise ProviderStreamError(
+                                "Authentication failed. Please re-authorize your "
+                                "ChatGPT subscription.",
+                                code="needs_reauth",
+                            ) from refresh_error
 
                         # Retry with new token
                         async with client.stream(
@@ -234,23 +237,28 @@ class OpenAISubscriptionProvider(BaseProvider):
                         ) as retry_response:
                             if retry_response.status_code != 200:
                                 text = (await retry_response.aread()).decode()
-                                yield StreamChunk(type="error", data={"message": f"WHAM API error after refresh: {retry_response.status_code} — {text[:200]}"})
-                                return
+                                raise ProviderStreamError(
+                                    f"WHAM API error after refresh: "
+                                    f"{retry_response.status_code} — {text[:200]}"
+                                )
                             async for chunk in self._parse_wham_stream(retry_response):
                                 yield chunk
                         return
 
                     if response.status_code != 200:
                         text = (await response.aread()).decode()
-                        yield StreamChunk(type="error", data={"message": f"WHAM API error: {response.status_code} — {text[:200]}"})
-                        return
+                        raise ProviderStreamError(
+                            f"WHAM API error: {response.status_code} — {text[:200]}"
+                        )
 
                     async for chunk in self._parse_wham_stream(response):
                         yield chunk
 
         except Exception as e:
+            # Raise rather than yield an error chunk so the session retry
+            # classifier sees the failure; see ProviderStreamError.
             logger.error("OpenAI subscription stream error: %s", e)
-            yield StreamChunk(type="error", data={"message": str(e)})
+            raise
 
     def _build_wham_request(
         self,
@@ -563,7 +571,7 @@ class OpenAISubscriptionProvider(BaseProvider):
                 error_msg = event.get("error", {})
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
-                yield StreamChunk(type="error", data={"message": str(error_msg)})
+                raise ProviderStreamError(str(error_msg))
 
     async def health_check(self) -> ProviderStatus:
         """Check if the subscription is active by verifying the token."""

--- a/backend/app/provider/openrouter.py
+++ b/backend/app/provider/openrouter.py
@@ -23,6 +23,21 @@ from app.schemas.provider import (
 
 logger = logging.getLogger(__name__)
 
+def _optional_per_million(raw: Any) -> float | None:
+    """Convert an OpenRouter per-token price string to per-million, or None.
+
+    Absent and unparseable are both None: the cost calculator distinguishes
+    "this catalog does not publish a cache rate" from a real zero, and a
+    silently-zeroed rate would under-report instead of over-report.
+    """
+    if raw is None:
+        return None
+    try:
+        return float(raw) * 1_000_000
+    except (TypeError, ValueError):
+        return None
+
+
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 def _is_free(pricing: dict) -> bool:
@@ -165,6 +180,13 @@ class OpenRouterProvider(OpenAICompatProvider):
                     pricing=ModelPricing(
                         prompt=float(pricing.get("prompt", "0")) * 1_000_000,  # Convert per-token → per-million
                         completion=float(pricing.get("completion", "0")) * 1_000_000,  # Convert per-token → per-million
+                        # The catalog carries real cache rates (Anthropic reads
+                        # at ~0.1x prompt). Without them the cost calculator has
+                        # to fall back to the prompt price, over-stating a long
+                        # session — where cache reads are most of the input — by
+                        # roughly an order of magnitude.
+                        cache_read=_optional_per_million(pricing.get("input_cache_read")),
+                        cache_write=_optional_per_million(pricing.get("input_cache_write")),
                     ),
                     metadata={
                         "description": m.get("description", ""),

--- a/backend/app/schemas/provider.py
+++ b/backend/app/schemas/provider.py
@@ -77,6 +77,13 @@ class ModelPricing(BaseModel):
 
     prompt: float = 0.0  # Cost per million prompt tokens
     completion: float = 0.0  # Cost per million completion tokens
+    cache_read: float | None = None  # Per million cached-input tokens read
+    cache_write: float | None = None  # Per million tokens written to cache
+    """Cache rates vary by provider — Anthropic reads at 0.1x prompt and writes
+    at 1.25x, OpenAI reads at 0.5x — so there is no safe single multiplier.
+    When a catalog does not supply them, ``calculate_step_cost`` falls back to
+    the prompt price, which over-states rather than silently billing cached
+    tokens at zero."""
 
 
 class ModelInfo(BaseModel):

--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -46,6 +46,27 @@ PROTECTED_TOKEN_BUDGET = 40_000  # Protect this many tokens of tool output
 SKIP_RECENT_TURNS = 2  # Don't compact the last N assistant messages
 PROTECTED_TOOLS = frozenset({"skill"})  # Never prune these tool outputs
 AUTO_COMPACT_CONTEXT_RATIO = 0.85  # Proactively compact before the hard context edge
+SUMMARY_MAX_TOKENS = 4096  # Output cap for the summary; hitting it fails the run
+
+
+def _estimate_message_tokens(messages: list[dict[str, Any]]) -> int:
+    """Approximate the context cost of an LLM message list."""
+    total = 0
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            total += estimate_tokens(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        total += estimate_tokens(text)
+        for call in message.get("tool_calls") or []:
+            function = call.get("function") if isinstance(call, dict) else None
+            if isinstance(function, dict):
+                total += estimate_tokens(str(function.get("arguments", "")))
+    return total
 
 
 @dataclass
@@ -53,6 +74,14 @@ class CompactionResult:
     pruned_parts: int = 0
     summary: str | None = None
     summary_visible: bool = False
+    tokens_freed: int = 0
+    """Approximate context tokens this run actually reclaimed.
+
+    Callers gate their retry budget on this rather than on the call returning:
+    a run that summarises nothing and prunes nothing still returns normally, and
+    treating that as success lets an unproductive compaction loop reset its own
+    circuit breaker forever.
+    """
 
 
 async def run_compaction(
@@ -83,7 +112,10 @@ async def run_compaction(
     job.publish(SSEEvent(COMPACTION_PHASE, {
         "session_id": session_id, "phase": "prune", "status": "started",
     }))
-    result.pruned_parts = await _phase1_prune(session_id, session_factory=session_factory)
+    result.pruned_parts, pruned_tokens = await _phase1_prune(
+        session_id, session_factory=session_factory
+    )
+    result.tokens_freed += pruned_tokens
     job.publish(SSEEvent(COMPACTION_PHASE, {
         "session_id": session_id, "phase": "prune", "status": "completed",
     }))
@@ -96,7 +128,7 @@ async def run_compaction(
     job.publish(SSEEvent(COMPACTION_PHASE, {
         "session_id": session_id, "phase": "summarize", "status": "started",
     }))
-    result.summary = await _phase2_summarize(
+    result.summary, summary_tokens_freed = await _phase2_summarize(
         session_id,
         job=job,
         session_factory=session_factory,
@@ -104,6 +136,7 @@ async def run_compaction(
         agent_registry=agent_registry,
         model_id=model_id,
     )
+    result.tokens_freed += summary_tokens_freed
     job.publish(SSEEvent(COMPACTION_PHASE, {
         "session_id": session_id, "phase": "summarize", "status": "completed",
     }))
@@ -163,9 +196,10 @@ async def _phase1_prune(
     session_id: str,
     *,
     session_factory: async_sessionmaker[AsyncSession],
-) -> int:
-    """Mark old tool outputs as truncated to reduce context size."""
+) -> tuple[int, int]:
+    """Flag old tool outputs as compacted. Returns (parts flagged, tokens freed)."""
     pruned_parts = 0
+    tokens_freed = 0
     async with session_factory() as db:
         async with db.begin():
             # Get all messages ordered by time
@@ -178,7 +212,7 @@ async def _phase1_prune(
             messages = list(result.scalars().all())
 
             if len(messages) <= SKIP_RECENT_TURNS * 2:
-                return 0  # Not enough history to prune
+                return 0, 0  # Not enough history to prune
 
             # Skip the last N turns (each turn = user + assistant)
             cutoff = len(messages) - (SKIP_RECENT_TURNS * 2)
@@ -216,17 +250,23 @@ async def _phase1_prune(
                         token_budget -= output_tokens
                         continue  # Protected
 
-                    # Mark as compacted
+                    # Flag the part as compacted, but keep the stored output.
+                    # ``get_message_history_for_llm`` substitutes "[truncated]"
+                    # from this flag alone, so the prompt is byte-identical
+                    # either way — overwriting would only destroy the user's
+                    # own copy of a tool result they may still need, and would
+                    # break the ADR-0005 promise that pruned history stays
+                    # recoverable.
                     updated_data = dict(part.data)
                     updated_state = dict(state)
-                    updated_state["output"] = "[truncated]"
                     updated_state["time_compacted"] = "auto"
                     updated_data["state"] = updated_state
                     part.data = updated_data
                     pruned_parts += 1
+                    tokens_freed += output_tokens
 
             await db.flush()
-    return pruned_parts
+    return pruned_parts, tokens_freed
 
 
 async def _phase2_summarize(
@@ -237,22 +277,22 @@ async def _phase2_summarize(
     provider_registry: ProviderRegistry,
     agent_registry: AgentRegistry,
     model_id: str | None = None,
-) -> str | None:
-    """Generate a structured summary of the conversation."""
+) -> tuple[str | None, int]:
+    """Summarise the conversation. Returns (summary, approximate tokens freed)."""
     compaction_agent = agent_registry.get("compaction")
     if not compaction_agent or not compaction_agent.system_prompt:
-        return None
+        return None, 0
 
     # Find a model
     if not model_id:
         models = provider_registry.all_models()
         if not models:
-            return None
+            return None, 0
         model_id = models[0].id
 
     resolved = provider_registry.resolve_model(model_id)
     if not resolved:
-        return None
+        return None, 0
 
     provider, model_info = resolved
 
@@ -269,7 +309,7 @@ async def _phase2_summarize(
             )
 
     if not llm_messages:
-        return None
+        return None, 0
 
     # Ask compaction agent to summarize
     try:
@@ -281,15 +321,18 @@ async def _phase2_summarize(
         summary = ""
         usage_data: dict[str, Any] = {}
         last_reported = 0
+        finish_reason: str | None = None
         async for chunk in provider.stream_chat(
             model_id,
             messages,
             system=compaction_agent.system_prompt,
-            max_tokens=4096,
+            max_tokens=SUMMARY_MAX_TOKENS,
         ):
             if job.abort_event.is_set():
                 logger.info("Compaction summarize stream aborted for session %s", session_id)
-                return None
+                return None, 0
+            if chunk.type == "finish":
+                finish_reason = chunk.data.get("reason")
             if chunk.type == "text-delta":
                 summary += chunk.data.get("text", "")
                 # Emit progress every ~200 chars to avoid flooding
@@ -326,7 +369,40 @@ async def _phase2_summarize(
                 usage_data.get("total", 0), cost, session_id,
             )
 
-        return summary.strip() if summary.strip() else None
+        summary = summary.strip()
+        if not summary:
+            return None, 0
+
+        # A summary that hit the output cap is a half-written checkpoint. It
+        # would still be non-empty, still get persisted, and — because the
+        # newest summary becomes the permanent history anchor — would replace
+        # everything it was meant to summarise with a sentence that stops
+        # mid-thought. Refuse it and let the caller's retry budget decide.
+        if finish_reason == "length":
+            logger.warning(
+                "Compaction summary for session %s hit the %d-token cap; discarding "
+                "the truncated checkpoint",
+                session_id,
+                SUMMARY_MAX_TOKENS,
+            )
+            return None, 0
+
+        # Compaction must shrink the context it anchors past. On a short or
+        # tool-light history the summary can be larger than the turns it
+        # replaces, which makes the next request worse, not better.
+        summary_tokens = estimate_tokens(summary)
+        replaced_tokens = _estimate_message_tokens(llm_messages)
+        if summary_tokens >= replaced_tokens:
+            logger.warning(
+                "Compaction summary for session %s (~%d tokens) does not shrink the "
+                "~%d tokens it would anchor past; discarding",
+                session_id,
+                summary_tokens,
+                replaced_tokens,
+            )
+            return None, 0
+
+        return summary, replaced_tokens - summary_tokens
 
     except Exception as e:
         logger.warning("Failed to generate compaction summary: %s", e)
@@ -334,7 +410,7 @@ async def _phase2_summarize(
             "session_id": session_id,
             "message": "Context compression failed. Consider starting a new chat.",
         }))
-        return None
+        return None, 0
 
 
 def should_compact(

--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -47,7 +47,27 @@ PROTECTED_TOKEN_BUDGET = 40_000  # Protect this many tokens of tool output
 SKIP_RECENT_TURNS = 2  # Don't compact the last N assistant messages
 PROTECTED_TOOLS = frozenset({"skill"})  # Never prune these tool outputs
 AUTO_COMPACT_CONTEXT_RATIO = 0.85  # Proactively compact before the hard context edge
-SUMMARY_MAX_TOKENS = 4096  # Output cap for the summary; hitting it fails the run
+SUMMARY_MAX_TOKENS = 4096  # Output cap for the summary
+SUMMARY_RETRY_MAX_TOKENS = 12_288
+"""Second-attempt cap when the first summary is cut off at the limit.
+
+Discarding a truncated checkpoint is right — it would replace everything it was
+meant to summarise with a sentence that stops mid-thought — but discarding it
+three times in a row trips the caller's circuit breaker and dead-ends a session
+that used to survive. A long history, or a reasoning model spending the budget
+before it writes any summary, needs more room, not fewer attempts.
+"""
+
+
+def _wrap_summary(summary: str, *, visible: bool) -> str:
+    """The exact text a summary is persisted as.
+
+    One definition, so the shrink guard measures what the next request will
+    actually carry rather than the bare summary.
+    """
+    if visible:
+        return f"[Context Summary]\n\n{summary}"
+    return f"[Context Summary]\n\n{summary}\n\nContinue if you have next steps."
 
 
 def _estimate_message_tokens(messages: list[dict[str, Any]]) -> int:
@@ -176,11 +196,7 @@ async def run_compaction(
                     session_id=session_id,
                     data={
                         "type": "text",
-                        "text": (
-                            f"[Context Summary]\n\n{result.summary}"
-                            if visible_summary
-                            else f"[Context Summary]\n\n{result.summary}\n\nContinue if you have next steps."
-                        ),
+                        "text": _wrap_summary(result.summary, visible=visible_summary),
                         "synthetic": True,
                     },
                 )
@@ -283,8 +299,7 @@ async def _phase1_prune(
             await db.flush()
     return pruned_parts, tokens_freed
 
-
-async def _phase2_summarize(
+async def _summarize_once(
     session_id: str,
     *,
     job: GenerationJob,
@@ -292,22 +307,27 @@ async def _phase2_summarize(
     provider_registry: ProviderRegistry,
     agent_registry: AgentRegistry,
     model_id: str | None = None,
-) -> tuple[str | None, int]:
-    """Summarise the conversation. Returns (summary, approximate tokens freed)."""
+    max_tokens: int,
+) -> tuple[str | None, int, bool]:
+    """One summarisation attempt.
+
+    Returns ``(summary, tokens freed, hit the output cap)``. The third value
+    lets the caller decide whether a larger budget is worth one more request.
+    """
     compaction_agent = agent_registry.get("compaction")
     if not compaction_agent or not compaction_agent.system_prompt:
-        return None, 0
+        return None, 0, False
 
     # Find a model
     if not model_id:
         models = provider_registry.all_models()
         if not models:
-            return None, 0
+            return None, 0, False
         model_id = models[0].id
 
     resolved = provider_registry.resolve_model(model_id)
     if not resolved:
-        return None, 0
+        return None, 0, False
 
     provider, model_info = resolved
 
@@ -324,7 +344,7 @@ async def _phase2_summarize(
             )
 
     if not llm_messages:
-        return None, 0
+        return None, 0, False
 
     # Ask compaction agent to summarize
     try:
@@ -341,11 +361,11 @@ async def _phase2_summarize(
             model_id,
             messages,
             system=compaction_agent.system_prompt,
-            max_tokens=SUMMARY_MAX_TOKENS,
+            max_tokens=max_tokens,
         ):
             if job.abort_event.is_set():
                 logger.info("Compaction summarize stream aborted for session %s", session_id)
-                return None, 0
+                return None, 0, False
             if chunk.type == "finish":
                 finish_reason = chunk.data.get("reason")
             if chunk.type == "text-delta":
@@ -386,7 +406,7 @@ async def _phase2_summarize(
 
         summary = summary.strip()
         if not summary:
-            return None, 0
+            return None, 0, False
 
         # A summary that hit the output cap is a half-written checkpoint. It
         # would still be non-empty, still get persisted, and — because the
@@ -395,17 +415,21 @@ async def _phase2_summarize(
         # mid-thought. Refuse it and let the caller's retry budget decide.
         if finish_reason == "length":
             logger.warning(
-                "Compaction summary for session %s hit the %d-token cap; discarding "
-                "the truncated checkpoint",
+                "Compaction summary for session %s hit the %d-token cap",
                 session_id,
-                SUMMARY_MAX_TOKENS,
+                max_tokens,
             )
-            return None, 0
+            return None, 0, True
 
         # Compaction must shrink the context it anchors past. On a short or
         # tool-light history the summary can be larger than the turns it
         # replaces, which makes the next request worse, not better.
-        summary_tokens = estimate_tokens(summary)
+        #
+        # Both sides are measured as they will exist in the next request: the
+        # summary is persisted inside a fixed wrapper, and counting the bare
+        # text instead leaves a permanent positive margin that reads as progress
+        # on a session where compaction is achieving nothing.
+        summary_tokens = estimate_tokens(_wrap_summary(summary, visible=False))
         replaced_tokens = _estimate_message_tokens(llm_messages)
         if summary_tokens >= replaced_tokens:
             logger.warning(
@@ -415,9 +439,9 @@ async def _phase2_summarize(
                 summary_tokens,
                 replaced_tokens,
             )
-            return None, 0
+            return None, 0, False
 
-        return summary, replaced_tokens - summary_tokens
+        return summary, replaced_tokens - summary_tokens, False
 
     except Exception as e:
         logger.warning("Failed to generate compaction summary: %s", e)
@@ -425,7 +449,33 @@ async def _phase2_summarize(
             "session_id": session_id,
             "message": "Context compression failed. Consider starting a new chat.",
         }))
-        return None, 0
+        return None, 0, False
+
+
+
+async def _phase2_summarize(
+    session_id: str,
+    *,
+    job: GenerationJob,
+    session_factory: async_sessionmaker[AsyncSession],
+    provider_registry: ProviderRegistry,
+    agent_registry: AgentRegistry,
+    model_id: str | None = None,
+) -> tuple[str | None, int]:
+    """Summarise the conversation. Returns (summary, approximate tokens freed)."""
+    for max_tokens in (SUMMARY_MAX_TOKENS, SUMMARY_RETRY_MAX_TOKENS):
+        summary, freed, hit_cap = await _summarize_once(
+            session_id,
+            job=job,
+            session_factory=session_factory,
+            provider_registry=provider_registry,
+            agent_registry=agent_registry,
+            model_id=model_id,
+            max_tokens=max_tokens,
+        )
+        if not hit_cap:
+            return summary, freed
+    return None, 0
 
 
 def should_compact(

--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -19,11 +19,12 @@ from typing import Any
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
 from app.agent.agent import AgentRegistry
 from app.models.message import Message, Part
 from app.provider.registry import ProviderRegistry
-from app.session.manager import create_message, create_part
+from app.session.manager import create_message, create_part, prompt_visible_messages
 from app.streaming.events import (
     COMPACTED,
     COMPACTION_ERROR,
@@ -50,18 +51,26 @@ SUMMARY_MAX_TOKENS = 4096  # Output cap for the summary; hitting it fails the ru
 
 
 def _estimate_message_tokens(messages: list[dict[str, Any]]) -> int:
-    """Approximate the context cost of an LLM message list."""
+    """Approximate the context cost of an LLM message list.
+
+    Counts every field that reaches the request body. ``reasoning_content`` is
+    one of them: ``get_message_history_for_llm`` attaches it to assistant turns
+    for DeepSeek-family and custom OpenAI-compatible providers, up to 40k chars
+    per turn. Omitting it under-counts the history so badly that the shrink
+    guard rejects perfectly good summaries on exactly those providers.
+    """
     total = 0
     for message in messages:
-        content = message.get("content")
-        if isinstance(content, str):
-            total += estimate_tokens(content)
-        elif isinstance(content, list):
-            for block in content:
-                if isinstance(block, dict):
-                    text = block.get("text")
-                    if isinstance(text, str):
-                        total += estimate_tokens(text)
+        for key in ("content", "reasoning_content"):
+            value = message.get(key)
+            if isinstance(value, str):
+                total += estimate_tokens(value)
+            elif isinstance(value, list):
+                for block in value:
+                    if isinstance(block, dict):
+                        text = block.get("text")
+                        if isinstance(text, str):
+                            total += estimate_tokens(text)
         for call in message.get("tool_calls") or []:
             function = call.get("function") if isinstance(call, dict) else None
             if isinstance(function, dict):
@@ -206,10 +215,16 @@ async def _phase1_prune(
             stmt = (
                 select(Message)
                 .where(Message.session_id == session_id)
+                .options(selectinload(Message.parts))
                 .order_by(Message.time_created.asc())
             )
             result = await db.execute(stmt)
-            messages = list(result.scalars().all())
+            # Only rows the model still sees can free context. A row already
+            # collapsed, or sitting before the newest compaction anchor, is out
+            # of the prompt either way — flagging its tool parts changes nothing
+            # and would credit `tokens_freed` for a saving that does not exist,
+            # which is now what resets the compaction circuit breaker.
+            messages = prompt_visible_messages(list(result.scalars().all()))
 
             if len(messages) <= SKIP_RECENT_TURNS * 2:
                 return 0, 0  # Not enough history to prune

--- a/backend/app/session/middleware.py
+++ b/backend/app/session/middleware.py
@@ -7,10 +7,9 @@ in SessionProcessor with a pluggable chain.
 Middleware hooks:
   - before_llm_call(messages, ctx) → messages
     Modify messages before sending to LLM. Return modified messages.
-  - after_llm_response(text, tool_calls, ctx) → (text, tool_calls)
-    Inspect/modify LLM response before tool execution.
   - before_tool_exec(tool_name, tool_args, ctx) → ToolAction
-    Decide whether to allow, warn, or block a tool call.
+    Decide whether to allow, warn, or block a tool call. The strictest
+    verdict across the chain wins, and every middleware runs regardless.
   - after_tool_exec(tool_name, tool_args, result, ctx) → result_output
     Modify tool result output before it's persisted.
   - on_step_complete(ctx) → None
@@ -56,6 +55,10 @@ class ToolAction:
     message: str | None = None  # Warning/block message
 
 
+# How the chain combines verdicts from several middlewares: strictest wins.
+_STRICTNESS = {"allow": 0, "warn": 1, "block": 2}
+
+
 class Middleware:
     """Base middleware class with no-op defaults for all hooks.
 
@@ -69,15 +72,6 @@ class Middleware:
     ) -> list[dict[str, Any]]:
         """Called before LLM invocation. Return (possibly modified) messages."""
         return messages
-
-    async def after_llm_response(
-        self,
-        text: str,
-        tool_calls: list[dict[str, Any]],
-        ctx: MiddlewareContext,
-    ) -> tuple[str, list[dict[str, Any]]]:
-        """Called after LLM responds. Return (possibly modified) text and tool_calls."""
-        return text, tool_calls
 
     async def before_tool_exec(
         self,
@@ -125,28 +119,27 @@ class MiddlewareChain:
             messages = await mw.before_llm_call(messages, ctx)
         return messages
 
-    async def run_after_llm_response(
-        self,
-        text: str,
-        tool_calls: list[dict[str, Any]],
-        ctx: MiddlewareContext,
-    ) -> tuple[str, list[dict[str, Any]]]:
-        for mw in self._middlewares:
-            text, tool_calls = await mw.after_llm_response(text, tool_calls, ctx)
-        return text, tool_calls
-
     async def run_before_tool_exec(
         self,
         tool_name: str,
         tool_args: dict[str, Any],
         ctx: MiddlewareContext,
     ) -> ToolAction:
-        """Run before_tool_exec on all middlewares. First non-allow result wins."""
+        """Run before_tool_exec on every middleware; the strictest verdict wins.
+
+        Every middleware runs even once one has decided to block, because a
+        middleware's job here is partly to observe (loop detection counts the
+        call, and stashes a warning for ``after_tool_exec``). Returning on the
+        first non-allow would make the outcome depend on registration order —
+        add a blocking policy above loop detection and the loop counter
+        silently stops advancing.
+        """
+        verdict = ToolAction(action="allow")
         for mw in self._middlewares:
             result = await mw.before_tool_exec(tool_name, tool_args, ctx)
-            if result.action != "allow":
-                return result
-        return ToolAction(action="allow")
+            if _STRICTNESS[result.action] > _STRICTNESS[verdict.action]:
+                verdict = result
+        return verdict
 
     async def run_after_tool_exec(
         self,

--- a/backend/app/session/middlewares/loop_detection.py
+++ b/backend/app/session/middlewares/loop_detection.py
@@ -16,6 +16,21 @@ from app.session.middleware import Middleware, MiddlewareContext, ToolAction
 class LoopDetectionMiddleware(Middleware):
     """Two-stage warn-then-stop loop detection for tool calls."""
 
+    _SLOT = "_loop_warnings"
+
+    @staticmethod
+    def _key(tool_name: str, tool_args: dict[str, Any]) -> str:
+        """Identify the call a warning belongs to.
+
+        ``before_tool_exec`` runs for every call as its chunk streams in, while
+        ``after_tool_exec`` runs later, once per call, during dispatch. A single
+        shared slot would be popped by whichever call finishes first, so a
+        warning earned by a repeated ``read`` could be appended to an unrelated
+        ``bash`` in the same step. Keying by the call's own identity — the same
+        (name, args) pair the detector counts — puts it back on its own result.
+        """
+        return f"{tool_name}:{sorted(tool_args.items())!r}"
+
     async def before_tool_exec(
         self,
         tool_name: str,
@@ -28,8 +43,8 @@ class LoopDetectionMiddleware(Middleware):
         if result.action == "block":
             return ToolAction(action="block", message=result.message)
         if result.action == "warn":
-            # Store warning for after_tool_exec to inject
-            ctx.extra["_loop_warning"] = result.message
+            warnings: dict[str, str] = ctx.extra.setdefault(self._SLOT, {})
+            warnings[self._key(tool_name, tool_args)] = result.message or ""
         return ToolAction(action="allow")
 
     async def after_tool_exec(
@@ -39,7 +54,10 @@ class LoopDetectionMiddleware(Middleware):
         output: str,
         ctx: MiddlewareContext,
     ) -> str:
-        warning = ctx.extra.pop("_loop_warning", None)
+        warnings = ctx.extra.get(self._SLOT)
+        if not warnings:
+            return output
+        warning = warnings.pop(self._key(tool_name, tool_args), None)
         if warning:
             output += f"\n\n{warning}"
         return output

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -29,15 +29,18 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.agent.agent import AgentRegistry
 from app.agent.permission import (
     RejectedError,
+    agent_verdict,
     evaluate,
     pattern_matches,
 )
+from app.provider.base import ProviderStreamError
 from app.provider.registry import ProviderRegistry
 from app.schemas.agent import PermissionRule
 from app.schemas.chat import PromptRequest
 from app.schemas.message import StepFinishReason
 from app.session.llm import stream_llm
 from app.session.loop_detection import LoopCheckResult, loop_detector
+from app.session.middleware import ToolAction
 from app.session.manager import (
     create_part,
     get_messages,
@@ -560,8 +563,12 @@ class SessionProcessor:
     async def _stream_llm_with_retry(self) -> Literal["stop"] | None:
         """Stream from the LLM with retry. Mutates self._accumulated_*, self._stream_error.
 
-        Returns "stop" early only for fatal in-stream conditions (non-vision model
-        received images, or the stream chunk reported an explicit error).
+        Every stream failure arrives as a raised exception — providers never
+        signal one with a chunk — so all of them reach the classifier below and
+        share one backoff, retry budget, and context-overflow recovery path.
+
+        Returns "stop" early only for a non-vision model that was sent images;
+        stream failures leave ``self._stream_error`` set for the caller.
         """
         sp = self._sp
         job = sp.job
@@ -656,7 +663,14 @@ class SessionProcessor:
                             )
 
                         case "error":
-                            return await self._handle_stream_error_chunk(chunk)
+                            # Defensive net for a provider that still yields an
+                            # error chunk instead of raising (custom or
+                            # third-party). Raising routes it through the same
+                            # classifier as every other stream failure.
+                            raise ProviderStreamError(
+                                str(chunk.data.get("message", "LLM error")),
+                                code=chunk.data.get("code"),
+                            )
 
                 self._stream_error = None
                 logger.info(
@@ -842,18 +856,27 @@ class SessionProcessor:
             and isinstance(raw_tool_args, dict)
         )
 
-        # Loop detection
-        lr: LoopCheckResult = loop_detector.check(job.session_id, tn, ta)
-        if lr.action == "block":
+        # Pre-execution policy. Loop detection lives in the middleware chain
+        # rather than inline here, so its warn stage (which stashes a message
+        # for after_tool_exec to append) actually runs, and so any other policy
+        # middleware gets the same hook instead of a seam nothing calls.
+        if self._mw_ctx is not None:
+            decision = await sp.middleware_chain.run_before_tool_exec(tn, ta, self._mw_ctx)
+        else:
+            lr: LoopCheckResult = loop_detector.check(job.session_id, tn, ta)
+            decision = ToolAction(
+                action="block" if lr.action == "block" else "allow", message=lr.message
+            )
+        if decision.action == "block":
             job.publish(SSEEvent(AGENT_ERROR, {
                 "error_type": "loop_detected",
-                "error_message": lr.message,
+                "error_message": decision.message,
                 "tool": tn,
             }))
             await _persist_tool_error(
                 session_factory, self._assistant_msg_id,
                 job.session_id, tn, ci, ta,
-                lr.message or "Loop detected — hard stop",
+                decision.message or "Loop detected — hard stop",
             )
             self._exec_blocked = True
             return
@@ -946,7 +969,7 @@ class SessionProcessor:
                 if parsed.scheme in {"http", "https"} and parsed.hostname:
                     port = f":{parsed.port}" if parsed.port else ""
                     rp = f"{parsed.scheme.lower()}://{parsed.hostname.lower()}{port}"
-        if evaluate(tool.id, rp, sp.agent.permissions) == "deny":
+        if agent_verdict(tool.id, rp, sp.agent.permissions) == "deny":
             message = f"Agent policy denied tool: {tool.id}"
             job.publish(SSEEvent(TOOL_ERROR, {
                 "call_id": ci,
@@ -1036,9 +1059,13 @@ class SessionProcessor:
             "tool_registry": sp.tool_registry,
             "stream_manager": get_stream_manager(),
         }
+        # What a subagent inherits (via task/swarm) — this session's decisions
+        # without the global defaults the child re-applies itself. Handing down
+        # the fully merged set instead would carry ``allow *`` into the child's
+        # request layer, outranking its own agent-level denials.
         effective_permission_rules = tuple(
             rule.model_dump()
-            for rule in sp.merged_permissions.rules
+            for rule in sp.inheritable_permissions.rules
         )
         ctx = ToolContext(
             session_id=job.session_id,
@@ -1204,27 +1231,6 @@ class SessionProcessor:
                 "metadata": ws_metadata,
             },
         ))
-
-    async def _handle_stream_error_chunk(self, chunk: Any) -> Literal["stop"]:
-        """Mid-stream 'error' chunk: persist any accumulated text + publish error + clean up."""
-        sp = self._sp
-        job = sp.job
-
-        if self._accumulated_text:
-            async with sp.session_factory() as db:
-                async with db.begin():
-                    await create_part(
-                        db,
-                        message_id=self._assistant_msg_id,
-                        session_id=job.session_id,
-                        data={"type": "text", "text": self._accumulated_text},
-                    )
-        job.publish(SSEEvent(
-            AGENT_ERROR,
-            {"error_message": chunk.data.get("message", "LLM error")},
-        ))
-        await _delete_empty_assistant_messages(sp.session_factory, job.session_id)
-        return "stop"
 
     # ------------------------------------------------------------------
     # process() phases — post-stream
@@ -1991,6 +1997,10 @@ async def _remember_permission_rule(
     ]
     sp.session_permissions.rules.append(rule)
     sp.merged_permissions.rules.append(rule)
+    # Subagents must see a remembered *denial* too: a non-interactive child
+    # cannot prompt, so an inherited "ask" would execute where the user has
+    # already said no.
+    sp.inheritable_permissions.rules.append(rule)
 
 
 def _permission_arguments_for_event(

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -877,22 +877,22 @@ class SessionProcessor:
         # for after_tool_exec to append) actually runs, and so any other policy
         # middleware gets the same hook instead of a seam nothing calls.
         if self._mw_ctx is not None:
-            decision = await sp.middleware_chain.run_before_tool_exec(tn, ta, self._mw_ctx)
+            policy = await sp.middleware_chain.run_before_tool_exec(tn, ta, self._mw_ctx)
         else:
             # No chain (direct construction in tests) — run the detector itself
             # so loop protection is never silently absent.
             lr: LoopCheckResult = loop_detector.check(job.session_id, tn, ta)
-            decision = ToolAction(action=lr.action, message=lr.message)
-        if decision.action == "block":
+            policy = ToolAction(action=lr.action, message=lr.message)
+        if policy.action == "block":
             job.publish(SSEEvent(AGENT_ERROR, {
                 "error_type": "loop_detected",
-                "error_message": decision.message,
+                "error_message": policy.message,
                 "tool": tn,
             }))
             await _persist_tool_error(
                 session_factory, self._assistant_msg_id,
                 job.session_id, tn, ci, ta,
-                decision.message or "Loop detected — hard stop",
+                policy.message or "Loop detected — hard stop",
             )
             self._exec_blocked = True
             return
@@ -1075,14 +1075,7 @@ class SessionProcessor:
             "tool_registry": sp.tool_registry,
             "stream_manager": get_stream_manager(),
         }
-        # What a subagent inherits (via task/swarm) — this session's decisions
-        # without the global defaults the child re-applies itself. Handing down
-        # the fully merged set instead would carry ``allow *`` into the child's
-        # request layer, outranking its own agent-level denials.
-        effective_permission_rules = tuple(
-            rule.model_dump()
-            for rule in sp.inheritable_permissions.rules
-        )
+        effective_permission_rules = self._inheritable_permission_rules()
         ctx = ToolContext(
             session_id=job.session_id,
             message_id=self._assistant_msg_id,
@@ -1129,7 +1122,7 @@ class SessionProcessor:
         ))
         self._exec_metadata[self._exec_index] = {
             "tool_part_id": tool_part_id,
-            "policy_decision": decision,
+            "policy_decision": policy,
             "tool": tool,
             "tool_args": ta,
             "call_id": ci,
@@ -1258,9 +1251,24 @@ class SessionProcessor:
         job = sp.job
 
         # The stream can fail after tool calls were dispatched. Nothing else
-        # will collect them from here, so terminate their persisted "running"
-        # parts rather than leaving the session with rows that never resolve.
+        # will collect them from here, so record what actually happened and
+        # terminate the rest, rather than leaving rows that never resolve.
         if self._streaming_executor.has_submissions:
+            # Tools that finished during streaming really did run. Persist their
+            # real outcome first — sweeping them into the cancellation cleanup
+            # would tell the user an email was not sent when it was.
+            for exec_result in self._streaming_executor.harvest_finished():
+                meta = self._exec_metadata.get(exec_result.index)
+                if meta is None:
+                    continue
+                try:
+                    await self._finalize_exec_result(exec_result.index, meta, exec_result)
+                except Exception:
+                    logger.warning(
+                        "Could not persist a tool result after the stream failed; "
+                        "cancellation cleanup will terminate its part",
+                        exc_info=True,
+                    )
             await self._cancel_running_tools()
 
         # --- Reactive compact: recover from context overflow via compaction ---
@@ -1460,6 +1468,19 @@ class SessionProcessor:
                 )
 
         return None
+
+    def _inheritable_permission_rules(self) -> tuple[dict[str, Any], ...]:
+        """The rules a subagent spawned from this turn will be given.
+
+        ``task`` and ``swarm`` pass ``ToolContext.permission_rules`` straight to
+        the child, where it lands in the request layer — *after* the child's own
+        agent rules under last-match-wins. So it must carry this session's
+        restrictions and nothing permissive: handing down the fully merged set
+        would put the global ``allow *`` above the child's own ``deny *``.
+        """
+        return tuple(
+            rule.model_dump() for rule in self._sp.inheritable_permissions.rules
+        )
 
     async def _cancel_running_tools(self) -> None:
         """Cancel executor work and durably terminate every running ToolPart."""

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -705,6 +705,22 @@ class SessionProcessor:
                 retry_reason = is_retryable(e)
                 effective_max = max_retries_for_error(e)
 
+                if retry_reason and self._streaming_executor.has_submissions:
+                    # Tool calls from this attempt are already dispatched, and
+                    # some have side effects that cannot be taken back — a sent
+                    # email, a written file. Replaying the stream would submit
+                    # them a second time, because the executor and
+                    # ``_exec_metadata`` outlive ``_reset_stream_accumulators``.
+                    # Stop instead and let the outer loop surface the failure
+                    # with whatever the tools produced.
+                    logger.warning(
+                        "Stream failed after %d tool call(s) were dispatched; not "
+                        "retrying to avoid re-running them: %s",
+                        len(self._tool_calls_in_step),
+                        e,
+                    )
+                    retry_reason = None
+
                 if retry_reason and attempt < effective_max:
                     delay = retry_delay(attempt, e)
                     logger.warning(
@@ -863,10 +879,10 @@ class SessionProcessor:
         if self._mw_ctx is not None:
             decision = await sp.middleware_chain.run_before_tool_exec(tn, ta, self._mw_ctx)
         else:
+            # No chain (direct construction in tests) — run the detector itself
+            # so loop protection is never silently absent.
             lr: LoopCheckResult = loop_detector.check(job.session_id, tn, ta)
-            decision = ToolAction(
-                action="block" if lr.action == "block" else "allow", message=lr.message
-            )
+            decision = ToolAction(action=lr.action, message=lr.message)
         if decision.action == "block":
             job.publish(SSEEvent(AGENT_ERROR, {
                 "error_type": "loop_detected",
@@ -1113,7 +1129,7 @@ class SessionProcessor:
         ))
         self._exec_metadata[self._exec_index] = {
             "tool_part_id": tool_part_id,
-            "loop_result": lr,
+            "policy_decision": decision,
             "tool": tool,
             "tool_args": ta,
             "call_id": ci,
@@ -1241,6 +1257,12 @@ class SessionProcessor:
         sp = self._sp
         job = sp.job
 
+        # The stream can fail after tool calls were dispatched. Nothing else
+        # will collect them from here, so terminate their persisted "running"
+        # parts rather than leaving the session with rows that never resolve.
+        if self._streaming_executor.has_submissions:
+            await self._cancel_running_tools()
+
         # --- Reactive compact: recover from context overflow via compaction ---
         # Inspired by Claude Code's reactive compact pattern.
         if is_context_overflow(self._stream_error):
@@ -1251,7 +1273,14 @@ class SessionProcessor:
             await _delete_empty_assistant_messages(sp.session_factory, job.session_id)
             return "compact"
 
-        logger.exception("LLM stream error (not retryable or retries exhausted)")
+        # Not inside an `except` block — `logger.exception` here would append a
+        # bare "NoneType: None". Carry the exception explicitly; this line is
+        # the primary diagnostic for every provider stream failure.
+        logger.error(
+            "LLM stream error (not retryable or retries exhausted): %s",
+            self._stream_error,
+            exc_info=self._stream_error,
+        )
         self.has_text = bool(self._accumulated_text.strip())
         self.finish_reason = "error"
         if self._accumulated_text or self._accumulated_reasoning:
@@ -1530,7 +1559,7 @@ class SessionProcessor:
         session_factory = sp.session_factory
 
         tool_part_id = meta["tool_part_id"]
-        loop_result = meta["loop_result"]
+        policy_decision = meta["policy_decision"]
         tool = meta["tool"]
         tool_args = meta["tool_args"]
         call_id = meta["call_id"]
@@ -1612,7 +1641,7 @@ class SessionProcessor:
 
         await self._apply_tool_side_effects(tool, result)
         persist_output = await self._build_tool_persist_output(
-            tool, tool_args, result, loop_result,
+            tool, tool_args, result, policy_decision,
         )
 
         # Persist file attachments returned by the tool as FileParts
@@ -1730,7 +1759,7 @@ class SessionProcessor:
         tool: Any,
         tool_args: dict[str, Any],
         result: Any,
-        loop_result: Any,
+        policy_decision: ToolAction,
     ) -> str:
         """Assemble the output text persisted to the tool part (+ reminders, middleware)."""
         sp = self._sp
@@ -1739,9 +1768,16 @@ class SessionProcessor:
         if result.success:
             persist_output += _presentation_reminder(tool.id, result.metadata)
 
-        # Inject loop warning into output so LLM sees it
-        if loop_result.action == "warn" and loop_result.message:
-            persist_output += f"\n\n{loop_result.message}"
+        # A "warn" verdict is appended by LoopDetectionMiddleware.after_tool_exec
+        # (via the message it stashed in before_tool_exec), so only the
+        # chain-less path has to do it here — mirroring the run_after_tool_exec
+        # call at the end of this method.
+        if (
+            self._mw_ctx is None
+            and policy_decision.action == "warn"
+            and policy_decision.message
+        ):
+            persist_output += f"\n\n{policy_decision.message}"
 
         if (
             tool.id in _MODIFYING_TOOLS

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -2054,10 +2054,9 @@ async def _remember_permission_rule(
     ]
     sp.session_permissions.rules.append(rule)
     sp.merged_permissions.rules.append(rule)
-    # Subagents must see a remembered *denial* too: a non-interactive child
-    # cannot prompt, so an inherited "ask" would execute where the user has
-    # already said no.
-    sp.inheritable_permissions.rules.append(rule)
+    # `inheritable_permissions` picks this up on its own: it is derived from
+    # `session_permissions` above, so a remembered denial reaches subagents
+    # while still sitting *below* the agent-denial ceiling.
 
 
 def _permission_arguments_for_event(

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -112,6 +112,7 @@ class SessionPrompt:
         self.workspace_memory_section: str | None = None
         self.system_prompt_parts: SystemPromptParts | None = None
         self.merged_permissions: list = []
+        self.inheritable_permissions: list = []
         self.request_permissions: list = []
         self.preset_permissions: list = []
         self.session_permissions: list = []
@@ -381,6 +382,7 @@ class SessionPrompt:
         self.preset_permissions = presets_to_ruleset(self.request.permission_presets)
         self.request_permissions = parse_session_permissions(self.request.permission_rules)
         self.merged_permissions = self._merge_effective_permissions()
+        self.inheritable_permissions = self._merge_inheritable_permissions()
 
         # --- Reconstruct artifact cache from message history ---
         # Allows update/rewrite operations to work across generations.
@@ -577,6 +579,25 @@ class SessionPrompt:
                 "total": processor.usage_data.get("total", 0),
             }
 
+    def _record_compaction_failure(self) -> bool:
+        """Count one unproductive compaction. Returns True when the loop must stop."""
+        self._consecutive_compact_failures += 1
+        logger.warning(
+            "Compaction freed nothing (%d/%d) for session %s",
+            self._consecutive_compact_failures,
+            self._MAX_CONSECUTIVE_COMPACT_FAILURES,
+            self.job.session_id,
+        )
+        if self._consecutive_compact_failures >= self._MAX_CONSECUTIVE_COMPACT_FAILURES:
+            self.job.publish(SSEEvent(AGENT_ERROR, {
+                "error_message": (
+                    "Context compression failed repeatedly. "
+                    "Please start a new conversation."
+                ),
+            }))
+            return True
+        return False
+
     async def _handle_compact_result(self) -> bool:
         """Handle ``result == 'compact'``.
 
@@ -646,7 +667,7 @@ class SessionPrompt:
                     )
 
             try:
-                await run_compaction(
+                compaction = await run_compaction(
                     self.job.session_id,
                     job=self.job,
                     session_factory=self.session_factory,
@@ -654,23 +675,21 @@ class SessionPrompt:
                     agent_registry=self.agent_registry,
                     model_id=self.model_id,
                 )
-                self._consecutive_compact_failures = 0
             except Exception:
-                self._consecutive_compact_failures += 1
                 logger.warning(
-                    "Compaction failed (%d/%d) for session %s",
-                    self._consecutive_compact_failures,
-                    self._MAX_CONSECUTIVE_COMPACT_FAILURES,
-                    self.job.session_id,
-                    exc_info=True,
+                    "Compaction raised for session %s", self.job.session_id, exc_info=True
                 )
-                if self._consecutive_compact_failures >= self._MAX_CONSECUTIVE_COMPACT_FAILURES:
-                    self.job.publish(SSEEvent(AGENT_ERROR, {
-                        "error_message": (
-                            "Context compression failed repeatedly. "
-                            "Please start a new conversation."
-                        ),
-                    }))
+                if self._record_compaction_failure():
+                    return True
+            else:
+                # run_compaction swallows provider failures and returns a result
+                # that freed nothing. Counting that as success would let a
+                # compaction loop that never reclaims anything reset its own
+                # circuit breaker on every pass, leaving only the step cap to
+                # stop it.
+                if compaction.tokens_freed > 0:
+                    self._consecutive_compact_failures = 0
+                elif self._record_compaction_failure():
                     return True
 
         # Todo context recovery: after compaction the LLM may have lost
@@ -905,6 +924,7 @@ class SessionPrompt:
         Called by SessionProcessor when the plan tool switches agents.
         """
         self.merged_permissions = self._merge_effective_permissions()
+        self.inheritable_permissions = self._merge_inheritable_permissions()
         self.system_prompt_parts = self._build_system_prompt_parts()
 
     # ------------------------------------------------------------------
@@ -926,6 +946,34 @@ class SessionPrompt:
         return merge_rulesets(
             GLOBAL_DEFAULTS,
             self.agent.permissions,
+            self.preset_permissions,
+            self.request_permissions,
+            self.session_permissions,
+        )
+
+    def _merge_inheritable_permissions(self) -> Ruleset:
+        """The rules a subagent inherits — restrictions only, never defaults.
+
+        A child slots inherited rules in *after* its own agent layer, and
+        last-match-wins means anything permissive here outranks the child's own
+        ``deny``. So two things stay out:
+
+        - ``GLOBAL_DEFAULTS``, which the child re-applies as its own first
+          layer. Passing this session's copy down would put a second
+          ``allow *`` above the child's restrictions.
+        - This agent's *permissive* rules. A persona's ``allow``/``ask``
+          defaults describe this agent, not the one being spawned; the child
+          has its own. Only the parent's denials are a ceiling, so a read-only
+          Plan session cannot delegate its way around itself.
+
+        The user's own choices — presets, request rules, session rules, and
+        remembered approvals — pass through whole and keep narrowing the child.
+        """
+        agent_denials = Ruleset(
+            rules=[rule for rule in self.agent.permissions.rules if rule.action == "deny"]
+        )
+        return merge_rulesets(
+            agent_denials,
             self.preset_permissions,
             self.request_permissions,
             self.session_permissions,

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -23,13 +23,14 @@ from app.agent.agent import AgentRegistry
 from app.agent.agent import ULTRA_PROMPT
 from app.agent.permission import (
     GLOBAL_DEFAULTS,
+    agent_verdict,
     merge_rulesets,
     parse_session_permissions,
     presets_to_ruleset,
 )
 from app.models.message import Message, Part
 from app.provider.registry import ProviderRegistry
-from app.schemas.agent import Ruleset
+from app.schemas.agent import PermissionRule, Ruleset
 from app.schemas.chat import PromptRequest
 from app.session.manager import (
     create_message,
@@ -112,7 +113,6 @@ class SessionPrompt:
         self.workspace_memory_section: str | None = None
         self.system_prompt_parts: SystemPromptParts | None = None
         self.merged_permissions: list = []
-        self.inheritable_permissions: list = []
         self.request_permissions: list = []
         self.preset_permissions: list = []
         self.session_permissions: list = []
@@ -162,6 +162,17 @@ class SessionPrompt:
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
+
+    @property
+    def inheritable_permissions(self) -> Ruleset:
+        """Recomputed on every read, never snapshotted.
+
+        A stored copy invites callers to append to it — and ``_remember_permission_rule``
+        did, landing a remembered ``allow`` *after* the agent denials that are
+        placed last precisely so nothing permissive can outrank them. Deriving
+        it keeps the layer order authoritative in one place.
+        """
+        return self._merge_inheritable_permissions()
 
     @property
     def system_prompt(self) -> str | list[dict[str, Any]]:
@@ -382,7 +393,6 @@ class SessionPrompt:
         self.preset_permissions = presets_to_ruleset(self.request.permission_presets)
         self.request_permissions = parse_session_permissions(self.request.permission_rules)
         self.merged_permissions = self._merge_effective_permissions()
-        self.inheritable_permissions = self._merge_inheritable_permissions()
 
         # --- Reconstruct artifact cache from message history ---
         # Allows update/rewrite operations to work across generations.
@@ -924,7 +934,6 @@ class SessionPrompt:
         Called by SessionProcessor when the plan tool switches agents.
         """
         self.merged_permissions = self._merge_effective_permissions()
-        self.inheritable_permissions = self._merge_inheritable_permissions()
         self.system_prompt_parts = self._build_system_prompt_parts()
 
     # ------------------------------------------------------------------
@@ -969,9 +978,6 @@ class SessionPrompt:
         The user's own choices — presets, request rules, session rules, and
         remembered approvals — pass through whole and keep narrowing the child.
         """
-        agent_denials = Ruleset(
-            rules=[rule for rule in self.agent.permissions.rules if rule.action == "deny"]
-        )
         return merge_rulesets(
             self.preset_permissions,
             self.request_permissions,
@@ -980,7 +986,25 @@ class SessionPrompt:
             # default. Placing them first would let an Auto preset's
             # `allow file_changes` re-open exactly what a Plan session forbids,
             # inside the very ruleset meant to constrain the child.
-            agent_denials,
+            self._agent_denial_ceiling(),
+        )
+
+    def _agent_denial_ceiling(self) -> Ruleset:
+        """This agent's effective denials, resolved per tool.
+
+        Copying the agent's literal ``deny`` rules does not work: every
+        restrictive agent here is written as ``deny *`` followed by an
+        allow-list, so the copy keeps the ``deny *`` and drops everything that
+        re-opens it — handing a child a ceiling that forbids all tools. Asking
+        for the agent's *verdict* on each known tool preserves the allow-list,
+        because the verdict already accounts for it.
+        """
+        return Ruleset(
+            rules=[
+                PermissionRule(action="deny", permission=tool.id)
+                for tool in self.tool_registry.all_tools()
+                if agent_verdict(tool.id, "*", self.agent.permissions) == "deny"
+            ]
         )
 
     def _build_system_prompt_parts(self) -> SystemPromptParts:

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -973,10 +973,14 @@ class SessionPrompt:
             rules=[rule for rule in self.agent.permissions.rules if rule.action == "deny"]
         )
         return merge_rulesets(
-            agent_denials,
             self.preset_permissions,
             self.request_permissions,
             self.session_permissions,
+            # Last, so last-match-wins makes these a ceiling rather than a
+            # default. Placing them first would let an Auto preset's
+            # `allow file_changes` re-open exactly what a Plan session forbids,
+            # inside the very ruleset meant to constrain the child.
+            agent_denials,
         )
 
     def _build_system_prompt_parts(self) -> SystemPromptParts:
@@ -1054,7 +1058,16 @@ def _collapsed_row_stats(rows: list[Message]) -> tuple[int, int, int, int]:
                 tool_results += 1
                 state = pdata.get("state", {}) or {}
                 tokens += estimate_tokens(str(state.get("input", "")))
-                tokens += estimate_tokens(str(state.get("output", "")))
+                # A part compaction already pruned costs the prompt the
+                # "[truncated]" placeholder, not its stored output — the row
+                # keeps the original text so the user can still read it. Count
+                # what the model sees, or this number (which is shown to the
+                # user in the collapse boundary) claims a saving that is not
+                # there.
+                if state.get("time_compacted"):
+                    tokens += estimate_tokens("[truncated]")
+                else:
+                    tokens += estimate_tokens(str(state.get("output", "")))
     return tokens, users, assistants, tool_results
 
 

--- a/backend/app/session/retry.py
+++ b/backend/app/session/retry.py
@@ -23,14 +23,20 @@ MAX_RETRIES = 5  # Increased from 3 (Claude Code uses 10)
 # Capacity overload (529) — retry for foreground, fail fast for background
 MAX_OVERLOAD_RETRIES = 3  # Separate limit for 529 to prevent amplification
 
-# Context overflow keywords — NEVER retry these (handled by reactive compact instead)
+# Context overflow keywords — NEVER retry these (handled by reactive compact
+# instead). Each must name the *input* being too large. A bare "max_tokens"
+# does not: providers reject an oversized completion budget with a 400 that
+# mentions the parameter by name, and treating that as overflow sends the
+# session into a compaction loop that can never fix it.
 _OVERFLOW_PATTERNS = [
     "context_length_exceeded",
     "maximum context length",
-    "max_tokens",
+    "max_tokens is too large",
+    "exceed context limit",
     "too many tokens",
     "context window",
     "input too long",
+    "prompt is too long",
 ]
 
 # Capacity overload patterns

--- a/backend/app/session/tool_executor.py
+++ b/backend/app/session/tool_executor.py
@@ -1,13 +1,21 @@
-"""Streaming tool executor — inspired by Claude Code's StreamingToolExecutor.
+"""Streaming tool executor — overlaps tool I/O with LLM streaming.
 
-Key behavior:
-  - Tools can be submitted during LLM streaming (before streaming completes)
-  - Concurrent-safe tools start executing immediately in background tasks
-  - Exclusive tools are queued and run sequentially after concurrent ones
-  - Results are collected in submission order after streaming completes
+Tools are submitted as their call chunks arrive, so a read can start before the
+model has finished writing the next call. That overlap is the point of this
+class; the ordering rules below are what keep it safe.
 
-This overlaps LLM network latency with tool I/O — the core performance
-insight from Claude Code's architecture.
+**Execution follows model order.** An exclusive tool is a barrier: everything
+the model asked for before it finishes first, and nothing after it starts until
+it is done. Running every concurrent tool first and the exclusive ones
+afterwards would be faster and wrong — the model that emits
+``[write(f), read(f)]`` means "write, then read what I wrote", and reordering
+silently answers from the pre-write file. Results are reported in model order
+either way, so a reordering bug is invisible in the transcript.
+
+**Concurrency is bounded.** A run of consecutive concurrency-safe calls executes
+in parallel up to ``max_parallel_tool_calls``. Unbounded fan-out puts one
+model turn's worth of ``web_fetch`` calls on the network at once, from the
+user's own machine and against their own rate limits.
 """
 
 from __future__ import annotations
@@ -23,9 +31,11 @@ from app.tool.context import ToolContext
 logger = logging.getLogger(__name__)
 
 
-# Bash errors cancel sibling concurrent tools (inspired by Claude Code).
-# Bash commands often form implicit dependency chains — if one fails,
-# continuing siblings is pointless and can cause confusing cascading errors.
+# A failure in one of these cancels the calls the model placed *after* it.
+# Bash commands form implicit dependency chains — once one fails, running the
+# rest produces confusing cascading errors against a state that never happened.
+# Only later calls are cancelled: an earlier one has already run, and under the
+# barrier rules its result was correct when it was produced.
 SIBLING_ABORT_TOOLS = frozenset({"bash"})
 
 
@@ -101,136 +111,175 @@ class StreamingToolExecutor:
         results = await executor.collect()
     """
 
-    def __init__(self, abort_event: asyncio.Event) -> None:
+    def __init__(
+        self, abort_event: asyncio.Event, *, max_parallel: int | None = None
+    ) -> None:
         self._abort = abort_event
-        self._concurrent_tasks: list[tuple[ToolCallInfo, asyncio.Task]] = []
-        self._exclusive_queue: list[ToolCallInfo] = []
+        self._calls: list[ToolCallInfo] = []
+        self._started: dict[int, asyncio.Task] = {}
         self._results: dict[int, ToolExecutionResult] = {}
-        self._submission_order: list[int] = []
-        # Sibling abort: set when a bash tool errors, cancels other concurrent tasks
+        self._barrier_pending = False
         self._sibling_errored = False
         self._sibling_error_desc = ""
+        if max_parallel is None:
+            from app.config import get_settings
+
+            max_parallel = get_settings().max_parallel_tool_calls
+        self._slots = asyncio.Semaphore(max(1, max_parallel))
 
     def submit(self, info: ToolCallInfo) -> None:
-        """Submit a tool for execution.
+        """Record a tool call in model order, starting it early when that is safe.
 
-        Concurrent-safe tools start immediately as background tasks.
-        Exclusive tools are queued for sequential execution after streaming.
+        A concurrency-safe call may start during streaming only while no
+        exclusive call is still outstanding ahead of it. Once one is queued it
+        becomes a barrier, and everything after waits for :meth:`collect` to
+        reach it in order.
         """
-        self._submission_order.append(info.index)
+        self._calls.append(info)
 
-        if info.tool.is_concurrency_safe:
-            task = asyncio.create_task(
-                _execute_single(info),
-                name=f"tool-{info.tool_name}-{info.call_id[:8]}",
-            )
-            self._concurrent_tasks.append((info, task))
-            logger.info(
-                "Started concurrent tool %s (call_id=%s) during streaming",
-                info.tool_name, info.call_id[:8],
-            )
-        else:
-            self._exclusive_queue.append(info)
+        if not info.tool.is_concurrency_safe:
+            self._barrier_pending = True
             logger.debug(
-                "Queued exclusive tool %s (call_id=%s) for post-stream execution",
+                "Queued exclusive tool %s (call_id=%s); it is a barrier for later calls",
                 info.tool_name, info.call_id[:8],
             )
+            return
+
+        if self._barrier_pending:
+            logger.debug(
+                "Deferred %s (call_id=%s) behind an earlier exclusive tool",
+                info.tool_name, info.call_id[:8],
+            )
+            return
+
+        self._started[info.index] = asyncio.create_task(
+            self._run(info), name=f"tool-{info.tool_name}-{info.call_id[:8]}"
+        )
+        logger.info(
+            "Started concurrent tool %s (call_id=%s) during streaming",
+            info.tool_name, info.call_id[:8],
+        )
+
+    async def _run(self, info: ToolCallInfo) -> ToolExecutionResult:
+        """Execute one call, holding a concurrency slot for its duration."""
+        async with self._slots:
+            return await _execute_single(info)
 
     async def collect(self) -> list[ToolExecutionResult]:
-        """Wait for all submitted tools to complete and return results in order.
-
-        1. Await all concurrent background tasks (with sibling abort)
-        2. Execute exclusive tools sequentially
-        3. Return results sorted by submission order
-        """
-        # 1. Collect concurrent results
-        for info, task in self._concurrent_tasks:
-            try:
-                result = await task
-                self._results[result.index] = result
-
-                # Sibling abort: if a bash tool errored, cancel remaining
-                # concurrent tasks. Bash commands often have implicit dependency
-                # chains — if one fails, continuing siblings is pointless.
-                if (
-                    result.error is not None
-                    and result.tool_name in SIBLING_ABORT_TOOLS
-                    and not self._sibling_errored
+        """Run everything still outstanding in model order and return all results."""
+        position = 0
+        while position < len(self._calls):
+            if self._calls[position].tool.is_concurrency_safe:
+                group: list[ToolCallInfo] = []
+                while (
+                    position < len(self._calls)
+                    and self._calls[position].tool.is_concurrency_safe
                 ):
-                    self._sibling_errored = True
-                    _input_summary = str(info.tool_args.get("command", ""))[:40]
-                    self._sibling_error_desc = (
-                        f"{info.tool_name}({_input_summary})"
-                        if _input_summary else info.tool_name
-                    )
-                    logger.info(
-                        "Bash tool %s errored — cancelling sibling concurrent tasks",
-                        info.call_id[:8],
-                    )
-                    self._cancel_remaining_concurrent(info.index)
+                    group.append(self._calls[position])
+                    position += 1
+                await self._run_group(group)
+            else:
+                await self._run_exclusive(self._calls[position])
+                position += 1
 
-            except asyncio.CancelledError:
-                # Task was cancelled by sibling abort or external abort
-                msg = (
-                    f"Cancelled: parallel tool call {self._sibling_error_desc} errored"
-                    if self._sibling_errored
-                    else "Cancelled"
-                )
-                self._results[info.index] = ToolExecutionResult(
-                    index=info.index, tool_name=info.tool_name,
-                    call_id=info.call_id, tool_args=info.tool_args,
-                    error=asyncio.CancelledError(msg),
-                    aborted_by_sibling=self._sibling_errored,
-                )
-            except Exception as e:
-                self._results[info.index] = ToolExecutionResult(
-                    index=info.index, tool_name=info.tool_name,
-                    call_id=info.call_id, tool_args=info.tool_args,
-                    error=e,
-                )
-
-        # 2. Execute exclusive tools sequentially
-        for info in self._exclusive_queue:
-            if self._abort.is_set() or self._sibling_errored:
-                msg = (
-                    f"Cancelled: parallel tool call {self._sibling_error_desc} errored"
-                    if self._sibling_errored
-                    else "Aborted"
-                )
-                self._results[info.index] = ToolExecutionResult(
-                    index=info.index, tool_name=info.tool_name,
-                    call_id=info.call_id, tool_args=info.tool_args,
-                    error=asyncio.CancelledError(msg),
-                    aborted_by_sibling=self._sibling_errored,
-                )
-                continue
-
-            result = await _execute_single(info)
-            self._results[result.index] = result
-
-        # 3. Return in submission order
         return [
-            self._results[idx]
-            for idx in self._submission_order
-            if idx in self._results
+            self._results[info.index]
+            for info in self._calls
+            if info.index in self._results
         ]
 
-    def _cancel_remaining_concurrent(self, errored_index: int) -> None:
-        """Cancel all concurrent tasks that haven't completed yet."""
-        for info, task in self._concurrent_tasks:
-            if info.index != errored_index and not task.done():
-                task.cancel()
-                logger.debug(
-                    "Cancelled sibling tool %s (call_id=%s)",
-                    info.tool_name, info.call_id[:8],
-                )
+    async def _run_group(self, group: list[ToolCallInfo]) -> None:
+        """Run a run of adjacent concurrency-safe calls together."""
+        if self._stopped:
+            for info in group:
+                self._record_cancelled(info)
+            return
+
+        tasks = {
+            info.index: self._started.get(info.index)
+            or asyncio.create_task(
+                self._run(info), name=f"tool-{info.tool_name}-{info.call_id[:8]}"
+            )
+            for info in group
+        }
+
+        for info in group:
+            await self._settle(info, tasks[info.index])
+
+    async def _run_exclusive(self, info: ToolCallInfo) -> None:
+        """Run one barrier call; everything before it has already settled."""
+        if self._stopped:
+            self._record_cancelled(info)
+            return
+
+        result = await _execute_single(info)
+        self._results[info.index] = result
+        self._note_sibling_abort(info, result)
+
+    async def _settle(self, info: ToolCallInfo, task: asyncio.Task) -> None:
+        """Await one started call and record whatever it produced."""
+        if self._stopped and not task.done():
+            task.cancel()
+        try:
+            result = await task
+        except asyncio.CancelledError:
+            self._record_cancelled(info)
+            return
+        except Exception as exc:  # a crash inside the wrapper, not the tool
+            self._results[info.index] = ToolExecutionResult(
+                index=info.index, tool_name=info.tool_name,
+                call_id=info.call_id, tool_args=info.tool_args,
+                error=exc,
+            )
+            return
+
+        self._results[info.index] = result
+        self._note_sibling_abort(info, result)
+
+    def _note_sibling_abort(
+        self, info: ToolCallInfo, result: ToolExecutionResult
+    ) -> None:
+        """Latch the cascade flag when a dependency-chain tool fails."""
+        if (
+            result.error is None
+            or info.tool_name not in SIBLING_ABORT_TOOLS
+            or self._sibling_errored
+        ):
+            return
+
+        self._sibling_errored = True
+        summary = str(info.tool_args.get("command", ""))[:40]
+        self._sibling_error_desc = f"{info.tool_name}({summary})" if summary else info.tool_name
+        logger.info(
+            "%s (call_id=%s) errored — cancelling the calls queued after it",
+            info.tool_name, info.call_id[:8],
+        )
+        self.cancel_all()
+
+    @property
+    def _stopped(self) -> bool:
+        return self._abort.is_set() or self._sibling_errored
+
+    def _record_cancelled(self, info: ToolCallInfo) -> None:
+        message = (
+            f"Cancelled: earlier tool call {self._sibling_error_desc} errored"
+            if self._sibling_errored
+            else "Aborted"
+        )
+        self._results[info.index] = ToolExecutionResult(
+            index=info.index, tool_name=info.tool_name,
+            call_id=info.call_id, tool_args=info.tool_args,
+            error=asyncio.CancelledError(message),
+            aborted_by_sibling=self._sibling_errored,
+        )
 
     def cancel_all(self) -> None:
-        """Cancel all pending concurrent tasks."""
-        for _, task in self._concurrent_tasks:
+        """Cancel every started call that has not finished."""
+        for index, task in self._started.items():
             if not task.done():
                 task.cancel()
+                logger.debug("Cancelled in-flight tool at index %d", index)
 
     @property
     def has_submissions(self) -> bool:
-        return bool(self._submission_order)
+        return bool(self._calls)

--- a/backend/app/session/tool_executor.py
+++ b/backend/app/session/tool_executor.py
@@ -191,7 +191,15 @@ class StreamingToolExecutor:
     async def _run_group(self, group: list[ToolCallInfo]) -> None:
         """Run a run of adjacent concurrency-safe calls together."""
         if self._stopped:
+            # Calls already started keep running inside ``await tool(...)`` —
+            # the abort check in _execute_single only guards the moment before
+            # dispatch. Cancel and reap them rather than reporting "Aborted"
+            # while they carry on writing files in the background.
             for info in group:
+                started = self._started.get(info.index)
+                if started is not None:
+                    started.cancel()
+                    await asyncio.gather(started, return_exceptions=True)
                 self._record_cancelled(info)
             return
 
@@ -203,8 +211,17 @@ class StreamingToolExecutor:
             for info in group
         }
 
-        for info in group:
-            await self._settle(info, tasks[info.index])
+        try:
+            for info in group:
+                await self._settle(info, tasks[info.index])
+        finally:
+            # Whatever ended this group — an abort mid-way, or the caller being
+            # cancelled — no task in it may outlive it unobserved.
+            pending = [t for t in tasks.values() if not t.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
     async def _run_exclusive(self, info: ToolCallInfo) -> None:
         """Run one barrier call; everything before it has already settled."""
@@ -224,6 +241,16 @@ class StreamingToolExecutor:
             result = await task
         except asyncio.CancelledError:
             self._record_cancelled(info)
+            # Distinguish "this tool was cancelled" from "the caller awaiting
+            # us was cancelled". Swallowing the latter makes collect() return
+            # normally, and asyncio never re-delivers it — so the processor's
+            # cancellation cleanup (persist partial output, terminate running
+            # ToolParts) is skipped and the turn looks like it finished.
+            if not task.cancelled():
+                raise
+            current = asyncio.current_task()
+            if current is not None and current.cancelling():
+                raise
             return
         except Exception as exc:  # a crash inside the wrapper, not the tool
             self._results[info.index] = ToolExecutionResult(

--- a/backend/app/session/tool_executor.py
+++ b/backend/app/session/tool_executor.py
@@ -31,12 +31,15 @@ from app.tool.context import ToolContext
 logger = logging.getLogger(__name__)
 
 
-# A failure in one of these cancels the calls the model placed *after* it.
-# Bash commands form implicit dependency chains — once one fails, running the
-# rest produces confusing cascading errors against a state that never happened.
-# Only later calls are cancelled: an earlier one has already run, and under the
-# barrier rules its result was correct when it was produced.
-SIBLING_ABORT_TOOLS = frozenset({"bash"})
+# There is deliberately no failure cascade here. A `SIBLING_ABORT_TOOLS` set
+# existed for bash on the theory that shell commands form dependency chains, but
+# it was unreachable — bash is exclusive, and the cascade lived on a
+# concurrent-only path — so it had never run. Making it run showed why it should
+# not: `BashTool` reports any non-zero exit as `ToolResult.error`, and a non-zero
+# exit is how `grep`, `test` and `diff` answer "no". Every such answer would have
+# cancelled the rest of the turn. The barrier already gives the model ordering it
+# can rely on; deciding that one tool's result invalidates the next is the
+# model's judgement to make, not the scheduler's.
 
 
 @dataclass
@@ -63,7 +66,6 @@ class ToolExecutionResult:
     result: ToolResult | None = None
     error: Exception | None = None
     timed_out: bool = False
-    aborted_by_sibling: bool = False
 
 
 async def _execute_single(info: ToolCallInfo) -> ToolExecutionResult:
@@ -119,8 +121,12 @@ class StreamingToolExecutor:
         self._started: dict[int, asyncio.Task] = {}
         self._results: dict[int, ToolExecutionResult] = {}
         self._barrier_pending = False
-        self._sibling_errored = False
-        self._sibling_error_desc = ""
+        # Indices this executor cancelled itself. `Task.cancelled()` cannot tell
+        # those apart from a tool cancelled as a side effect of the *caller*
+        # being cancelled: a task suspended at `await task` has that task as its
+        # `_fut_waiter`, so cancelling the caller cancels the tool too, and
+        # asyncio never re-delivers the caller's cancellation once it is caught.
+        self._self_cancelled: set[int] = set()
         if max_parallel is None:
             from app.config import get_settings
 
@@ -199,13 +205,21 @@ class StreamingToolExecutor:
             # Cancel every one first, then reap: a cancellation landing on us
             # mid-reap would otherwise leave the untouched remainder running.
             # Recording the outcomes goes in a `finally` for the same reason.
-            live = [t for t in (self._started.get(i.index) for i in group) if t]
-            for task in live:
-                task.cancel()
+            # Anything that already finished keeps its real result; only work
+            # still in flight is cancelled.
+            self.harvest_finished()
+            live = []
+            for info in group:
+                task = self._started.get(info.index)
+                if task is not None and not task.done():
+                    live.append(task)
+                    self._self_cancelled.add(info.index)
+                    task.cancel()
             try:
                 if live:
                     await asyncio.gather(*live, return_exceptions=True)
             finally:
+                self.harvest_finished()
                 for info in group:
                     self._record_cancelled(info)
             return
@@ -245,11 +259,11 @@ class StreamingToolExecutor:
 
         result = await _execute_single(info)
         self._results[info.index] = result
-        self._note_sibling_abort(info, result)
 
     async def _settle(self, info: ToolCallInfo, task: asyncio.Task) -> None:
         """Await one started call and record whatever it produced."""
         if self._stopped and not task.done():
+            self._self_cancelled.add(info.index)
             task.cancel()
         try:
             result = await task
@@ -261,13 +275,12 @@ class StreamingToolExecutor:
             # cancellation cleanup (persist partial output, terminate running
             # ToolParts) is skipped and the turn looks like it finished.
             #
-            # `task.cancelled()` is the reliable discriminator. `Task.cancelling()`
-            # is not: it is a monotone counter reset only by `uncancel()`, which
-            # nothing in this codebase calls, while the processor has several
-            # `except CancelledError: continue` shield loops that bump it. A
-            # caller carrying a stale count would see every later tool
-            # cancellation re-raised.
-            if not task.cancelled():
+            # Only a cancellation this executor issued is ours to absorb.
+            # `task.cancelled()` is true either way — cancelling the caller
+            # cancels the tool it is suspended on — and `Task.cancelling()` is a
+            # monotone counter that nothing here uncancels while the processor's
+            # shield loops bump it. Neither can discriminate; the record can.
+            if info.index not in self._self_cancelled:
                 raise
             return
         except Exception as exc:  # a crash inside the wrapper, not the tool
@@ -279,53 +292,19 @@ class StreamingToolExecutor:
             return
 
         self._results[info.index] = result
-        self._note_sibling_abort(info, result)
-
-    def _note_sibling_abort(
-        self, info: ToolCallInfo, result: ToolExecutionResult
-    ) -> None:
-        """Latch the cascade flag when a dependency-chain tool fails."""
-        # ``ToolDefinition.__call__`` catches everything a tool raises and
-        # returns it as ``ToolResult.error``, so the executor almost never sees
-        # ``ToolExecutionResult.error`` set for an ordinary failure. Checking
-        # only that field is why this cascade has never fired. A timeout counts
-        # too: a build that never finished did not succeed.
-        failed = (
-            result.error is not None
-            or result.timed_out
-            or (result.result is not None and result.result.error is not None)
-        )
-        if (
-            not failed
-            or info.tool_name not in SIBLING_ABORT_TOOLS
-            or self._sibling_errored
-        ):
-            return
-
-        self._sibling_errored = True
-        summary = str(info.tool_args.get("command", ""))[:40]
-        self._sibling_error_desc = f"{info.tool_name}({summary})" if summary else info.tool_name
-        logger.info(
-            "%s (call_id=%s) errored — cancelling the calls queued after it",
-            info.tool_name, info.call_id[:8],
-        )
-        self.cancel_all()
 
     @property
     def _stopped(self) -> bool:
-        return self._abort.is_set() or self._sibling_errored
+        return self._abort.is_set()
 
     def _record_cancelled(self, info: ToolCallInfo) -> None:
-        message = (
-            f"Cancelled: earlier tool call {self._sibling_error_desc} errored"
-            if self._sibling_errored
-            else "Aborted"
-        )
+        """Record a call that never produced a result, without losing one that did."""
+        if info.index in self._results:
+            return  # it finished before the abort landed; keep the real outcome
         self._results[info.index] = ToolExecutionResult(
             index=info.index, tool_name=info.tool_name,
             call_id=info.call_id, tool_args=info.tool_args,
-            error=asyncio.CancelledError(message),
-            aborted_by_sibling=self._sibling_errored,
+            error=asyncio.CancelledError("Aborted"),
         )
 
     def harvest_finished(self) -> list[ToolExecutionResult]:
@@ -355,6 +334,7 @@ class StreamingToolExecutor:
         """Cancel every started call that has not finished."""
         for index, task in self._started.items():
             if not task.done():
+                self._self_cancelled.add(index)
                 task.cancel()
                 logger.debug("Cancelled in-flight tool at index %d", index)
 

--- a/backend/app/session/tool_executor.py
+++ b/backend/app/session/tool_executor.py
@@ -195,21 +195,35 @@ class StreamingToolExecutor:
             # the abort check in _execute_single only guards the moment before
             # dispatch. Cancel and reap them rather than reporting "Aborted"
             # while they carry on writing files in the background.
-            for info in group:
-                started = self._started.get(info.index)
-                if started is not None:
-                    started.cancel()
-                    await asyncio.gather(started, return_exceptions=True)
-                self._record_cancelled(info)
+            #
+            # Cancel every one first, then reap: a cancellation landing on us
+            # mid-reap would otherwise leave the untouched remainder running.
+            # Recording the outcomes goes in a `finally` for the same reason.
+            live = [t for t in (self._started.get(i.index) for i in group) if t]
+            for task in live:
+                task.cancel()
+            try:
+                if live:
+                    await asyncio.gather(*live, return_exceptions=True)
+            finally:
+                for info in group:
+                    self._record_cancelled(info)
             return
 
-        tasks = {
-            info.index: self._started.get(info.index)
-            or asyncio.create_task(
-                self._run(info), name=f"tool-{info.tool_name}-{info.call_id[:8]}"
-            )
-            for info in group
-        }
+        tasks: dict[int, asyncio.Task] = {}
+        for info in group:
+            task = self._started.get(info.index)
+            if task is None:
+                task = asyncio.create_task(
+                    self._run(info), name=f"tool-{info.tool_name}-{info.call_id[:8]}"
+                )
+                # Register it: ``_started`` is the one place that knows which
+                # calls have a live task, and cancel_all/harvest_finished both
+                # read it. A task created only here would be invisible to both,
+                # so aborting a turn could not stop anything queued behind a
+                # barrier.
+                self._started[info.index] = task
+            tasks[info.index] = task
 
         try:
             for info in group:
@@ -241,15 +255,19 @@ class StreamingToolExecutor:
             result = await task
         except asyncio.CancelledError:
             self._record_cancelled(info)
-            # Distinguish "this tool was cancelled" from "the caller awaiting
-            # us was cancelled". Swallowing the latter makes collect() return
+            # Distinguish "this tool was cancelled" from "the caller awaiting us
+            # was cancelled". Swallowing the latter makes collect() return
             # normally, and asyncio never re-delivers it — so the processor's
             # cancellation cleanup (persist partial output, terminate running
             # ToolParts) is skipped and the turn looks like it finished.
+            #
+            # `task.cancelled()` is the reliable discriminator. `Task.cancelling()`
+            # is not: it is a monotone counter reset only by `uncancel()`, which
+            # nothing in this codebase calls, while the processor has several
+            # `except CancelledError: continue` shield loops that bump it. A
+            # caller carrying a stale count would see every later tool
+            # cancellation re-raised.
             if not task.cancelled():
-                raise
-            current = asyncio.current_task()
-            if current is not None and current.cancelling():
                 raise
             return
         except Exception as exc:  # a crash inside the wrapper, not the tool
@@ -267,8 +285,18 @@ class StreamingToolExecutor:
         self, info: ToolCallInfo, result: ToolExecutionResult
     ) -> None:
         """Latch the cascade flag when a dependency-chain tool fails."""
+        # ``ToolDefinition.__call__`` catches everything a tool raises and
+        # returns it as ``ToolResult.error``, so the executor almost never sees
+        # ``ToolExecutionResult.error`` set for an ordinary failure. Checking
+        # only that field is why this cascade has never fired. A timeout counts
+        # too: a build that never finished did not succeed.
+        failed = (
+            result.error is not None
+            or result.timed_out
+            or (result.result is not None and result.result.error is not None)
+        )
         if (
-            result.error is None
+            not failed
             or info.tool_name not in SIBLING_ABORT_TOOLS
             or self._sibling_errored
         ):
@@ -299,6 +327,29 @@ class StreamingToolExecutor:
             error=asyncio.CancelledError(message),
             aborted_by_sibling=self._sibling_errored,
         )
+
+    def harvest_finished(self) -> list[ToolExecutionResult]:
+        """Results from calls that already ran, without starting any more.
+
+        For teardown: a turn abandoned mid-stream still has tools that
+        completed during it. Recording those as "cancelled" tells the user an
+        email was not sent when it was. Nothing not already running is started.
+        """
+        harvested: list[ToolExecutionResult] = []
+        for info in self._calls:
+            existing = self._results.get(info.index)
+            if existing is not None:
+                harvested.append(existing)
+                continue
+            task = self._started.get(info.index)
+            if task is None or not task.done() or task.cancelled():
+                continue
+            if task.exception() is not None:
+                continue
+            result = task.result()
+            self._results[info.index] = result
+            harvested.append(result)
+        return harvested
 
     def cancel_all(self) -> None:
         """Cancel every started call that has not finished."""

--- a/backend/app/session/utils.py
+++ b/backend/app/session/utils.py
@@ -518,9 +518,23 @@ def calculate_step_cost(
     input_tokens = usage_data.get("input", 0)
     output_tokens = usage_data.get("output", 0)
     reasoning_tokens = usage_data.get("reasoning", 0)
+    # Providers report cached input separately from `input`, so leaving these
+    # out does not merely mis-price them — it bills them at zero. In a long
+    # session cache reads are most of the input, which is exactly when the
+    # reported cost drifts furthest from the user's provider bill.
+    cache_read_tokens = usage_data.get("cache_read", 0)
+    cache_write_tokens = usage_data.get("cache_write", 0)
+    cache_read_price = getattr(model_info.pricing, "cache_read", None)
+    cache_write_price = getattr(model_info.pricing, "cache_write", None)
 
     raw_cost = (
         input_tokens * prompt_price / 1_000_000
         + (output_tokens + reasoning_tokens) * completion_price / 1_000_000
+        + cache_read_tokens
+        * (prompt_price if cache_read_price is None else cache_read_price)
+        / 1_000_000
+        + cache_write_tokens
+        * (prompt_price if cache_write_price is None else cache_write_price)
+        / 1_000_000
     )
     return raw_cost

--- a/backend/app/session/utils.py
+++ b/backend/app/session/utils.py
@@ -518,23 +518,26 @@ def calculate_step_cost(
     input_tokens = usage_data.get("input", 0)
     output_tokens = usage_data.get("output", 0)
     reasoning_tokens = usage_data.get("reasoning", 0)
-    # Providers report cached input separately from `input`, so leaving these
-    # out does not merely mis-price them — it bills them at zero. In a long
-    # session cache reads are most of the input, which is exactly when the
-    # reported cost drifts furthest from the user's provider bill.
+    # `_extract_usage_tokens` subtracts cached reads out of `input`, so without
+    # this term they are billed at nothing — and in a long session cache reads
+    # are most of the input, which is when the reported cost drifts furthest
+    # from the user's actual bill.
+    #
+    # Only priced where the catalog publishes a rate. Substituting the prompt
+    # price would over-state by roughly 10x (Anthropic reads at ~0.1x prompt),
+    # which is a worse answer than the previous zero, not a better one.
+    #
+    # Cache *writes* are deliberately absent: `input` still includes them on the
+    # OpenAI-shaped path (see tests/test_provider/test_usage_parsing.py), so
+    # adding a term here would bill them twice. Splitting them out means
+    # changing the normalizer, which moves every reported `input` figure, and
+    # wants per-provider evidence this change does not have.
     cache_read_tokens = usage_data.get("cache_read", 0)
-    cache_write_tokens = usage_data.get("cache_write", 0)
-    cache_read_price = getattr(model_info.pricing, "cache_read", None)
-    cache_write_price = getattr(model_info.pricing, "cache_write", None)
+    cache_read_price = getattr(model_info.pricing, "cache_read", None) or 0.0
 
     raw_cost = (
         input_tokens * prompt_price / 1_000_000
         + (output_tokens + reasoning_tokens) * completion_price / 1_000_000
-        + cache_read_tokens
-        * (prompt_price if cache_read_price is None else cache_read_price)
-        / 1_000_000
-        + cache_write_tokens
-        * (prompt_price if cache_write_price is None else cache_write_price)
-        / 1_000_000
+        + cache_read_tokens * cache_read_price / 1_000_000
     )
     return raw_cost

--- a/backend/app/tool/base.py
+++ b/backend/app/tool/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from app.tool.truncation import truncate_output
 
@@ -77,6 +77,18 @@ class ToolDefinition(ABC):
         """Optional Tool-specific timeout; ``None`` uses the global limit."""
         return None
 
+    @property
+    def truncation_direction(self) -> Literal["head", "tail"]:
+        """Which end of an oversized result to keep.
+
+        ``head`` suits tools whose output is ordered by relevance — a search
+        result list, a file read from the top. ``tail`` suits anything whose
+        conclusion is at the end: a failed build reports its error on the last
+        lines, and keeping the first 2000 lines of setup noise drops the one
+        thing the model needed.
+        """
+        return "head"
+
     @abstractmethod
     def parameters_schema(self) -> dict[str, Any]:
         """Return JSON Schema for the tool's parameters."""
@@ -132,22 +144,41 @@ class ToolDefinition(ABC):
             result = await self.execute(args, ctx)
             # Truncate output — save full text to file if oversized
             # Mirrors OpenCode's Truncate.output() integration in tool/tool.ts
+            # Check if agent has "task" tool for smarter hints
+            has_task = not ctx.agent.tools or "task" in ctx.agent.tools
             if result.output:
-                # Check if agent has "task" tool for smarter hints
-                has_task = not ctx.agent.tools or "task" in ctx.agent.tools
                 tr = truncate_output(
                     result.output,
                     workspace=ctx.workspace,
                     has_task_tool=has_task,
+                    direction=self.truncation_direction,
                 )
                 result.output = tr.content
                 if tr.truncated:
                     result.metadata["truncated"] = True
                     result.metadata["output_path"] = tr.output_path
+            if result.error:
+                # An error is model-visible context like any other, and an
+                # unbounded one (a stack trace, a dumped response body) eats the
+                # window the same way an unbounded output would.
+                error_tr = truncate_output(
+                    result.error,
+                    workspace=ctx.workspace,
+                    has_task_tool=has_task,
+                    direction=self.truncation_direction,
+                )
+                result.error = error_tr.content
             return result
         except Exception as e:
             logger.exception("Tool %s failed", self.id)
-            return ToolResult(error=str(e))
+            # Bound this the same way as a returned error: an exception's repr
+            # can carry a whole response body.
+            failure = truncate_output(
+                str(e),
+                workspace=getattr(ctx, "workspace", None),
+                direction=self.truncation_direction,
+            )
+            return ToolResult(error=failure.content)
 
     def to_openai_spec(self) -> dict[str, Any]:
         """Convert to OpenAI function calling format."""

--- a/backend/app/tool/builtin/bash.py
+++ b/backend/app/tool/builtin/bash.py
@@ -10,7 +10,7 @@ import asyncio
 import os
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from app.tool.base import ToolDefinition, ToolResult
 from app.tool.context import ToolContext
@@ -32,6 +32,11 @@ class BashTool(ToolDefinition):
     @property
     def id(self) -> str:
         return "bash"
+
+    @property
+    def truncation_direction(self) -> Literal["head", "tail"]:
+        """Keep the end: a failed run reports why on its last lines."""
+        return "tail"
 
     @property
     def description(self) -> str:

--- a/backend/app/tool/builtin/bash.py
+++ b/backend/app/tool/builtin/bash.py
@@ -137,7 +137,11 @@ class BashTool(ToolDefinition):
         exit_code = result.returncode
 
         if exit_code != 0:
-            output = f"Exit code: {exit_code}\n{output}"
+            # Trailing, not leading: this tool truncates from the head
+            # (see truncation_direction), so a header on a long failing
+            # run is the first thing dropped — and it is the only signal
+            # the model gets that the command failed at all.
+            output = f"{output}\n\nExit code: {exit_code}"
 
         return ToolResult(
             output=output,

--- a/backend/app/tool/builtin/code_execute.py
+++ b/backend/app/tool/builtin/code_execute.py
@@ -15,7 +15,7 @@ import os
 import traceback
 from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from app.tool.base import ToolDefinition, ToolResult
 from app.tool.context import ToolContext
@@ -55,6 +55,11 @@ class CodeExecuteTool(ToolDefinition):
     @property
     def id(self) -> str:
         return "code_execute"
+
+    @property
+    def truncation_direction(self) -> Literal["head", "tail"]:
+        """Keep the end: a failed run reports why on its last lines."""
+        return "tail"
 
     @property
     def description(self) -> str:

--- a/backend/app/tool/builtin/code_execute.py
+++ b/backend/app/tool/builtin/code_execute.py
@@ -195,6 +195,10 @@ def _run_code(
 
     output = "\n".join(parts) if parts else "(no output)"
     if exit_code != 0:
-        output = f"Exit code: {exit_code}\n{output}"
+        # Trailing, not leading: this tool truncates from the head (see
+        # truncation_direction), so a header on a long failing run is the first
+        # thing dropped — and it is the only signal the model gets that the
+        # command failed at all.
+        output = f"{output}\n\nExit code: {exit_code}"
 
     return output, exit_code

--- a/backend/app/tool/context.py
+++ b/backend/app/tool/context.py
@@ -83,7 +83,10 @@ class ToolContext:
             return await self._ask_fn(
                 permission, patterns or [], arguments, message
             )
-        return True  # Default: allow
+        # No way to ask means no approval was given. A permission primitive
+        # defaults closed: the caller reached here precisely because something
+        # needed the user's consent, and nobody can supply it.
+        return False
 
     @property
     def is_aborted(self) -> bool:

--- a/backend/app/tool/registry.py
+++ b/backend/app/tool/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from app.agent.permission import evaluate, merge_rulesets
+from app.agent.permission import agent_verdict, evaluate, merge_rulesets
 from app.schemas.agent import AgentInfo, Ruleset
 from app.tool.base import ToolDefinition
 
@@ -58,14 +58,22 @@ class ToolRegistry:
         else:
             candidates = list(self._tools.values())
 
-        # Filter by permissions
-        ruleset = agent.permissions
-        if extra_ruleset:
-            ruleset = merge_rulesets(ruleset, extra_ruleset)
-
+        # Filter by permissions. The agent's own ruleset and the session's
+        # merged ruleset each get a veto — inherited rules narrow what an agent
+        # may do, never widen it. Merging them into one list instead would let
+        # a later layer outrank the agent: a subagent inherits its parent's
+        # rules, and those start with the global ``allow *``, which would
+        # otherwise reopen everything a restrictive agent denies. This mirrors
+        # the agent-policy gate in ``SessionProcessor`` so the tools advertised
+        # to the model are exactly the ones it is allowed to call.
         result = [
             tool for tool in candidates
-            if evaluate(tool.id, "*", ruleset) != "deny"
+            if agent_verdict(tool.id, "*", agent.permissions) != "deny"
+            and (
+                extra_ruleset is None
+                or evaluate(tool.id, "*", merge_rulesets(agent.permissions, extra_ruleset))
+                != "deny"
+            )
         ]
 
         if exclude:

--- a/backend/app/utils/atomic_write.py
+++ b/backend/app/utils/atomic_write.py
@@ -1,0 +1,97 @@
+"""Crash-safe, owner-only writes for local credential and config files.
+
+These files hold the user's BYOK API keys, OAuth refresh tokens, and channel
+credentials. They are rewritten whole on every change — including on hot paths
+like an Ollama generation recording its model — so a plain ``write_text`` puts
+the entire set at risk on any interrupted write, and two concurrent writers
+silently lose one another's changes.
+
+:func:`atomic_write_text` replaces the file in one step and never leaves a
+partial one behind, and :func:`file_lock` serialises the read-modify-write
+sequences that surround it.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+# One lock per resolved path, shared process-wide. Callers hold it across the
+# whole read-modify-write, not just the write, because the read is what a
+# concurrent writer invalidates.
+_locks: dict[str, threading.RLock] = {}
+_locks_guard = threading.Lock()
+
+SECRET_FILE_MODE = 0o600
+SECRET_DIR_MODE = 0o700
+
+
+@contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Serialise read-modify-write cycles against one path within this process."""
+    key = str(Path(path).expanduser().resolve(strict=False))
+    with _locks_guard:
+        lock = _locks.setdefault(key, threading.RLock())
+    with lock:
+        yield
+
+
+def atomic_write_text(
+    path: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    mode: int = SECRET_FILE_MODE,
+) -> None:
+    """Write *content* to *path* as one indivisible replacement.
+
+    Writes a sibling temporary file, flushes it to disk, renames it over the
+    target, then flushes the directory entry. A reader either sees the previous
+    file or the new one, never a truncated mix, and a crash mid-write leaves the
+    previous file intact.
+
+    The file is created with *mode* before any content reaches it, so a secret
+    is never briefly world-readable. The parent directory is created with
+    ``0o700`` when missing.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=SECRET_DIR_MODE)
+
+    tmp_path = path.with_name(f".{path.name}.tmp{os.getpid()}")
+    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+        try:
+            handle = os.fdopen(fd, "w", encoding=encoding)
+        except BaseException:
+            os.close(fd)  # fdopen did not take ownership
+            raise
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        _fsync_dir(path.parent)
+    finally:
+        # os.replace consumed the temp file on success; clean up on any failure
+        # so a full disk does not accumulate droppings next to the real file.
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def _fsync_dir(directory: Path) -> None:
+    """Persist the rename itself, not just the new file's contents."""
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return  # Windows cannot open a directory; the rename is atomic regardless
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)

--- a/backend/tests/test_agent/test_permission_inheritance.py
+++ b/backend/tests/test_agent/test_permission_inheritance.py
@@ -14,6 +14,7 @@ from app.agent.permission import (
     agent_verdict,
     evaluate,
     merge_rulesets,
+    presets_to_ruleset,
 )
 from app.schemas.agent import AgentInfo, PermissionRule, Ruleset
 
@@ -43,11 +44,11 @@ def _child_merged(child: AgentInfo, inherited: Ruleset) -> Ruleset:
 
 
 def _inheritable(agent: AgentInfo, *user_layers: Ruleset) -> Ruleset:
-    """Reproduce PromptAssembler._merge_inheritable_permissions."""
+    """Reproduce SessionPrompt._merge_inheritable_permissions."""
     denials = Ruleset(
         rules=[rule for rule in agent.permissions.rules if rule.action == "deny"]
     )
-    return merge_rulesets(denials, *user_layers)
+    return merge_rulesets(*user_layers, denials)
 
 
 def test_inherited_rules_carry_no_allow_all() -> None:
@@ -93,6 +94,28 @@ def test_plan_mode_cannot_delegate_around_its_read_only_ceiling() -> None:
     for mutating in ("write", "edit", "apply_patch", "bash", "computer", "browser"):
         assert evaluate(mutating, "*", merged) == "deny", mutating
     assert evaluate("read", "*", merged) == "allow"
+
+
+def test_a_permissive_preset_cannot_reopen_an_inherited_denial() -> None:
+    """The ceiling must outrank the user layers travelling with it.
+
+    An Auto preset emits broad ``allow`` rules. Ordered before them, the
+    parent's denials are the weakest layer in the set that is supposed to
+    constrain the child — so Plan mode would delegate its way to a writable
+    subagent for any user who is not on the Ask preset.
+    """
+    plan = BUILTIN_AGENTS["plan"]
+    auto_preset = presets_to_ruleset({"file_changes": True, "run_commands": True})
+    assert any(rule.action == "allow" for rule in auto_preset.rules), (
+        "this test is only meaningful while the preset grants something"
+    )
+
+    merged = _child_merged(
+        BUILTIN_AGENTS["general"], _inheritable(plan, auto_preset)
+    )
+
+    for mutating in ("write", "edit", "apply_patch", "bash"):
+        assert evaluate(mutating, "*", merged) == "deny", mutating
 
 
 def test_advertised_tools_match_what_the_agent_may_call(tool_registry) -> None:

--- a/backend/tests/test_agent/test_permission_inheritance.py
+++ b/backend/tests/test_agent/test_permission_inheritance.py
@@ -1,31 +1,51 @@
 """Inherited permissions must narrow a subagent, never widen it.
 
-A subagent is spawned with its parent's permission rules, and a session layers
-those in *after* its own agent rules under last-match-wins. Anything permissive
-in the inherited set therefore outranks the child's own restrictions unless the
-handoff and the tool filter both keep the agent's denials on top.
+These tests drive the real ``SessionPrompt`` merges. An earlier version of this
+file reimplemented ``_merge_inheritable_permissions`` and
+``_merge_effective_permissions`` as local helpers and asserted against the
+copies — so the production ordering could be reverted with the suite green. A
+guard that duplicates the code it guards is not a guard.
 """
 
 from __future__ import annotations
 
-from app.agent.agent import BUILTIN_AGENTS
-from app.agent.permission import (
-    GLOBAL_DEFAULTS,
-    agent_verdict,
-    evaluate,
-    merge_rulesets,
-    presets_to_ruleset,
-)
+import pytest
+
+from app.agent.agent import AgentRegistry, BUILTIN_AGENTS
+from app.agent.permission import GLOBAL_DEFAULTS, agent_verdict, evaluate, merge_rulesets
 from app.schemas.agent import AgentInfo, PermissionRule, Ruleset
+from app.schemas.chat import PromptRequest
+from app.schemas.provider import ModelInfo
+from app.session.manager import create_session
+from app.session.prompt import SessionPrompt
+from app.streaming.manager import GenerationJob
+
+MUTATING = ("write", "edit", "apply_patch", "bash")
 
 
-def _restrictive_agent(*, tools: list[str] | None = None) -> AgentInfo:
+class _Provider:
+    id = "test-provider"
+
+
+class _ProviderRegistry:
+    def __init__(self) -> None:
+        self.provider = _Provider()
+        self.model = ModelInfo(id="test-model", name="Test", provider_id=self.provider.id)
+
+    def resolve_model(self, _model_id: str, _provider_id: str | None = None):
+        return self.provider, self.model
+
+    async def refresh_models(self):
+        return {}
+
+
+def _locked_down() -> AgentInfo:
     """A user-defined agent that denies everything except read."""
     return AgentInfo(
         name="locked-down",
         description="",
         mode="subagent",
-        tools=tools or [],
+        tools=[],
         permissions=Ruleset(
             rules=[
                 PermissionRule(action="deny", permission="*"),
@@ -36,121 +56,185 @@ def _restrictive_agent(*, tools: list[str] | None = None) -> AgentInfo:
     )
 
 
-def _child_merged(child: AgentInfo, inherited: Ruleset) -> Ruleset:
-    """Reproduce PromptAssembler._merge_effective_permissions for a child."""
-    return merge_rulesets(
-        GLOBAL_DEFAULTS, child.permissions, Ruleset(), inherited, Ruleset()
+async def _prompt(
+    session_factory,
+    *,
+    session_id: str,
+    agent: AgentInfo,
+    permission_rules: list[dict] | None = None,
+    presets: dict[str, bool] | None = None,
+    tool_registry=None,
+) -> SessionPrompt:
+    """A real SessionPrompt, set up the way the production loop sets one up."""
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+
+    registry = AgentRegistry()
+    registry.register(agent)
+
+    prompt = SessionPrompt(
+        job=GenerationJob(stream_id=f"{session_id}-stream", session_id=session_id),
+        request=PromptRequest(
+            session_id=session_id,
+            text="do the thing",
+            model="test-model",
+            agent=agent.name,
+            permission_rules=permission_rules,
+            permission_presets=presets,
+        ),
+        session_factory=session_factory,
+        provider_registry=_ProviderRegistry(),
+        agent_registry=registry,
+        tool_registry=tool_registry if tool_registry is not None else object(),
     )
+    await prompt._setup()
+    return prompt
 
 
-def _inheritable(agent: AgentInfo, *user_layers: Ruleset) -> Ruleset:
-    """Reproduce SessionPrompt._merge_inheritable_permissions."""
-    denials = Ruleset(
-        rules=[rule for rule in agent.permissions.rules if rule.action == "deny"]
-    )
-    return merge_rulesets(*user_layers, denials)
+async def _handoff(
+    session_factory,
+    *,
+    parent: AgentInfo,
+    child: AgentInfo,
+    presets: dict[str, bool] | None = None,
+    parent_rules: list[dict] | None = None,
+    tool_registry=None,
+) -> SessionPrompt:
+    """Run the real parent → child permission handoff and return the child.
 
-
-def test_inherited_rules_carry_no_allow_all() -> None:
-    """Neither the global defaults nor the parent persona may re-open the child.
-
-    ``GLOBAL_DEFAULTS`` and ``build``'s own ruleset both lead with ``allow *``.
-    Handing either down puts it above the child's ``deny *``.
+    Mirrors what ``SessionProcessor`` does: it builds ``ctx.permission_rules``
+    from ``sp.inheritable_permissions`` and ``task``/``swarm`` pass that to the
+    child as ``request.permission_rules``.
     """
-    parent = BUILTIN_AGENTS["build"]
-    assert GLOBAL_DEFAULTS.rules[0] == PermissionRule(action="allow", permission="*")
-    assert PermissionRule(action="allow", permission="*") in parent.permissions.rules
+    parent_prompt = await _prompt(
+        session_factory,
+        session_id=f"parent-{parent.name}-{child.name}",
+        agent=parent,
+        presets=presets,
+        permission_rules=parent_rules,
+    )
+    # Go through the processor, which is what actually builds the rules a
+    # subagent receives — reading `inheritable_permissions` here instead would
+    # leave that step untested and revertible.
+    from app.session.processor import SessionProcessor
 
-    inheritable = _inheritable(parent)
+    processor = SessionProcessor(parent_prompt, [], "assistant-msg")
+    inherited = list(processor._inheritable_permission_rules())
+    return await _prompt(
+        session_factory,
+        session_id=f"child-{parent.name}-{child.name}",
+        agent=child,
+        permission_rules=inherited,
+        tool_registry=tool_registry,
+    )
+
+
+async def test_a_parent_does_not_hand_down_an_allow_all(session_factory) -> None:
+    """``GLOBAL_DEFAULTS`` and ``build`` both lead with ``allow *``.
+
+    Handing either down puts it above the child's own ``deny *``.
+    """
+    parent = await _prompt(
+        session_factory, session_id="p-allow-all", agent=BUILTIN_AGENTS["build"]
+    )
+
+    assert GLOBAL_DEFAULTS.rules[0] == PermissionRule(action="allow", permission="*")
     assert not any(
         rule.action == "allow" and rule.permission == "*"
-        for rule in inheritable.rules
+        for rule in parent.inheritable_permissions.rules
     ), "no allow-all may be inherited"
 
-    child = _restrictive_agent()
-    assert evaluate("write", "*", _child_merged(child, inheritable)) == "deny"
-    assert evaluate("read", "*", _child_merged(child, inheritable)) == "allow"
 
-
-def test_parent_denial_still_reaches_the_child() -> None:
-    """Dropping the defaults must not drop the parent's real restrictions."""
-    parent = BUILTIN_AGENTS["build"]
-    remembered_denial = Ruleset(
-        rules=[PermissionRule(action="deny", permission="bash", pattern="*")]
+async def test_a_restrictive_child_keeps_its_denials(session_factory) -> None:
+    child = await _handoff(
+        session_factory, parent=BUILTIN_AGENTS["build"], child=_locked_down()
     )
-    inheritable = _inheritable(parent, remembered_denial)
 
-    child = BUILTIN_AGENTS["general"]
-    assert evaluate("bash", "*", _child_merged(child, inheritable)) == "deny"
-
-
-def test_plan_mode_cannot_delegate_around_its_read_only_ceiling() -> None:
-    """A Plan session's denials must follow the subagents it spawns."""
-    plan = BUILTIN_AGENTS["plan"]
-    inheritable = _inheritable(plan)
-    child = BUILTIN_AGENTS["general"]
-    merged = _child_merged(child, inheritable)
-
-    for mutating in ("write", "edit", "apply_patch", "bash", "computer", "browser"):
-        assert evaluate(mutating, "*", merged) == "deny", mutating
-    assert evaluate("read", "*", merged) == "allow"
+    assert evaluate("write", "*", child.merged_permissions) == "deny"
+    assert evaluate("read", "*", child.merged_permissions) == "allow"
 
 
-def test_a_permissive_preset_cannot_reopen_an_inherited_denial() -> None:
+async def test_plan_mode_cannot_delegate_around_its_read_only_ceiling(
+    session_factory,
+) -> None:
+    child = await _handoff(
+        session_factory, parent=BUILTIN_AGENTS["plan"], child=BUILTIN_AGENTS["general"]
+    )
+
+    for mutating in (*MUTATING, "computer", "browser"):
+        assert evaluate(mutating, "*", child.merged_permissions) == "deny", mutating
+    assert evaluate("read", "*", child.merged_permissions) == "allow"
+
+
+async def test_an_auto_preset_cannot_reopen_an_inherited_denial(session_factory) -> None:
     """The ceiling must outrank the user layers travelling with it.
 
-    An Auto preset emits broad ``allow`` rules. Ordered before them, the
-    parent's denials are the weakest layer in the set that is supposed to
-    constrain the child — so Plan mode would delegate its way to a writable
-    subagent for any user who is not on the Ask preset.
+    An Auto preset emits broad ``allow`` rules. Ordered before the parent's
+    denials, they win under last-match-wins — so Plan mode would delegate its
+    way to a writable subagent for every user not on the Ask preset.
     """
-    plan = BUILTIN_AGENTS["plan"]
-    auto_preset = presets_to_ruleset({"file_changes": True, "run_commands": True})
-    assert any(rule.action == "allow" for rule in auto_preset.rules), (
-        "this test is only meaningful while the preset grants something"
+    child = await _handoff(
+        session_factory,
+        parent=BUILTIN_AGENTS["plan"],
+        child=BUILTIN_AGENTS["general"],
+        presets={"file_changes": True, "run_commands": True},
     )
 
-    merged = _child_merged(
-        BUILTIN_AGENTS["general"], _inheritable(plan, auto_preset)
+    for mutating in MUTATING:
+        assert evaluate(mutating, "*", child.merged_permissions) == "deny", mutating
+
+
+async def test_a_parent_denial_still_reaches_the_child(session_factory) -> None:
+    """Narrowing must survive the handoff, not just widening be blocked."""
+    child = await _handoff(
+        session_factory,
+        parent=BUILTIN_AGENTS["build"],
+        child=BUILTIN_AGENTS["general"],
+        parent_rules=[{"action": "deny", "permission": "bash", "pattern": "*"}],
     )
 
-    for mutating in ("write", "edit", "apply_patch", "bash"):
-        assert evaluate(mutating, "*", merged) == "deny", mutating
+    assert evaluate("bash", "*", child.merged_permissions) == "deny"
 
 
-def test_advertised_tools_match_what_the_agent_may_call(tool_registry) -> None:
-    """A restrictive agent without a tool whitelist must not be over-advertised.
-
-    Inherited rules used to widen the advertised list, so the model was offered
-    tools the agent-policy gate then refused on every call.
-    """
-    parent = BUILTIN_AGENTS["build"]
-    inherited = merge_rulesets(parent.permissions)
-    child = _restrictive_agent()
+async def test_a_permissive_parent_does_not_widen_a_strict_child(
+    session_factory, tool_registry
+) -> None:
+    """End to end: the advertised tool list matches what the child may call."""
+    child = await _handoff(
+        session_factory,
+        parent=BUILTIN_AGENTS["build"],
+        child=_locked_down(),
+        presets={"file_changes": True, "run_commands": True},
+        tool_registry=tool_registry,
+    )
 
     advertised = {
         tool.id
         for tool in tool_registry.resolve_for_agent(
-            child, extra_ruleset=_child_merged(child, inherited)
+            child.agent, extra_ruleset=child.merged_permissions
         )
     }
-
     assert advertised == {"read"}
 
 
-def test_whitelisted_subagent_keeps_its_declared_tools(tool_registry) -> None:
-    """The fix must not shrink an agent whose rules already allow its tools."""
-    parent = BUILTIN_AGENTS["build"]
-    inherited = merge_rulesets(parent.permissions)
-    explore = BUILTIN_AGENTS["explore"]
+async def test_a_whitelisted_subagent_keeps_its_declared_tools(
+    session_factory, tool_registry
+) -> None:
+    """The narrowing must not shrink an agent whose rules already allow its tools."""
+    child = await _handoff(
+        session_factory,
+        parent=BUILTIN_AGENTS["build"],
+        child=BUILTIN_AGENTS["explore"],
+        tool_registry=tool_registry,
+    )
 
     advertised = {
         tool.id
         for tool in tool_registry.resolve_for_agent(
-            explore, extra_ruleset=_child_merged(explore, inherited)
+            child.agent, extra_ruleset=child.merged_permissions
         )
     }
-
     assert {"read", "glob", "grep", "bash", "web_fetch", "web_search"} <= advertised
     assert "write" not in advertised
     assert "computer" not in advertised
@@ -167,12 +251,8 @@ def test_an_agent_that_declares_no_permissions_is_not_locked_out(
     ``.openyak/agents/*.md``.
     """
     silent = AgentInfo(
-        name="silent",
-        description="",
-        mode="subagent",
-        tools=[],
-        permissions=Ruleset(),
-        system_prompt="x",
+        name="silent", description="", mode="subagent", tools=[],
+        permissions=Ruleset(), system_prompt="x",
     )
 
     assert agent_verdict("read", "*", silent.permissions) == "allow"
@@ -181,26 +261,49 @@ def test_an_agent_that_declares_no_permissions_is_not_locked_out(
     advertised = {
         tool.id
         for tool in tool_registry.resolve_for_agent(
-            silent, extra_ruleset=_child_merged(silent, Ruleset())
+            silent, extra_ruleset=merge_rulesets(GLOBAL_DEFAULTS, silent.permissions)
         )
     }
-    assert "read" in advertised
-    assert "bash" in advertised
-    assert len(advertised) > 10
+    assert {"read", "bash"} <= advertised
 
 
-def test_session_denial_still_removes_an_agent_allowed_tool(tool_registry) -> None:
+def test_a_session_denial_still_removes_an_agent_allowed_tool(tool_registry) -> None:
     """The extra ruleset keeps its veto — this is an intersection, not a swap."""
-    child = _restrictive_agent()
-    session_denies_read = Ruleset(
+    child = _locked_down()
+    denies_read = Ruleset(
         rules=[PermissionRule(action="deny", permission="read", pattern="*")]
     )
 
     advertised = {
         tool.id
         for tool in tool_registry.resolve_for_agent(
-            child, extra_ruleset=merge_rulesets(child.permissions, session_denies_read)
+            child, extra_ruleset=merge_rulesets(child.permissions, denies_read)
         )
     }
-
     assert advertised == set()
+
+
+async def test_a_remembered_denial_propagates_to_subagents(session_factory) -> None:
+    """``_remember_permission_rule`` must reach ``inheritable_permissions``.
+
+    A non-interactive child cannot prompt, so an inherited ``ask`` executes
+    where the user already said no.
+    """
+    from app.session.processor import _remember_permission_rule
+
+    prompt = await _prompt(
+        session_factory, session_id="remember-denial", agent=BUILTIN_AGENTS["build"]
+    )
+    await _remember_permission_rule(
+        session_factory, "remember-denial", prompt,
+        permission="bash", pattern="*", allow=False,
+    )
+
+    assert evaluate("bash", "*", prompt.inheritable_permissions) == "deny"
+
+
+@pytest.mark.parametrize("agent_name", ["explore", "research", "compaction"])
+def test_builtin_restrictive_agents_declare_a_real_ceiling(agent_name: str) -> None:
+    """These agents' ``deny *`` is the thing the handoff must preserve."""
+    agent = BUILTIN_AGENTS[agent_name]
+    assert PermissionRule(action="deny", permission="*") in agent.permissions.rules

--- a/backend/tests/test_agent/test_permission_inheritance.py
+++ b/backend/tests/test_agent/test_permission_inheritance.py
@@ -58,12 +58,12 @@ def _locked_down() -> AgentInfo:
 
 async def _prompt(
     session_factory,
+    tool_registry,
     *,
     session_id: str,
     agent: AgentInfo,
     permission_rules: list[dict] | None = None,
     presets: dict[str, bool] | None = None,
-    tool_registry=None,
 ) -> SessionPrompt:
     """A real SessionPrompt, set up the way the production loop sets one up."""
     async with session_factory() as db:
@@ -86,7 +86,7 @@ async def _prompt(
         session_factory=session_factory,
         provider_registry=_ProviderRegistry(),
         agent_registry=registry,
-        tool_registry=tool_registry if tool_registry is not None else object(),
+        tool_registry=tool_registry,
     )
     await prompt._setup()
     return prompt
@@ -94,12 +94,12 @@ async def _prompt(
 
 async def _handoff(
     session_factory,
+    tool_registry,
     *,
     parent: AgentInfo,
     child: AgentInfo,
     presets: dict[str, bool] | None = None,
     parent_rules: list[dict] | None = None,
-    tool_registry=None,
 ) -> SessionPrompt:
     """Run the real parent → child permission handoff and return the child.
 
@@ -109,6 +109,7 @@ async def _handoff(
     """
     parent_prompt = await _prompt(
         session_factory,
+        tool_registry,
         session_id=f"parent-{parent.name}-{child.name}",
         agent=parent,
         presets=presets,
@@ -123,20 +124,20 @@ async def _handoff(
     inherited = list(processor._inheritable_permission_rules())
     return await _prompt(
         session_factory,
+        tool_registry,
         session_id=f"child-{parent.name}-{child.name}",
         agent=child,
         permission_rules=inherited,
-        tool_registry=tool_registry,
     )
 
 
-async def test_a_parent_does_not_hand_down_an_allow_all(session_factory) -> None:
+async def test_a_parent_does_not_hand_down_an_allow_all(session_factory, tool_registry) -> None:
     """``GLOBAL_DEFAULTS`` and ``build`` both lead with ``allow *``.
 
     Handing either down puts it above the child's own ``deny *``.
     """
     parent = await _prompt(
-        session_factory, session_id="p-allow-all", agent=BUILTIN_AGENTS["build"]
+        session_factory, tool_registry, session_id="p-allow-all", agent=BUILTIN_AGENTS["build"]
     )
 
     assert GLOBAL_DEFAULTS.rules[0] == PermissionRule(action="allow", permission="*")
@@ -146,20 +147,18 @@ async def test_a_parent_does_not_hand_down_an_allow_all(session_factory) -> None
     ), "no allow-all may be inherited"
 
 
-async def test_a_restrictive_child_keeps_its_denials(session_factory) -> None:
+async def test_a_restrictive_child_keeps_its_denials(session_factory, tool_registry) -> None:
     child = await _handoff(
-        session_factory, parent=BUILTIN_AGENTS["build"], child=_locked_down()
+        session_factory, tool_registry, parent=BUILTIN_AGENTS["build"], child=_locked_down()
     )
 
     assert evaluate("write", "*", child.merged_permissions) == "deny"
     assert evaluate("read", "*", child.merged_permissions) == "allow"
 
 
-async def test_plan_mode_cannot_delegate_around_its_read_only_ceiling(
-    session_factory,
-) -> None:
+async def test_plan_mode_cannot_delegate_around_its_read_only_ceiling(session_factory, tool_registry) -> None:
     child = await _handoff(
-        session_factory, parent=BUILTIN_AGENTS["plan"], child=BUILTIN_AGENTS["general"]
+        session_factory, tool_registry, parent=BUILTIN_AGENTS["plan"], child=BUILTIN_AGENTS["general"]
     )
 
     for mutating in (*MUTATING, "computer", "browser"):
@@ -167,7 +166,7 @@ async def test_plan_mode_cannot_delegate_around_its_read_only_ceiling(
     assert evaluate("read", "*", child.merged_permissions) == "allow"
 
 
-async def test_an_auto_preset_cannot_reopen_an_inherited_denial(session_factory) -> None:
+async def test_an_auto_preset_cannot_reopen_an_inherited_denial(session_factory, tool_registry) -> None:
     """The ceiling must outrank the user layers travelling with it.
 
     An Auto preset emits broad ``allow`` rules. Ordered before the parent's
@@ -176,6 +175,7 @@ async def test_an_auto_preset_cannot_reopen_an_inherited_denial(session_factory)
     """
     child = await _handoff(
         session_factory,
+        tool_registry,
         parent=BUILTIN_AGENTS["plan"],
         child=BUILTIN_AGENTS["general"],
         presets={"file_changes": True, "run_commands": True},
@@ -185,10 +185,56 @@ async def test_an_auto_preset_cannot_reopen_an_inherited_denial(session_factory)
         assert evaluate(mutating, "*", child.merged_permissions) == "deny", mutating
 
 
-async def test_a_parent_denial_still_reaches_the_child(session_factory) -> None:
+async def test_a_deny_all_parent_does_not_zero_out_its_child(
+    session_factory, tool_registry
+) -> None:
+    """The ceiling is the parent's *verdict* per tool, not its literal rules.
+
+    Every restrictive agent here is written as ``deny *`` plus an allow-list.
+    Copying only the ``deny`` rules keeps the ``deny *`` and drops everything
+    that re-opens it, handing the child a ceiling that forbids every tool.
+    """
+    parent = _locked_down()  # deny * + allow read
+    child = await _handoff(
+        session_factory, tool_registry, parent=parent, child=BUILTIN_AGENTS["general"]
+    )
+
+    assert evaluate("read", "*", child.merged_permissions) != "deny", (
+        "the parent allows read, so the child must keep it"
+    )
+    assert evaluate("write", "*", child.merged_permissions) == "deny"
+
+    advertised = {
+        tool.id
+        for tool in tool_registry.resolve_for_agent(
+            child.agent, extra_ruleset=child.merged_permissions
+        )
+    }
+    assert advertised, "a restrictive parent must not leave the child with no tools"
+    assert "read" in advertised
+
+
+async def test_an_explore_parent_keeps_its_allow_list_for_the_child(
+    session_factory, tool_registry
+) -> None:
+    """Same shape, using a built-in: explore is ``deny *`` + seven allows."""
+    child = await _handoff(
+        session_factory,
+        tool_registry,
+        parent=BUILTIN_AGENTS["explore"],
+        child=BUILTIN_AGENTS["general"],
+    )
+
+    for allowed in ("read", "grep", "web_fetch"):
+        assert evaluate(allowed, "*", child.merged_permissions) != "deny", allowed
+    assert evaluate("write", "*", child.merged_permissions) == "deny"
+
+
+async def test_a_parent_denial_still_reaches_the_child(session_factory, tool_registry) -> None:
     """Narrowing must survive the handoff, not just widening be blocked."""
     child = await _handoff(
         session_factory,
+        tool_registry,
         parent=BUILTIN_AGENTS["build"],
         child=BUILTIN_AGENTS["general"],
         parent_rules=[{"action": "deny", "permission": "bash", "pattern": "*"}],
@@ -203,10 +249,10 @@ async def test_a_permissive_parent_does_not_widen_a_strict_child(
     """End to end: the advertised tool list matches what the child may call."""
     child = await _handoff(
         session_factory,
+        tool_registry,
         parent=BUILTIN_AGENTS["build"],
         child=_locked_down(),
         presets={"file_changes": True, "run_commands": True},
-        tool_registry=tool_registry,
     )
 
     advertised = {
@@ -224,9 +270,9 @@ async def test_a_whitelisted_subagent_keeps_its_declared_tools(
     """The narrowing must not shrink an agent whose rules already allow its tools."""
     child = await _handoff(
         session_factory,
+        tool_registry,
         parent=BUILTIN_AGENTS["build"],
         child=BUILTIN_AGENTS["explore"],
-        tool_registry=tool_registry,
     )
 
     advertised = {
@@ -283,7 +329,7 @@ def test_a_session_denial_still_removes_an_agent_allowed_tool(tool_registry) -> 
     assert advertised == set()
 
 
-async def test_a_remembered_denial_propagates_to_subagents(session_factory) -> None:
+async def test_a_remembered_denial_propagates_to_subagents(session_factory, tool_registry) -> None:
     """``_remember_permission_rule`` must reach ``inheritable_permissions``.
 
     A non-interactive child cannot prompt, so an inherited ``ask`` executes
@@ -292,7 +338,7 @@ async def test_a_remembered_denial_propagates_to_subagents(session_factory) -> N
     from app.session.processor import _remember_permission_rule
 
     prompt = await _prompt(
-        session_factory, session_id="remember-denial", agent=BUILTIN_AGENTS["build"]
+        session_factory, tool_registry, session_id="remember-denial", agent=BUILTIN_AGENTS["build"]
     )
     await _remember_permission_rule(
         session_factory, "remember-denial", prompt,

--- a/backend/tests/test_agent/test_permission_inheritance.py
+++ b/backend/tests/test_agent/test_permission_inheritance.py
@@ -1,0 +1,183 @@
+"""Inherited permissions must narrow a subagent, never widen it.
+
+A subagent is spawned with its parent's permission rules, and a session layers
+those in *after* its own agent rules under last-match-wins. Anything permissive
+in the inherited set therefore outranks the child's own restrictions unless the
+handoff and the tool filter both keep the agent's denials on top.
+"""
+
+from __future__ import annotations
+
+from app.agent.agent import BUILTIN_AGENTS
+from app.agent.permission import (
+    GLOBAL_DEFAULTS,
+    agent_verdict,
+    evaluate,
+    merge_rulesets,
+)
+from app.schemas.agent import AgentInfo, PermissionRule, Ruleset
+
+
+def _restrictive_agent(*, tools: list[str] | None = None) -> AgentInfo:
+    """A user-defined agent that denies everything except read."""
+    return AgentInfo(
+        name="locked-down",
+        description="",
+        mode="subagent",
+        tools=tools or [],
+        permissions=Ruleset(
+            rules=[
+                PermissionRule(action="deny", permission="*"),
+                PermissionRule(action="allow", permission="read"),
+            ]
+        ),
+        system_prompt="x",
+    )
+
+
+def _child_merged(child: AgentInfo, inherited: Ruleset) -> Ruleset:
+    """Reproduce PromptAssembler._merge_effective_permissions for a child."""
+    return merge_rulesets(
+        GLOBAL_DEFAULTS, child.permissions, Ruleset(), inherited, Ruleset()
+    )
+
+
+def _inheritable(agent: AgentInfo, *user_layers: Ruleset) -> Ruleset:
+    """Reproduce PromptAssembler._merge_inheritable_permissions."""
+    denials = Ruleset(
+        rules=[rule for rule in agent.permissions.rules if rule.action == "deny"]
+    )
+    return merge_rulesets(denials, *user_layers)
+
+
+def test_inherited_rules_carry_no_allow_all() -> None:
+    """Neither the global defaults nor the parent persona may re-open the child.
+
+    ``GLOBAL_DEFAULTS`` and ``build``'s own ruleset both lead with ``allow *``.
+    Handing either down puts it above the child's ``deny *``.
+    """
+    parent = BUILTIN_AGENTS["build"]
+    assert GLOBAL_DEFAULTS.rules[0] == PermissionRule(action="allow", permission="*")
+    assert PermissionRule(action="allow", permission="*") in parent.permissions.rules
+
+    inheritable = _inheritable(parent)
+    assert not any(
+        rule.action == "allow" and rule.permission == "*"
+        for rule in inheritable.rules
+    ), "no allow-all may be inherited"
+
+    child = _restrictive_agent()
+    assert evaluate("write", "*", _child_merged(child, inheritable)) == "deny"
+    assert evaluate("read", "*", _child_merged(child, inheritable)) == "allow"
+
+
+def test_parent_denial_still_reaches_the_child() -> None:
+    """Dropping the defaults must not drop the parent's real restrictions."""
+    parent = BUILTIN_AGENTS["build"]
+    remembered_denial = Ruleset(
+        rules=[PermissionRule(action="deny", permission="bash", pattern="*")]
+    )
+    inheritable = _inheritable(parent, remembered_denial)
+
+    child = BUILTIN_AGENTS["general"]
+    assert evaluate("bash", "*", _child_merged(child, inheritable)) == "deny"
+
+
+def test_plan_mode_cannot_delegate_around_its_read_only_ceiling() -> None:
+    """A Plan session's denials must follow the subagents it spawns."""
+    plan = BUILTIN_AGENTS["plan"]
+    inheritable = _inheritable(plan)
+    child = BUILTIN_AGENTS["general"]
+    merged = _child_merged(child, inheritable)
+
+    for mutating in ("write", "edit", "apply_patch", "bash", "computer", "browser"):
+        assert evaluate(mutating, "*", merged) == "deny", mutating
+    assert evaluate("read", "*", merged) == "allow"
+
+
+def test_advertised_tools_match_what_the_agent_may_call(tool_registry) -> None:
+    """A restrictive agent without a tool whitelist must not be over-advertised.
+
+    Inherited rules used to widen the advertised list, so the model was offered
+    tools the agent-policy gate then refused on every call.
+    """
+    parent = BUILTIN_AGENTS["build"]
+    inherited = merge_rulesets(parent.permissions)
+    child = _restrictive_agent()
+
+    advertised = {
+        tool.id
+        for tool in tool_registry.resolve_for_agent(
+            child, extra_ruleset=_child_merged(child, inherited)
+        )
+    }
+
+    assert advertised == {"read"}
+
+
+def test_whitelisted_subagent_keeps_its_declared_tools(tool_registry) -> None:
+    """The fix must not shrink an agent whose rules already allow its tools."""
+    parent = BUILTIN_AGENTS["build"]
+    inherited = merge_rulesets(parent.permissions)
+    explore = BUILTIN_AGENTS["explore"]
+
+    advertised = {
+        tool.id
+        for tool in tool_registry.resolve_for_agent(
+            explore, extra_ruleset=_child_merged(explore, inherited)
+        )
+    }
+
+    assert {"read", "glob", "grep", "bash", "web_fetch", "web_search"} <= advertised
+    assert "write" not in advertised
+    assert "computer" not in advertised
+
+
+def test_an_agent_that_declares_no_permissions_is_not_locked_out(
+    tool_registry,
+) -> None:
+    """Saying nothing means "use the global defaults", not "deny everything".
+
+    ``evaluate`` returns ``deny`` when no rule matches, so reading an agent's
+    ruleset in isolation refuses every tool for an agent defined without a
+    ``permissions`` block — the default shape of a user-defined agent in
+    ``.openyak/agents/*.md``.
+    """
+    silent = AgentInfo(
+        name="silent",
+        description="",
+        mode="subagent",
+        tools=[],
+        permissions=Ruleset(),
+        system_prompt="x",
+    )
+
+    assert agent_verdict("read", "*", silent.permissions) == "allow"
+    assert agent_verdict("write", "*", silent.permissions) == "ask"
+
+    advertised = {
+        tool.id
+        for tool in tool_registry.resolve_for_agent(
+            silent, extra_ruleset=_child_merged(silent, Ruleset())
+        )
+    }
+    assert "read" in advertised
+    assert "bash" in advertised
+    assert len(advertised) > 10
+
+
+def test_session_denial_still_removes_an_agent_allowed_tool(tool_registry) -> None:
+    """The extra ruleset keeps its veto — this is an intersection, not a swap."""
+    child = _restrictive_agent()
+    session_denies_read = Ruleset(
+        rules=[PermissionRule(action="deny", permission="read", pattern="*")]
+    )
+
+    advertised = {
+        tool.id
+        for tool in tool_registry.resolve_for_agent(
+            child, extra_ruleset=merge_rulesets(child.permissions, session_denies_read)
+        )
+    }
+
+    assert advertised == set()

--- a/backend/tests/test_provider/test_provider_error_surface.py
+++ b/backend/tests/test_provider/test_provider_error_surface.py
@@ -1,0 +1,115 @@
+"""The provider layer's own behaviour, driven directly.
+
+``test_stream_error_path`` monkeypatches ``stream_llm``, so it never reaches a
+real provider — the ``raise`` in ``OpenAICompatProvider.stream_chat`` that the
+whole unified-error-path change rests on had no coverage at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.provider.openai_compat import OpenAICompatProvider
+from app.schemas.provider import ModelPricing
+
+
+class _ExplodingStream:
+    """Stands in for the OpenAI SDK's streaming call."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    async def create(self, **kwargs: Any):
+        raise self._error
+
+
+class _Client:
+    def __init__(self, error: Exception) -> None:
+        self.chat = type("chat", (), {"completions": _ExplodingStream(error)})()
+
+
+class _Provider(OpenAICompatProvider):
+    @property
+    def id(self) -> str:
+        return "test-compat"
+
+    async def list_models(self):
+        return []
+
+    async def health_check(self):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+
+async def test_a_provider_failure_propagates_instead_of_becoming_a_chunk() -> None:
+    """Yielding an error chunk instead bypasses the retry classifier entirely.
+
+    The classifier reads the exception — including ``Retry-After`` off
+    ``e.response.headers`` — so the original object must survive unwrapped.
+    """
+    original = RuntimeError("Error code: 429 - rate limited")
+    original.response = type("r", (), {"headers": {"retry-after": "7"}})()
+
+    provider = _Provider(api_key="k", base_url="https://example.invalid")
+    provider._client = _Client(original)
+
+    with pytest.raises(RuntimeError) as caught:
+        async for _ in provider.stream_chat("m", [{"role": "user", "content": "hi"}]):
+            pass
+
+    assert caught.value is original, "the original exception must not be rewrapped"
+
+    from app.session.retry import is_retryable, retry_delay
+
+    assert is_retryable(caught.value) == "Rate limited"
+    assert retry_delay(0, caught.value) == 7.0
+
+
+async def test_no_error_chunk_is_ever_emitted() -> None:
+    provider = _Provider(api_key="k", base_url="https://example.invalid")
+    provider._client = _Client(RuntimeError("boom"))
+
+    chunks = []
+    with pytest.raises(RuntimeError):
+        async for chunk in provider.stream_chat("m", [{"role": "user", "content": "hi"}]):
+            chunks.append(chunk)
+
+    assert not any(c.type == "error" for c in chunks)
+
+
+def test_openrouter_publishes_the_catalog_cache_rates() -> None:
+    """Without these the cost calculator falls back to the prompt price.
+
+    Anthropic reads cache at ~0.1x prompt, so the fallback over-states a long
+    cached session by roughly an order of magnitude.
+    """
+    from app.provider.openrouter import _optional_per_million
+
+    assert _optional_per_million("0.0000005") == pytest.approx(0.5)
+    assert _optional_per_million(None) is None
+    assert _optional_per_million("not-a-number") is None
+    assert _optional_per_million("0") == 0.0, "a real zero is not 'unknown'"
+
+
+def test_catalog_rates_beat_the_fallback_in_the_cost_calculation() -> None:
+    from app.provider.openrouter import _optional_per_million
+    from app.schemas.provider import ModelInfo
+    from app.session.utils import calculate_step_cost
+
+    priced = ModelInfo(
+        id="m", name="m", provider_id="openrouter",
+        pricing=ModelPricing(
+            prompt=5.0,
+            completion=25.0,
+            cache_read=_optional_per_million("0.0000005"),
+        ),
+    )
+    unpriced = ModelInfo(
+        id="m", name="m", provider_id="openrouter",
+        pricing=ModelPricing(prompt=5.0, completion=25.0),
+    )
+    usage = {"input": 0, "output": 0, "cache_read": 1_000_000}
+
+    assert calculate_step_cost(usage, priced) == pytest.approx(0.5)
+    assert calculate_step_cost(usage, unpriced) == pytest.approx(5.0)

--- a/backend/tests/test_provider/test_provider_error_surface.py
+++ b/backend/tests/test_provider/test_provider_error_surface.py
@@ -92,7 +92,12 @@ def test_openrouter_publishes_the_catalog_cache_rates() -> None:
     assert _optional_per_million("0") == 0.0, "a real zero is not 'unknown'"
 
 
-def test_catalog_rates_beat_the_fallback_in_the_cost_calculation() -> None:
+def test_a_published_rate_is_what_prices_a_cached_read() -> None:
+    """Wiring the catalog rate is the whole mechanism — there is no fallback.
+
+    Guessing the prompt price for an unpublished rate over-states by ~10x, so
+    an unpriced model contributes nothing and the fix is to publish the rate.
+    """
     from app.provider.openrouter import _optional_per_million
     from app.schemas.provider import ModelInfo
     from app.session.utils import calculate_step_cost
@@ -100,9 +105,7 @@ def test_catalog_rates_beat_the_fallback_in_the_cost_calculation() -> None:
     priced = ModelInfo(
         id="m", name="m", provider_id="openrouter",
         pricing=ModelPricing(
-            prompt=5.0,
-            completion=25.0,
-            cache_read=_optional_per_million("0.0000005"),
+            prompt=5.0, completion=25.0, cache_read=_optional_per_million("0.0000005")
         ),
     )
     unpriced = ModelInfo(
@@ -112,4 +115,20 @@ def test_catalog_rates_beat_the_fallback_in_the_cost_calculation() -> None:
     usage = {"input": 0, "output": 0, "cache_read": 1_000_000}
 
     assert calculate_step_cost(usage, priced) == pytest.approx(0.5)
-    assert calculate_step_cost(usage, unpriced) == pytest.approx(5.0)
+    assert calculate_step_cost(usage, unpriced) == pytest.approx(0.0)
+
+
+def test_every_models_dev_provider_publishes_its_cache_rate() -> None:
+    """The rate is parsed centrally; each consumer has to actually read it.
+
+    Only OpenRouter did, so three providers priced every cached read at zero.
+    """
+    import inspect
+
+    from app.provider import anthropic_provider, generic_openai, gemini_provider
+
+    for module in (anthropic_provider, generic_openai, gemini_provider):
+        source = inspect.getsource(module)
+        assert "cache_read_price" in source, (
+            f"{module.__name__} builds ModelPricing without the parsed cache rate"
+        )

--- a/backend/tests/test_session/test_compaction_guards.py
+++ b/backend/tests/test_session/test_compaction_guards.py
@@ -1,0 +1,210 @@
+"""Compaction must shrink the context without destroying the user's copy.
+
+The newest summary becomes the permanent history anchor, so a bad summary is
+not a wasted call — it permanently replaces everything it was supposed to
+summarise. These tests pin the guards that stop a bad one from landing, and pin
+that pruning stays reversible.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncIterator
+
+import pytest
+
+from app.schemas.provider import StreamChunk
+from app.session import compaction as compaction_mod
+from app.session.compaction import (
+    PROTECTED_TOKEN_BUDGET,
+    SKIP_RECENT_TURNS,
+    _phase1_prune,
+    _phase2_summarize,
+)
+from app.session.manager import (
+    create_message,
+    create_part,
+    create_session,
+    get_message_history_for_llm,
+    get_messages,
+)
+from app.streaming.manager import GenerationJob
+
+
+async def _session_with_big_tool_output(session_factory, session_id: str, output: str):
+    """A history long enough to prune, ending at one oversized tool result.
+
+    The pruner protects the first ``PROTECTED_TOKEN_BUDGET`` tokens of tool
+    output outright, so the session needs an earlier tool result to absorb that
+    budget before the one under test becomes prunable.
+    """
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+            for index, text in enumerate((("f" * PROTECTED_TOKEN_BUDGET * 8), output)):
+                message = await create_message(
+                    db, session_id=session_id, data={"role": "assistant"}
+                )
+                await create_part(
+                    db,
+                    message_id=message.id,
+                    session_id=session_id,
+                    data={
+                        "type": "tool",
+                        "tool": "bash",
+                        "call_id": f"call-{index}",
+                        "state": {
+                            "status": "completed",
+                            "input": {"command": "cat report.txt"},
+                            "output": text,
+                        },
+                    },
+                )
+                target = message
+            # Recent turns are skipped by the pruner, so add enough after them.
+            for i in range(SKIP_RECENT_TURNS * 2 + 2):
+                await create_message(
+                    db, session_id=session_id, data={"role": "user", "text": f"turn {i}"}
+                )
+    return target
+
+
+async def test_prune_flags_the_part_without_destroying_the_stored_output(
+    session_factory,
+) -> None:
+    """The flag alone drives the model-facing substitution.
+
+    Overwriting the stored output produces a byte-identical prompt while
+    throwing away the user's only copy of a tool result — for an agent whose
+    deliverables live in tool output, that is data loss for no gain.
+    """
+    original = "x" * (PROTECTED_TOKEN_BUDGET * 8)
+    target = await _session_with_big_tool_output(
+        session_factory, "prune-keeps-output", original
+    )
+
+    pruned_parts, tokens_freed = await _phase1_prune(
+        "prune-keeps-output", session_factory=session_factory
+    )
+
+    assert pruned_parts == 1
+    assert tokens_freed > 0
+
+    async with session_factory() as db:
+        messages = await get_messages(db, "prune-keeps-output")
+    state = next(
+        part.data["state"]
+        for message in messages
+        if message.id == target.id
+        for part in message.parts
+        if part.data.get("type") == "tool"
+    )
+    assert state["time_compacted"] == "auto"
+    assert state["output"] == original, "the original tool output must survive pruning"
+
+
+async def test_pruned_output_is_still_hidden_from_the_model(session_factory) -> None:
+    """Keeping the row must not leak the bytes back into the prompt."""
+    original = "y" * (PROTECTED_TOKEN_BUDGET * 8)
+    await _session_with_big_tool_output(session_factory, "prune-hides-output", original)
+
+    await _phase1_prune("prune-hides-output", session_factory=session_factory)
+
+    async with session_factory() as db:
+        async with db.begin():
+            llm_messages = await get_message_history_for_llm(db, "prune-hides-output")
+
+    rendered = str(llm_messages)
+    assert "[truncated]" in rendered
+    assert original not in rendered
+
+
+def _summarizer(
+    monkeypatch, *, text: str, finish_reason: str | None = "stop"
+) -> None:
+    """Point _phase2_summarize at a scripted model and a fixed history."""
+
+    async def fake_history(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        return [{"role": "user", "content": "z" * 40_000}]
+
+    async def fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(type="text-delta", data={"text": text})
+        if finish_reason is not None:
+            yield StreamChunk(type="finish", data={"reason": finish_reason})
+
+    monkeypatch.setattr(
+        "app.session.manager.get_message_history_for_llm", fake_history
+    )
+    provider = SimpleNamespace(id="fake", stream_chat=fake_stream)
+    monkeypatch.setattr(
+        compaction_mod.ProviderRegistry,
+        "resolve_model",
+        lambda self, model_id: (provider, SimpleNamespace(id=model_id)),
+        raising=False,
+    )
+
+
+async def _summarize(session_factory, agent_registry) -> tuple[str | None, int]:
+    return await _phase2_summarize(
+        "summary-session",
+        job=GenerationJob("summary-stream", "summary-session"),
+        session_factory=session_factory,
+        provider_registry=compaction_mod.ProviderRegistry(),
+        agent_registry=agent_registry,
+        model_id="test-model",
+    )
+
+
+async def test_summary_truncated_at_the_output_cap_is_discarded(
+    session_factory, agent_registry, monkeypatch
+) -> None:
+    """A ``length`` finish means a half-written checkpoint — never persist it."""
+    _summarizer(monkeypatch, text="## Goal\nThe user asked me to", finish_reason="length")
+
+    summary, freed = await _summarize(session_factory, agent_registry)
+
+    assert summary is None
+    assert freed == 0
+
+
+async def test_summary_that_does_not_shrink_is_discarded(
+    session_factory, agent_registry, monkeypatch
+) -> None:
+    """Anchoring past 40k tokens of history behind a bigger summary is a loss."""
+    _summarizer(monkeypatch, text="q" * 200_000)
+
+    summary, freed = await _summarize(session_factory, agent_registry)
+
+    assert summary is None
+    assert freed == 0
+
+
+async def test_good_summary_is_kept_and_reports_what_it_freed(
+    session_factory, agent_registry, monkeypatch
+) -> None:
+    _summarizer(monkeypatch, text="## Goal\nShip the release.\n## Accomplished\nTagged rc.4.")
+
+    summary, freed = await _summarize(session_factory, agent_registry)
+
+    assert summary is not None
+    assert summary.startswith("## Goal")
+    assert freed > 0
+
+
+def test_circuit_breaker_trips_after_three_unproductive_compactions() -> None:
+    """``run_compaction`` swallows provider failures and returns normally, so
+    "freed nothing" is the only signal the caller has that it must stop."""
+    from app.session.prompt import SessionPrompt
+
+    prompt = SessionPrompt.__new__(SessionPrompt)
+    prompt._consecutive_compact_failures = 0
+    published: list[Any] = []
+    prompt.job = SimpleNamespace(session_id="cb", publish=published.append)
+
+    for expected in (1, 2):
+        assert prompt._record_compaction_failure() is False
+        assert prompt._consecutive_compact_failures == expected
+        assert published == []
+
+    assert prompt._record_compaction_failure() is True
+    assert len(published) == 1, "the user must be told compaction gave up"

--- a/backend/tests/test_session/test_compaction_guards.py
+++ b/backend/tests/test_session/test_compaction_guards.py
@@ -120,17 +120,31 @@ async def test_pruned_output_is_still_hidden_from_the_model(session_factory) -> 
 
 
 def _summarizer(
-    monkeypatch, *, text: str, finish_reason: str | None = "stop"
+    monkeypatch,
+    *,
+    text: str,
+    finish_reason: str | None = "stop",
+    first_only_cap: bool = False,
+    budgets: list[int] | None = None,
+    history_chars: int = 40_000,
 ) -> None:
     """Point _phase2_summarize at a scripted model and a fixed history."""
 
     async def fake_history(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
-        return [{"role": "user", "content": "z" * 40_000}]
+        return [{"role": "user", "content": "z" * history_chars}]
+
+    calls = {"n": 0}
 
     async def fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        calls["n"] += 1
+        if budgets is not None:
+            budgets.append(kwargs.get("max_tokens"))
         yield StreamChunk(type="text-delta", data={"text": text})
-        if finish_reason is not None:
-            yield StreamChunk(type="finish", data={"reason": finish_reason})
+        reason = finish_reason
+        if first_only_cap and calls["n"] > 1:
+            reason = "stop"
+        if reason is not None:
+            yield StreamChunk(type="finish", data={"reason": reason})
 
     monkeypatch.setattr(
         "app.session.manager.get_message_history_for_llm", fake_history
@@ -160,6 +174,56 @@ async def test_summary_truncated_at_the_output_cap_is_discarded(
 ) -> None:
     """A ``length`` finish means a half-written checkpoint — never persist it."""
     _summarizer(monkeypatch, text="## Goal\nThe user asked me to", finish_reason="length")
+
+    summary, freed = await _summarize(session_factory, agent_registry)
+
+    assert summary is None
+    assert freed == 0
+
+
+async def test_a_capped_summary_is_retried_at_a_larger_budget(
+    session_factory, agent_registry, monkeypatch
+) -> None:
+    """Discarding is right; discarding without a second try dead-ends sessions.
+
+    Three consecutive discards trip the caller's circuit breaker and tell the
+    user to start a new conversation — for a history that simply needed more
+    room than the first budget allowed.
+    """
+    from app.session.compaction import SUMMARY_MAX_TOKENS, SUMMARY_RETRY_MAX_TOKENS
+
+    budgets: list[int] = []
+    _summarizer(
+        monkeypatch,
+        text="## Goal\nShip it.\n## Accomplished\nDone.",
+        finish_reason="length",
+        first_only_cap=True,
+        budgets=budgets,
+    )
+
+    summary, freed = await _summarize(session_factory, agent_registry)
+
+    assert budgets == [SUMMARY_MAX_TOKENS, SUMMARY_RETRY_MAX_TOKENS]
+    assert summary is not None, "the second attempt succeeded and must be kept"
+    assert freed > 0
+
+
+async def test_the_shrink_guard_measures_the_persisted_wrapper(
+    session_factory, agent_registry, monkeypatch
+) -> None:
+    """A summary is stored inside a fixed wrapper; the guard must count it.
+
+    Counting the bare text leaves a permanent positive margin, which reads as
+    progress on a session where compaction is achieving nothing and keeps
+    resetting the circuit breaker.
+    """
+    from app.session.compaction import _wrap_summary
+
+    bare = "x" * 40
+    assert len(_wrap_summary(bare, visible=False)) > len(bare)
+
+    # A summary that only "shrinks" once its wrapper is ignored must be refused.
+    _summarizer(monkeypatch, text=bare, history_chars=len(bare) + 8)
 
     summary, freed = await _summarize(session_factory, agent_registry)
 

--- a/backend/tests/test_session/test_policy_surfaces.py
+++ b/backend/tests/test_session/test_policy_surfaces.py
@@ -1,0 +1,143 @@
+"""The pre-tool policy hook must actually run, and be order-independent.
+
+``run_before_tool_exec`` was declared, implemented by LoopDetectionMiddleware,
+and called by nobody — so the loop detector's warn stage never fired, and any
+policy middleware a contributor added would have been silently inert.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.session.middleware import (
+    Middleware,
+    MiddlewareChain,
+    MiddlewareContext,
+    ToolAction,
+)
+from app.session.middlewares.loop_detection import LoopDetectionMiddleware
+from app.streaming.manager import GenerationJob
+
+
+class _Recorder(Middleware):
+    def __init__(self, verdict: str, log: list[str], name: str) -> None:
+        self._verdict = verdict
+        self._log = log
+        self._name = name
+
+    async def before_tool_exec(
+        self, tool_name: str, tool_args: dict[str, Any], ctx: MiddlewareContext
+    ) -> ToolAction:
+        self._log.append(self._name)
+        return ToolAction(action=self._verdict, message=f"{self._name} says {self._verdict}")
+
+
+def _ctx() -> MiddlewareContext:
+    return MiddlewareContext(
+        session_id="policy-session", step=0, job=GenerationJob("s", "policy-session")
+    )
+
+
+async def test_the_strictest_verdict_wins_regardless_of_order() -> None:
+    for order in (["allow", "block", "warn"], ["block", "warn", "allow"]):
+        chain = MiddlewareChain()
+        log: list[str] = []
+        for index, verdict in enumerate(order):
+            chain.add(_Recorder(verdict, log, f"{verdict}{index}"))
+
+        decision = await chain.run_before_tool_exec("bash", {}, _ctx())
+
+        assert decision.action == "block"
+        assert len(log) == len(order), "every middleware must run, even after a block"
+
+
+async def test_a_blocking_middleware_does_not_starve_a_later_observer() -> None:
+    """Loop detection counts calls; a block above it must not stop the counter."""
+    chain = MiddlewareChain()
+    log: list[str] = []
+    chain.add(_Recorder("block", log, "gate"))
+    chain.add(_Recorder("allow", log, "counter"))
+
+    await chain.run_before_tool_exec("bash", {}, _ctx())
+
+    assert log == ["gate", "counter"]
+
+
+async def test_loop_detection_warn_stage_reaches_the_tool_output() -> None:
+    """The warn message is stashed in before_tool_exec and appended after —
+    with the hook uncalled, neither half ever ran."""
+    from app.session.loop_detection import loop_detector
+
+    chain = MiddlewareChain()
+    chain.add(LoopDetectionMiddleware())
+    ctx = _ctx()
+    loop_detector.reset(ctx.session_id)
+
+    warned = False
+    for _ in range(10):
+        decision = await chain.run_before_tool_exec("read", {"path": "same.txt"}, ctx)
+        if decision.action == "block":
+            break
+        output = await chain.run_after_tool_exec(
+            "read", {"path": "same.txt"}, "file contents", ctx
+        )
+        if output != "file contents":
+            warned = True
+            break
+
+    assert warned, "repeating one identical call must eventually warn the model"
+
+
+def test_ask_defaults_closed_when_nobody_can_be_asked() -> None:
+    """A permission primitive with no way to prompt must not self-approve."""
+    import asyncio
+
+    from app.tool.context import ToolContext
+
+    ctx = ToolContext(
+        session_id="s",
+        message_id="m",
+        agent=None,
+        call_id="c",
+        abort_event=asyncio.Event(),
+    )
+    assert asyncio.run(ctx.ask("bash")) is False
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        ({"input": 1_000_000, "output": 0}, 3.0),
+        ({"input": 0, "output": 1_000_000}, 15.0),
+        # Cached input used to cost nothing at all.
+        ({"input": 0, "output": 0, "cache_read": 1_000_000}, 0.3),
+        ({"input": 0, "output": 0, "cache_write": 1_000_000}, 3.75),
+    ],
+)
+def test_cached_tokens_are_priced(usage: dict[str, int], expected: float) -> None:
+    from app.schemas.provider import ModelInfo, ModelPricing
+    from app.session.utils import calculate_step_cost
+
+    model = ModelInfo(
+        id="m",
+        name="m",
+        provider_id="p",
+        pricing=ModelPricing(
+            prompt=3.0, completion=15.0, cache_read=0.3, cache_write=3.75
+        ),
+    )
+    assert calculate_step_cost(usage, model) == pytest.approx(expected)
+
+
+def test_cached_tokens_fall_back_to_the_prompt_price() -> None:
+    """Absent catalog rates, over-state rather than bill cache reads at zero."""
+    from app.schemas.provider import ModelInfo, ModelPricing
+    from app.session.utils import calculate_step_cost
+
+    model = ModelInfo(
+        id="m", name="m", provider_id="p", pricing=ModelPricing(prompt=3.0, completion=15.0)
+    )
+    cost = calculate_step_cost({"input": 0, "output": 0, "cache_read": 1_000_000}, model)
+    assert cost == pytest.approx(3.0)

--- a/backend/tests/test_session/test_policy_surfaces.py
+++ b/backend/tests/test_session/test_policy_surfaces.py
@@ -113,7 +113,9 @@ def test_ask_defaults_closed_when_nobody_can_be_asked() -> None:
         ({"input": 0, "output": 1_000_000}, 15.0),
         # Cached input used to cost nothing at all.
         ({"input": 0, "output": 0, "cache_read": 1_000_000}, 0.3),
-        ({"input": 0, "output": 0, "cache_write": 1_000_000}, 3.75),
+        # Cache writes stay inside `input` on the OpenAI-shaped path, so
+        # pricing them separately here would bill them twice.
+        ({"input": 0, "output": 0, "cache_write": 1_000_000}, 0.0),
     ],
 )
 def test_cached_tokens_are_priced(usage: dict[str, int], expected: float) -> None:
@@ -131,8 +133,13 @@ def test_cached_tokens_are_priced(usage: dict[str, int], expected: float) -> Non
     assert calculate_step_cost(usage, model) == pytest.approx(expected)
 
 
-def test_cached_tokens_fall_back_to_the_prompt_price() -> None:
-    """Absent catalog rates, over-state rather than bill cache reads at zero."""
+def test_an_unpublished_cache_rate_is_not_guessed() -> None:
+    """Substituting the prompt price over-states by ~10x — worse than zero.
+
+    Anthropic reads cache at roughly 0.1x prompt. A provider whose catalog does
+    not publish the rate gets no cache term, exactly as before; the fix is to
+    publish the rate, which models.dev already parses.
+    """
     from app.schemas.provider import ModelInfo, ModelPricing
     from app.session.utils import calculate_step_cost
 
@@ -140,4 +147,4 @@ def test_cached_tokens_fall_back_to_the_prompt_price() -> None:
         id="m", name="m", provider_id="p", pricing=ModelPricing(prompt=3.0, completion=15.0)
     )
     cost = calculate_step_cost({"input": 0, "output": 0, "cache_read": 1_000_000}, model)
-    assert cost == pytest.approx(3.0)
+    assert cost == pytest.approx(0.0)

--- a/backend/tests/test_session/test_processor_permission.py
+++ b/backend/tests/test_session/test_processor_permission.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.session.middleware import ToolAction
 from app.session.processor import (
     SessionProcessor,
     _permission_arguments_for_event,
@@ -387,7 +388,7 @@ async def test_cancelled_dispatch_finalizes_running_tool_part(
     processor._exec_metadata = {
         0: {
             "tool_part_id": tool_part.id,
-            "loop_result": None,
+            "policy_decision": ToolAction(action="allow"),
             "tool": TaskTool(),
             "tool_args": {"prompt": "wait"},
             "call_id": "cancel-call",
@@ -586,7 +587,7 @@ async def test_completed_tool_part_retries_transient_terminal_write(
         0,
         {
             "tool_part_id": part.id,
-            "loop_result": SimpleNamespace(action="none", message=None),
+            "policy_decision": ToolAction(action="allow"),
             "tool": TaskTool(),
             "tool_args": {},
             "call_id": "completed-retry-call",

--- a/backend/tests/test_session/test_retry.py
+++ b/backend/tests/test_session/test_retry.py
@@ -53,6 +53,35 @@ class TestIsRetryable:
         e = Exception("max_tokens exceeded for this model")
         assert is_retryable(e) is None
 
+    def test_a_max_tokens_parameter_error_is_not_a_context_overflow(self):
+        """Only the *input* being too large may route to reactive compaction.
+
+        Providers reject an oversized completion budget with a 400 naming the
+        `max_tokens` parameter. Reading that as overflow sends the session into
+        a compaction loop that cannot fix it — compaction shrinks the input.
+        """
+        from app.session.retry import is_context_overflow
+
+        for message in (
+            "Invalid value for max_tokens: must be <= 4096",
+            "400 Bad Request: max_tokens is required",
+        ):
+            error = Exception(message)
+            assert is_context_overflow(error) is False, message
+            assert is_retryable(error) is None, message
+
+    def test_real_overflow_messages_still_route_to_compaction(self):
+        from app.session.retry import is_context_overflow
+
+        for message in (
+            "This model maximum context length is 8192 tokens",
+            "context_length_exceeded: too long",
+            "prompt is too long: 250000 tokens > 200000 maximum",
+            "input too long for this model",
+            "Requested tokens exceed context limit of 128000",
+        ):
+            assert is_context_overflow(Exception(message)) is True, message
+
     def test_generic_error_not_retryable(self):
         e = Exception("Something unexpected happened")
         assert is_retryable(e) is None

--- a/backend/tests/test_session/test_stream_error_path.py
+++ b/backend/tests/test_session/test_stream_error_path.py
@@ -1,0 +1,195 @@
+"""Every provider stream failure must reach the retry classifier.
+
+``tests/test_session/test_retry.py`` covers the pure classifiers in
+``app.session.retry``. It cannot catch the failure these tests guard against:
+a provider that reports an error *without raising* never reaches those
+classifiers at all, so backoff, the 429/5xx retry budget, and context-overflow
+recovery are silently skipped for it. These tests drive the real
+``_stream_llm_with_retry`` loop instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncIterator
+
+import pytest
+
+from app.provider.base import ProviderStreamError
+from app.schemas.provider import StreamChunk
+from app.session.manager import create_message, create_session
+from app.session.processor import SessionProcessor
+from app.streaming.manager import GenerationJob
+
+
+def _text_chunk(text: str) -> StreamChunk:
+    return StreamChunk(type="text-delta", data={"text": text})
+
+
+async def _make_processor(session_factory, session_id: str) -> SessionProcessor:
+    """A processor wired far enough to run ``_stream_llm_with_retry``."""
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+            assistant = await create_message(
+                db, session_id=session_id, data={"role": "assistant"}
+            )
+
+    job = GenerationJob(f"{session_id}-stream", session_id)
+    prompt = SimpleNamespace(
+        job=job,
+        session_factory=session_factory,
+        provider=SimpleNamespace(id="generic"),
+        model_id="test-model",
+        request=SimpleNamespace(format=None),
+        agent=SimpleNamespace(name="general"),
+        tool_registry=SimpleNamespace(to_openai_specs=lambda *a, **k: []),
+        merged_permissions=None,
+        discovered_tools=None,
+        system_prompt=None,
+    )
+    processor = SessionProcessor(prompt, [], assistant.id)
+    processor._init_step_state()
+    return processor
+
+
+def _stub_stream_prerequisites(processor: SessionProcessor, monkeypatch) -> None:
+    """Skip arg-building and the vision gate; keep the retry loop itself real."""
+
+    async def build_args() -> tuple[Any, int, set[str] | None]:
+        return None, 1024, None
+
+    async def not_vision_blocked() -> None:
+        return None
+
+    monkeypatch.setattr(processor, "_build_stream_args", build_args)
+    monkeypatch.setattr(processor, "_check_vision_blocked", not_vision_blocked)
+
+
+def _no_backoff(monkeypatch) -> list[float]:
+    """Record backoff delays without actually sleeping."""
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float, abort_event=None) -> bool:
+        slept.append(delay)
+        return False
+
+    monkeypatch.setattr("app.session.processor.sleep_with_abort", fake_sleep)
+    return slept
+
+
+@pytest.mark.parametrize(
+    "signal",
+    ["raise", "chunk"],
+    ids=["provider raises", "provider yields an error chunk"],
+)
+async def test_rate_limit_is_retried_however_the_provider_reports_it(
+    session_factory, monkeypatch, signal: str
+) -> None:
+    """A 429 must be retried whether the provider raises or yields a chunk.
+
+    The chunk case is the regression: it used to return straight out of the
+    retry loop, so no OpenAI-compatible provider ever retried anything.
+    """
+    processor = await _make_processor(session_factory, f"retry-429-{signal}")
+    _stub_stream_prerequisites(processor, monkeypatch)
+    slept = _no_backoff(monkeypatch)
+
+    attempts = 0
+
+    async def flaky_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            if signal == "raise":
+                raise ProviderStreamError("Error code: 429 - rate limit exceeded")
+            yield StreamChunk(
+                type="error", data={"message": "Error code: 429 - rate limit exceeded"}
+            )
+            return
+        yield _text_chunk("recovered")
+
+    monkeypatch.setattr("app.session.processor.stream_llm", flaky_stream)
+
+    early = await processor._stream_llm_with_retry()
+
+    assert early is None, "a retryable error must not end the step"
+    assert attempts == 2, "the stream must be re-attempted after a 429"
+    assert processor._accumulated_text == "recovered"
+    assert processor._stream_error is None
+    assert len(slept) == 1, "the retry must go through backoff"
+
+
+async def test_context_overflow_is_not_retried_and_reaches_reactive_compaction(
+    session_factory, monkeypatch
+) -> None:
+    """Overflow is non-retryable and must hand off to compaction, not stop."""
+    processor = await _make_processor(session_factory, "retry-overflow")
+    _stub_stream_prerequisites(processor, monkeypatch)
+    slept = _no_backoff(monkeypatch)
+
+    attempts = 0
+
+    async def overflowing_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        yield StreamChunk(
+            type="error",
+            data={"message": "This model's maximum context length is 8192 tokens"},
+        )
+
+    monkeypatch.setattr("app.session.processor.stream_llm", overflowing_stream)
+
+    early = await processor._stream_llm_with_retry()
+
+    assert early is None
+    assert attempts == 1, "overflow must not be retried"
+    assert slept == [], "overflow must not back off"
+    assert processor._stream_error is not None
+
+    assert await processor._handle_stream_error() == "compact"
+
+
+async def test_non_retryable_error_stops_after_one_attempt(
+    session_factory, monkeypatch
+) -> None:
+    """A 400 is neither retried nor mistaken for overflow."""
+    processor = await _make_processor(session_factory, "retry-bad-request")
+    _stub_stream_prerequisites(processor, monkeypatch)
+    _no_backoff(monkeypatch)
+
+    attempts = 0
+
+    async def failing_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        raise ProviderStreamError("Error code: 400 - invalid tool schema")
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr("app.session.processor.stream_llm", failing_stream)
+
+    assert await processor._stream_llm_with_retry() is None
+    assert attempts == 1
+    assert await processor._handle_stream_error() == "stop"
+
+
+async def test_error_chunk_code_survives_onto_the_exception(
+    session_factory, monkeypatch
+) -> None:
+    """``needs_reauth`` and friends must not be dropped in translation."""
+    processor = await _make_processor(session_factory, "retry-code")
+    _stub_stream_prerequisites(processor, monkeypatch)
+    _no_backoff(monkeypatch)
+
+    async def reauth_stream(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(
+            type="error",
+            data={"message": "Authentication failed.", "code": "needs_reauth"},
+        )
+
+    monkeypatch.setattr("app.session.processor.stream_llm", reauth_stream)
+
+    await processor._stream_llm_with_retry()
+
+    assert isinstance(processor._stream_error, ProviderStreamError)
+    assert processor._stream_error.code == "needs_reauth"

--- a/backend/tests/test_session/test_stream_error_side_effects.py
+++ b/backend/tests/test_session/test_stream_error_side_effects.py
@@ -1,0 +1,193 @@
+"""A retry must never re-run a tool that already ran.
+
+Routing provider failures through the retry classifier made a path reachable
+that could not happen before: a stream that fails *after* tool-call chunks were
+dispatched. The executor and `_exec_metadata` outlive
+`_reset_stream_accumulators`, so replaying the stream submits the same calls a
+second time — and OpenYak's tools send email and write deliverables.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncIterator
+
+from app.provider.base import ProviderStreamError
+from app.schemas.provider import StreamChunk
+from app.session.manager import create_message, create_session
+from app.session.processor import SessionProcessor
+from app.streaming.manager import GenerationJob
+from app.tool.base import ToolDefinition, ToolResult
+
+
+class _SideEffectTool(ToolDefinition):
+    """Stands in for send_email: records every execution, cannot be undone."""
+
+    def __init__(self, log: list[str]) -> None:
+        self._log = log
+
+    @property
+    def id(self) -> str:
+        return "send_email"
+
+    @property
+    def description(self) -> str:
+        return "send an email"
+
+    @property
+    def is_concurrency_safe(self) -> bool:
+        return True
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict[str, Any], ctx: Any) -> ToolResult:
+        self._log.append("SENT")
+        return ToolResult(output="sent")
+
+    async def __call__(self, args: dict[str, Any], ctx: Any) -> ToolResult:
+        return await self.execute(args, ctx)
+
+
+async def test_a_dispatched_tool_is_not_re_run_when_the_stream_then_fails(
+    session_factory, monkeypatch
+) -> None:
+    """A drop after the tool-call chunk must end the step, not replay it.
+
+    `openai_compat` emits accumulated tool calls at `finish_reason` and keeps
+    reading for the trailing usage frame, so a connection reset there arrives
+    with the tool already dispatched — and "connection" is retryable.
+    """
+    session_id = "retry-side-effect"
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+            assistant = await create_message(
+                db, session_id=session_id, data={"role": "assistant"}
+            )
+
+    sent: list[str] = []
+    job = GenerationJob(f"{session_id}-stream", session_id)
+    prompt = SimpleNamespace(
+        job=job,
+        session_factory=session_factory,
+        provider=SimpleNamespace(id="generic"),
+        model_id="test-model",
+        request=SimpleNamespace(format=None),
+        agent=SimpleNamespace(name="general", tools=[]),
+        tool_registry=SimpleNamespace(to_openai_specs=lambda *a, **k: []),
+        merged_permissions=None,
+        discovered_tools=None,
+        system_prompt=None,
+    )
+    processor = SessionProcessor(prompt, [], assistant.id)
+    processor._init_step_state()
+
+    async def build_args() -> tuple[Any, int, set[str] | None]:
+        return None, 1024, None
+
+    async def not_blocked() -> None:
+        return None
+
+    attempts = 0
+
+    async def dispatch(chunk: Any) -> None:
+        """Stand in for the real handler: submit straight to the executor."""
+        from app.session.tool_executor import ToolCallInfo
+
+        processor._streaming_executor.submit(
+            ToolCallInfo(
+                index=processor._exec_index,
+                tool=_SideEffectTool(sent),
+                tool_name="send_email",
+                tool_args={},
+                call_id=f"call-{processor._exec_index}",
+                ctx=SimpleNamespace(is_aborted=False),
+                timeout=5.0,
+            )
+        )
+        processor._exec_index += 1
+
+    async def flaky(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        yield StreamChunk(
+            type="tool-call", data={"id": "c1", "name": "send_email", "arguments": {}}
+        )
+        yield StreamChunk(type="finish", data={"reason": "tool_calls"})
+        raise ProviderStreamError("peer closed connection without sending a body")
+
+    monkeypatch.setattr(processor, "_build_stream_args", build_args)
+    monkeypatch.setattr(processor, "_check_vision_blocked", not_blocked)
+    monkeypatch.setattr(processor, "_handle_tool_call_chunk", dispatch)
+    monkeypatch.setattr("app.session.processor.stream_llm", flaky)
+
+    async def no_sleep(delay: float, abort_event=None) -> bool:
+        return False
+
+    monkeypatch.setattr("app.session.processor.sleep_with_abort", no_sleep)
+
+    await processor._stream_llm_with_retry()
+    results = await processor._streaming_executor.collect()
+
+    assert attempts == 1, "a retry here would dispatch the email a second time"
+    assert sent.count("SENT") <= 1, f"the email was sent {len(sent)} times"
+    assert len(results) == 1
+    assert processor._stream_error is not None
+
+
+async def test_a_failure_before_any_tool_call_still_retries(
+    session_factory, monkeypatch
+) -> None:
+    """The common case — a 429 on connect — must keep its retry."""
+    session_id = "retry-no-side-effect"
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+            assistant = await create_message(
+                db, session_id=session_id, data={"role": "assistant"}
+            )
+
+    job = GenerationJob(f"{session_id}-stream", session_id)
+    prompt = SimpleNamespace(
+        job=job,
+        session_factory=session_factory,
+        provider=SimpleNamespace(id="generic"),
+        model_id="test-model",
+        request=SimpleNamespace(format=None),
+        agent=SimpleNamespace(name="general", tools=[]),
+        tool_registry=SimpleNamespace(to_openai_specs=lambda *a, **k: []),
+        merged_permissions=None,
+        discovered_tools=None,
+        system_prompt=None,
+    )
+    processor = SessionProcessor(prompt, [], assistant.id)
+    processor._init_step_state()
+
+    attempts = 0
+
+    async def flaky(*args: Any, **kwargs: Any) -> AsyncIterator[StreamChunk]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ProviderStreamError("Error code: 429 - rate limited")
+        yield StreamChunk(type="text-delta", data={"text": "recovered"})
+
+    async def build_args() -> tuple[Any, int, set[str] | None]:
+        return None, 1024, None
+
+    async def not_blocked() -> None:
+        return None
+
+    async def no_sleep(delay: float, abort_event=None) -> bool:
+        return False
+
+    monkeypatch.setattr(processor, "_build_stream_args", build_args)
+    monkeypatch.setattr(processor, "_check_vision_blocked", not_blocked)
+    monkeypatch.setattr("app.session.processor.stream_llm", flaky)
+    monkeypatch.setattr("app.session.processor.sleep_with_abort", no_sleep)
+
+    await processor._stream_llm_with_retry()
+
+    assert attempts == 2
+    assert processor._accumulated_text == "recovered"

--- a/backend/tests/test_session/test_tool_dispatch_policy.py
+++ b/backend/tests/test_session/test_tool_dispatch_policy.py
@@ -1,0 +1,188 @@
+"""The pre-execution verdict must survive to finalization intact.
+
+``_handle_tool_call_chunk`` computes a ``ToolAction``, stores it in
+``_exec_metadata``, and ``_build_tool_persist_output`` reads ``.action`` off it
+much later. An interactive permission prompt runs in between and used to rebind
+the same local name to its own ``{allowed, remember, pattern}`` dict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.agent.agent import BUILTIN_AGENTS
+from app.agent.permission import GLOBAL_DEFAULTS, merge_rulesets
+from app.schemas.agent import PermissionRule, Ruleset
+from app.session.manager import create_message, create_session
+from app.session.middleware import MiddlewareContext, ToolAction
+from app.session.middlewares.factory import build_middleware_chain
+from app.session.processor import SessionProcessor
+from app.streaming.manager import GenerationJob
+from app.tool.base import ToolDefinition, ToolResult
+from app.tool.registry import ToolRegistry
+
+
+class _Echo(ToolDefinition):
+    def __init__(self, tool_id: str = "read") -> None:
+        self._id = tool_id
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return self._id
+
+    @property
+    def is_concurrency_safe(self) -> bool:
+        return True
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {"path": {"type": "string"}}}
+
+    async def execute(self, args: dict[str, Any], ctx: Any) -> ToolResult:
+        return ToolResult(output="contents")
+
+
+async def _processor(session_factory, session_id: str, *, with_chain: bool):
+    async with session_factory() as db:
+        async with db.begin():
+            await create_session(db, id=session_id)
+            assistant = await create_message(
+                db, session_id=session_id, data={"role": "assistant"}
+            )
+
+    registry = ToolRegistry()
+    registry.register(_Echo())
+    job = GenerationJob(f"{session_id}-stream", session_id)
+    job.interactive = True
+
+    agent = BUILTIN_AGENTS["build"]
+    prompt = SimpleNamespace(
+        job=job,
+        session_factory=session_factory,
+        agent=agent,
+        tool_registry=registry,
+        # `read` resolves to ask, so the interactive prompt runs.
+        merged_permissions=merge_rulesets(
+            GLOBAL_DEFAULTS,
+            Ruleset(rules=[PermissionRule(action="ask", permission="read")]),
+        ),
+        inheritable_permissions=Ruleset(),
+        workspace=None,
+        discovered_tools=None,
+        model_id="m",
+        provider=SimpleNamespace(id="p"),
+        request=SimpleNamespace(reasoning=None, execution_mode="standard", format=None),
+        current_todos=[],
+        middleware_chain=build_middleware_chain(),
+        step=0,
+        provider_registry=SimpleNamespace(resolve_model=lambda *a, **k: None),
+        agent_registry=SimpleNamespace(get=lambda name: None),
+        index_manager=None,
+        session_id=session_id,
+        total_cost=0.0,
+    )
+    ctx = (
+        MiddlewareContext(session_id=session_id, step=0, job=job)
+        if with_chain
+        else None
+    )
+    processor = SessionProcessor(prompt, [], assistant.id, middleware_ctx=ctx)
+    processor._init_step_state()
+    processor._advertised_tool_ids = {"read"}
+    return processor
+
+
+@pytest.mark.parametrize("with_chain", [True, False], ids=["with chain", "chain-less"])
+async def test_an_approved_ask_leaves_a_toolaction_in_the_metadata(
+    session_factory, monkeypatch, with_chain: bool
+) -> None:
+    """The user approving a prompt must not overwrite the policy verdict.
+
+    The chain-less branch is covered too: it is the one the same change kept
+    alive so loop protection is never silently absent, and it is where a dict
+    here becomes an AttributeError during finalization.
+    """
+    processor = await _processor(
+        session_factory, f"ask-{with_chain}", with_chain=with_chain
+    )
+
+    async def approve(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"allowed": True, "remember": False, "pattern": None}
+
+    monkeypatch.setattr("app.session.processor._ask_permission", approve)
+
+    await processor._handle_tool_call_chunk(
+        SimpleNamespace(
+            data={"id": "call-1", "name": "read", "arguments": {"path": "a.txt"}}
+        )
+    )
+
+    assert processor._exec_metadata, "the call should have been dispatched"
+    stored = processor._exec_metadata[0]["policy_decision"]
+    assert isinstance(stored, ToolAction), f"got {stored!r}"
+    assert stored.action in {"allow", "warn"}
+
+
+async def test_the_approved_call_finalizes_without_crashing(
+    session_factory, monkeypatch
+) -> None:
+    """End to end on the chain-less branch, where the dict used to be read."""
+    processor = await _processor(session_factory, "ask-finalize", with_chain=False)
+
+    async def approve(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"allowed": True, "remember": False, "pattern": None}
+
+    monkeypatch.setattr("app.session.processor._ask_permission", approve)
+
+    await processor._handle_tool_call_chunk(
+        SimpleNamespace(
+            data={"id": "call-1", "name": "read", "arguments": {"path": "a.txt"}}
+        )
+    )
+    results = await processor._streaming_executor.collect()
+    assert len(results) == 1
+
+    meta = processor._exec_metadata[results[0].index]
+    output = await processor._build_tool_persist_output(
+        meta["tool"], meta["tool_args"], results[0].result, meta["policy_decision"]
+    )
+    assert "contents" in output
+
+
+async def test_a_loop_warning_lands_on_the_call_that_earned_it(session_factory) -> None:
+    """One shared slot would append it to whichever call finalizes first."""
+    from app.session.loop_detection import loop_detector
+
+    chain = build_middleware_chain()
+    ctx = MiddlewareContext(
+        session_id="warn-routing", step=0, job=GenerationJob("s", "warn-routing")
+    )
+    loop_detector.reset(ctx.session_id)
+
+    repeated = {"path": "same.txt"}
+
+    warned_on_repeat = False
+    for attempt in range(12):
+        if (await chain.run_before_tool_exec("read", repeated, ctx)).action == "block":
+            break
+        # A distinct sibling in the same step: never repeated, so it earns no
+        # warning of its own and must not carry the repeated call's.
+        other = {"pattern": f"needle-{attempt}"}
+        await chain.run_before_tool_exec("grep", other, ctx)
+
+        stolen = await chain.run_after_tool_exec("grep", other, "grep output", ctx)
+        assert stolen == "grep output", "the warning belongs to the repeated call"
+
+        earned = await chain.run_after_tool_exec("read", repeated, "file body", ctx)
+        if earned != "file body":
+            warned_on_repeat = True
+            break
+
+    assert warned_on_repeat, "the repeated call must eventually carry the warning"

--- a/backend/tests/test_session/test_tool_executor_ordering.py
+++ b/backend/tests/test_session/test_tool_executor_ordering.py
@@ -87,9 +87,16 @@ def _call(index: int, tool: ToolDefinition, tag: str) -> ToolCallInfo:
 
 
 async def test_an_exclusive_call_is_a_barrier_for_later_reads() -> None:
-    """``[write(f), read(f)]`` must not answer from the pre-write file."""
+    """``[write(f), read(f)]`` must not answer from the pre-write file.
+
+    The exclusive tool must actually suspend. Awaiting a coroutine that never
+    yields does not hand control back to the loop, so an eagerly-started read
+    could not interleave even without the barrier — and the test would pass
+    against the very bug it names. Every real exclusive tool (write, edit,
+    bash, apply_patch) does I/O and suspends.
+    """
     log: list[str] = []
-    write = _RecordingTool("write", log, concurrency_safe=False)
+    write = _RecordingTool("write", log, concurrency_safe=False, delay=0.02)
     read = _RecordingTool("read", log, concurrency_safe=True)
 
     executor = StreamingToolExecutor(asyncio.Event())
@@ -98,7 +105,7 @@ async def test_an_exclusive_call_is_a_barrier_for_later_reads() -> None:
 
     results = await executor.collect()
 
-    assert log.index("end:write") < log.index("start:read")
+    assert log == ["start:write", "end:write", "start:read", "end:read"]
     assert [r.tool_name for r in results] == ["write", "read"]
 
 

--- a/backend/tests/test_session/test_tool_executor_ordering.py
+++ b/backend/tests/test_session/test_tool_executor_ordering.py
@@ -1,0 +1,237 @@
+"""Tools must execute in the order the model asked for them.
+
+Results are reported in model order regardless of when they ran, so an
+execution-order bug produces a transcript that looks correct and an answer that
+is wrong. These tests assert on the *execution* log, never the returned order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.session.tool_executor import (
+    StreamingToolExecutor,
+    ToolCallInfo,
+)
+from app.tool.base import ToolDefinition, ToolResult
+
+
+class _RecordingTool(ToolDefinition):
+    """A tool that logs when it starts and finishes, and can fail on demand."""
+
+    def __init__(
+        self,
+        tool_id: str,
+        log: list[str],
+        *,
+        concurrency_safe: bool,
+        delay: float = 0.0,
+        fails: bool = False,
+        in_flight: dict[str, int] | None = None,
+    ) -> None:
+        self._id = tool_id
+        self._log = log
+        self._safe = concurrency_safe
+        self._delay = delay
+        self._fails = fails
+        self._in_flight = in_flight if in_flight is not None else {"now": 0, "peak": 0}
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return self._id
+
+    @property
+    def is_concurrency_safe(self) -> bool:
+        return self._safe
+
+    def parameters_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, args: dict[str, Any], ctx: Any) -> ToolResult:
+        tag = args.get("tag", self._id)
+        self._in_flight["now"] += 1
+        self._in_flight["peak"] = max(self._in_flight["peak"], self._in_flight["now"])
+        self._log.append(f"start:{tag}")
+        try:
+            if self._delay:
+                await asyncio.sleep(self._delay)
+            if self._fails:
+                raise RuntimeError(f"{tag} failed")
+            return ToolResult(output=tag)
+        finally:
+            self._in_flight["now"] -= 1
+            self._log.append(f"end:{tag}")
+
+    async def __call__(self, args: dict[str, Any], ctx: Any) -> ToolResult:
+        return await self.execute(args, ctx)
+
+
+def _call(index: int, tool: ToolDefinition, tag: str) -> ToolCallInfo:
+    return ToolCallInfo(
+        index=index,
+        tool=tool,
+        tool_name=tool.id,
+        tool_args={"tag": tag},
+        call_id=f"call-{index:02d}",
+        ctx=SimpleNamespace(is_aborted=False),
+        timeout=5.0,
+    )
+
+
+async def test_an_exclusive_call_is_a_barrier_for_later_reads() -> None:
+    """``[write(f), read(f)]`` must not answer from the pre-write file."""
+    log: list[str] = []
+    write = _RecordingTool("write", log, concurrency_safe=False)
+    read = _RecordingTool("read", log, concurrency_safe=True)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    executor.submit(_call(0, write, "write"))
+    executor.submit(_call(1, read, "read"))
+
+    results = await executor.collect()
+
+    assert log.index("end:write") < log.index("start:read")
+    assert [r.tool_name for r in results] == ["write", "read"]
+
+
+async def test_an_exclusive_call_waits_for_reads_the_model_placed_first() -> None:
+    """``[read(f), write(f)]`` must not write while the read is in flight."""
+    log: list[str] = []
+    read = _RecordingTool("read", log, concurrency_safe=True, delay=0.02)
+    write = _RecordingTool("write", log, concurrency_safe=False)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    executor.submit(_call(0, read, "read"))
+    executor.submit(_call(1, write, "write"))
+
+    await executor.collect()
+
+    assert log.index("end:read") < log.index("start:write")
+
+
+async def test_adjacent_reads_still_run_in_parallel() -> None:
+    """The barrier must not cost the overlap this executor exists for."""
+    log: list[str] = []
+    read = _RecordingTool("read", log, concurrency_safe=True, delay=0.05)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    for i in range(3):
+        executor.submit(_call(i, read, f"read{i}"))
+
+    started = asyncio.get_running_loop().time()
+    await executor.collect()
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert elapsed < 0.12, "three 50ms reads run in parallel should not serialise"
+    assert log[:3] == ["start:read0", "start:read1", "start:read2"]
+
+
+async def test_parallel_fan_out_is_bounded() -> None:
+    """One turn of web_fetch calls must not all hit the network at once."""
+    log: list[str] = []
+    in_flight = {"now": 0, "peak": 0}
+    fetch = _RecordingTool(
+        "web_fetch", log, concurrency_safe=True, delay=0.01, in_flight=in_flight
+    )
+
+    executor = StreamingToolExecutor(asyncio.Event(), max_parallel=3)
+    for i in range(12):
+        executor.submit(_call(i, fetch, f"fetch{i}"))
+
+    results = await executor.collect()
+
+    assert in_flight["peak"] <= 3
+    assert len(results) == 12
+    assert all(r.result is not None for r in results)
+
+
+async def test_a_failed_bash_cancels_the_calls_queued_after_it() -> None:
+    """The documented cascade must actually fire — bash is exclusive, and the
+    cancellation used to live on a concurrent-only path it never reached."""
+    log: list[str] = []
+    bash = _RecordingTool("bash", log, concurrency_safe=False, fails=True)
+    read = _RecordingTool("read", log, concurrency_safe=True)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    executor.submit(_call(0, bash, "bash"))
+    executor.submit(_call(1, read, "after"))
+
+    results = await executor.collect()
+
+    assert "start:after" not in log
+    assert results[1].aborted_by_sibling is True
+    assert isinstance(results[1].error, asyncio.CancelledError)
+
+
+async def test_a_failed_bash_keeps_results_the_model_asked_for_first() -> None:
+    """Earlier calls already ran under correct state; their results stand."""
+    log: list[str] = []
+    read = _RecordingTool("read", log, concurrency_safe=True)
+    bash = _RecordingTool("bash", log, concurrency_safe=False, fails=True)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    executor.submit(_call(0, read, "before"))
+    executor.submit(_call(1, bash, "bash"))
+
+    results = await executor.collect()
+
+    assert results[0].result is not None
+    assert results[0].result.output == "before"
+    assert results[0].aborted_by_sibling is False
+    assert results[1].error is not None
+
+
+async def test_results_come_back_in_model_order() -> None:
+    """Reporting order is independent of completion order."""
+    log: list[str] = []
+    slow = _RecordingTool("read", log, concurrency_safe=True, delay=0.04)
+    fast = _RecordingTool("grep", log, concurrency_safe=True, delay=0.0)
+
+    executor = StreamingToolExecutor(asyncio.Event())
+    executor.submit(_call(0, slow, "slow"))
+    executor.submit(_call(1, fast, "fast"))
+
+    results = await executor.collect()
+
+    assert [r.tool_args["tag"] for r in results] == ["slow", "fast"]
+    assert log.index("end:fast") < log.index("end:slow")
+
+
+async def test_external_abort_stops_work_that_has_not_started() -> None:
+    abort = asyncio.Event()
+    log: list[str] = []
+    read = _RecordingTool("read", log, concurrency_safe=True)
+
+    executor = StreamingToolExecutor(abort)
+    executor.submit(_call(0, read, "one"))
+    abort.set()
+    executor.submit(_call(1, read, "two"))
+
+    results = await executor.collect()
+
+    assert len(results) == 2
+    assert isinstance(results[1].error, asyncio.CancelledError)
+
+
+@pytest.mark.parametrize("max_parallel", [0, -5])
+async def test_a_nonsensical_limit_still_runs_one_at_a_time(max_parallel: int) -> None:
+    log: list[str] = []
+    in_flight = {"now": 0, "peak": 0}
+    read = _RecordingTool(
+        "read", log, concurrency_safe=True, delay=0.01, in_flight=in_flight
+    )
+
+    executor = StreamingToolExecutor(asyncio.Event(), max_parallel=max_parallel)
+    for i in range(3):
+        executor.submit(_call(i, read, f"read{i}"))
+    await executor.collect()
+
+    assert in_flight["peak"] == 1

--- a/backend/tests/test_session/test_tool_executor_ordering.py
+++ b/backend/tests/test_session/test_tool_executor_ordering.py
@@ -160,40 +160,47 @@ async def test_parallel_fan_out_is_bounded() -> None:
     assert all(r.result is not None for r in results)
 
 
-async def test_a_failed_bash_cancels_the_calls_queued_after_it() -> None:
-    """The documented cascade must actually fire — bash is exclusive, and the
-    cancellation used to live on a concurrent-only path it never reached."""
+async def test_a_failing_tool_does_not_cancel_the_calls_after_it() -> None:
+    """A non-zero exit is an answer, not a turn-ending failure.
+
+    A cascade keyed on tool failure was removed rather than kept: `BashTool`
+    reports any non-zero exit as `ToolResult.error`, and that is how `grep`,
+    `test` and `diff` say "no". Cancelling the rest of the turn on that would
+    discard work the model correctly queued.
+    """
     log: list[str] = []
-    bash = _RecordingTool("bash", log, concurrency_safe=False, fails=True)
+    failing = _RecordingTool("bash", log, concurrency_safe=False, fails=True)
     read = _RecordingTool("read", log, concurrency_safe=True)
 
     executor = StreamingToolExecutor(asyncio.Event())
-    executor.submit(_call(0, bash, "bash"))
+    executor.submit(_call(0, failing, "bash"))
     executor.submit(_call(1, read, "after"))
 
     results = await executor.collect()
 
-    assert "start:after" not in log
-    assert results[1].aborted_by_sibling is True
-    assert isinstance(results[1].error, asyncio.CancelledError)
+    assert "start:after" in log, "the later call must still run"
+    assert results[0].error is not None
+    assert results[1].result is not None
+    assert results[1].result.output == "after"
 
 
-async def test_a_failed_bash_keeps_results_the_model_asked_for_first() -> None:
-    """Earlier calls already ran under correct state; their results stand."""
+async def test_a_tool_that_finished_before_an_abort_keeps_its_result() -> None:
+    """Teardown must not relabel work that actually happened."""
+    abort = asyncio.Event()
     log: list[str] = []
     read = _RecordingTool("read", log, concurrency_safe=True)
-    bash = _RecordingTool("bash", log, concurrency_safe=False, fails=True)
 
-    executor = StreamingToolExecutor(asyncio.Event())
-    executor.submit(_call(0, read, "before"))
-    executor.submit(_call(1, bash, "bash"))
+    executor = StreamingToolExecutor(abort)
+    executor.submit(_call(0, read, "done"))
+    await asyncio.sleep(0)  # let it finish
+    while "end:done" not in log:
+        await asyncio.sleep(0)
+    abort.set()
 
     results = await executor.collect()
 
-    assert results[0].result is not None
-    assert results[0].result.output == "before"
-    assert results[0].aborted_by_sibling is False
-    assert results[1].error is not None
+    assert results[0].result is not None, "a completed tool must not become 'Aborted'"
+    assert results[0].result.output == "done"
 
 
 async def test_results_come_back_in_model_order() -> None:

--- a/backend/tests/test_tool/test_truncation_direction.py
+++ b/backend/tests/test_tool/test_truncation_direction.py
@@ -1,0 +1,64 @@
+"""Oversized output must keep the part that says what happened.
+
+`bash` and `code_execute` truncate from the head so the tail — where a failing
+run reports its error — survives. That only works if the exit status is at the
+tail too; as a header it was the first thing dropped, and `result.error` does
+not compensate because `_build_tool_persist_output` prefers `output` whenever
+it is non-empty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.tool.builtin.bash import BashTool
+from app.tool.truncation import MAX_LINES, truncate_output
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(
+        agent=SimpleNamespace(tools=[]),
+        workspace=str(tmp_path),
+        abort_event=asyncio.Event(),
+        is_aborted=False,
+    )
+
+
+@pytest.mark.parametrize("tool_cls", [BashTool])
+def test_the_failing_tools_truncate_from_the_tail(tool_cls) -> None:
+    assert tool_cls().truncation_direction == "tail"
+
+
+async def test_a_failing_command_with_huge_output_still_reports_its_exit_code(
+    tmp_path,
+) -> None:
+    """The model must not be told a failed command succeeded."""
+    tool = BashTool()
+    # Pure shell: the test host is not guaranteed a `python` on PATH.
+    noisy_failure = f"yes noise | head -n {MAX_LINES * 2}; exit 3"
+
+    result = await tool(
+        {"command": noisy_failure, "timeout": 60}, _ctx(tmp_path)
+    )
+
+    body = result.output or ""
+    assert len(body.splitlines()) < MAX_LINES * 2, "the output should have been truncated"
+    assert "Exit code: 3" in body, (
+        "tail truncation dropped the exit status, so the model sees only the "
+        "'tool call succeeded' hint for a command that failed"
+    )
+
+
+def test_tail_truncation_keeps_the_end_and_head_keeps_the_start() -> None:
+    """Pin the property the direction flag exists for."""
+    text = "\n".join(f"line{i}" for i in range(MAX_LINES * 2))
+
+    tail = truncate_output(text, direction="tail")
+    head = truncate_output(text, direction="head")
+
+    assert tail.truncated and head.truncated
+    assert text.splitlines()[-1] in tail.content
+    assert text.splitlines()[0] in head.content

--- a/backend/tests/test_utils/test_atomic_write.py
+++ b/backend/tests/test_utils/test_atomic_write.py
@@ -1,0 +1,113 @@
+"""Credential files must survive a crash and a concurrent writer."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from app.utils.atomic_write import SECRET_FILE_MODE, atomic_write_text, file_lock
+
+
+def test_write_creates_the_file_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / ".env"
+
+    atomic_write_text(target, "OPENYAK_API_KEY='sk-secret'\n")
+
+    assert target.read_text() == "OPENYAK_API_KEY='sk-secret'\n"
+    if sys.platform != "win32":
+        assert os.stat(target).st_mode & 0o777 == SECRET_FILE_MODE
+
+
+def test_a_secret_is_never_briefly_world_readable(tmp_path: Path) -> None:
+    """The mode is applied at open(), before any bytes are written."""
+    target = tmp_path / ".env"
+    atomic_write_text(target, "first")
+    if sys.platform != "win32":
+        os.chmod(target, 0o644)
+
+    atomic_write_text(target, "OPENYAK_API_KEY='sk-second'\n")
+
+    if sys.platform != "win32":
+        assert os.stat(target).st_mode & 0o777 == SECRET_FILE_MODE
+
+
+@pytest.mark.parametrize("failing_call", ["fsync", "replace"])
+def test_a_failed_write_leaves_the_previous_file_intact(
+    tmp_path: Path, monkeypatch, failing_call: str
+) -> None:
+    """A partial write must never be observable — this is the whole point.
+
+    Both halves are covered: the disk filling up while the new content is
+    flushed, and the rename itself failing.
+    """
+    target = tmp_path / ".env"
+    atomic_write_text(target, "OPENYAK_API_KEY='sk-original'\n")
+
+    def explode(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, failing_call, explode)
+
+    with pytest.raises(OSError):
+        atomic_write_text(target, "OPENYAK_API_KEY='sk-replacement'\n")
+
+    monkeypatch.undo()
+    assert target.read_text() == "OPENYAK_API_KEY='sk-original'\n"
+    assert [p.name for p in tmp_path.iterdir()] == [".env"]
+
+
+def test_no_temporary_files_are_left_behind(tmp_path: Path) -> None:
+    target = tmp_path / ".env"
+    atomic_write_text(target, "a=1\n")
+    atomic_write_text(target, "a=2\n")
+
+    assert [p.name for p in tmp_path.iterdir()] == [".env"]
+
+
+def test_concurrent_read_modify_writes_do_not_lose_keys(tmp_path: Path) -> None:
+    """Two threads adding different keys must both survive.
+
+    An unlocked read → splice → write loses whichever write lands second.
+    """
+    target = tmp_path / ".env"
+    atomic_write_text(target, "")
+    barrier = threading.Barrier(8)
+
+    def add_key(index: int) -> None:
+        barrier.wait()
+        for _ in range(20):
+            with file_lock(target):
+                lines = [
+                    line for line in target.read_text().splitlines() if line.strip()
+                ]
+                lines.append(f"KEY_{index}='v'")
+                # De-duplicate the way the real writer does.
+                seen: dict[str, str] = {}
+                for line in lines:
+                    seen[line.split("=", 1)[0]] = line
+                atomic_write_text(target, "\n".join(seen.values()) + "\n")
+
+    threads = [threading.Thread(target=add_key, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    written = {
+        line.split("=", 1)[0] for line in target.read_text().splitlines() if line.strip()
+    }
+    assert written == {f"KEY_{i}" for i in range(8)}
+
+
+def test_json_stores_round_trip(tmp_path: Path) -> None:
+    target = tmp_path / "mcp-tokens.json"
+    payload = {"slack": {"access_token": "xoxb-1", "expires_at": 1.5}}
+
+    atomic_write_text(target, json.dumps(payload, indent=2))
+
+    assert json.loads(target.read_text()) == payload

--- a/backend/tests/test_utils/test_atomic_write.py
+++ b/backend/tests/test_utils/test_atomic_write.py
@@ -20,7 +20,11 @@ def test_write_creates_the_file_owner_only(tmp_path: Path) -> None:
 
     assert target.read_text() == "OPENYAK_API_KEY='sk-secret'\n"
     if sys.platform != "win32":
-        assert os.stat(target).st_mode & 0o777 == SECRET_FILE_MODE
+        # A literal, not the module's own constant: `mode == mode` pins that the
+        # writer honours whatever is declared, not that the file holding every
+        # BYOK key is unreadable by other accounts on the machine.
+        assert os.stat(target).st_mode & 0o777 == 0o600
+        assert SECRET_FILE_MODE == 0o600, "the declared default must stay owner-only"
 
 
 def test_a_secret_is_never_briefly_world_readable(tmp_path: Path) -> None:
@@ -33,7 +37,7 @@ def test_a_secret_is_never_briefly_world_readable(tmp_path: Path) -> None:
     atomic_write_text(target, "OPENYAK_API_KEY='sk-second'\n")
 
     if sys.platform != "win32":
-        assert os.stat(target).st_mode & 0o777 == SECRET_FILE_MODE
+        assert os.stat(target).st_mode & 0o777 == 0o600
 
 
 @pytest.mark.parametrize("failing_call", ["fsync", "replace"])


### PR DESCRIPTION
Read [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) subsystem by subsystem against OpenYak, asking of each what invariant it holds that we do not. Eight of the answers were bugs on our side. Every fix ships with a regression test that was verified to fail without it.

## The defects

**Retry was dead code for ~25 of 27 providers.** `OpenAICompatProvider` caught every exception and yielded it as a `type="error"` chunk; `_stream_llm_with_retry` handled that chunk by returning out of its own retry loop. So backoff, the 429/5xx budget, and reactive compaction never ran for Generic OpenAI, OpenRouter, Ollama, Rapid-MLX, or the ChatGPT subscription — a 429 simply ended the session. Only the two native-SDK providers retried anything. Providers now raise; the chunk path remains as a defensive net that re-raises.

**Tools executed out of model order.** Every concurrency-safe call ran before every exclusive one, then results were sorted back into submission order — so `[write(f), read(f)]` answered from the pre-write file while the transcript looked correct. Exclusive calls are barriers now, adjacent safe calls run in parallel up to `max_parallel_tool_calls` (previously unbounded), and `SIBLING_ABORT_TOOLS` fires for the first time.

**Compaction destroyed the user's tool output.** Pruning overwrote the stored output with `[truncated]` even though `get_message_history_for_llm` already substitutes that from the `time_compacted` flag — identical prompt, and the only copy of the result gone. It also accepted summaries that hit the output cap or were larger than the history they anchor past, and a compaction that freed nothing reset its own circuit breaker.

**Subagents inherited `allow *`.** The parent handed down its fully merged ruleset, which leads with the global `allow *`, and a child layers inherited rules *after* its own under last-match-wins. Only a parent's denials propagate now, so a Plan session cannot delegate around its read-only ceiling.

**An agent with no `permissions` block was refused every tool.** `evaluate` returns `deny` when no rule matches, so reading an agent's ruleset in isolation denies everything it does not mention — the default shape of a user-defined agent in `.openyak/agents/*.md`. `agent_verdict` reads that layer over the global defaults, the way it is actually stacked.

**Credential files were rewritten non-atomically.** `.env`, `channels.json` and the MCP token store were whole-file `write_text` under no lock — and the generation hot path writes `.env` on every Ollama call. Two concurrent writes lost each other; an interrupted one lost every key.

**Two policy surfaces were unreachable.** `run_before_tool_exec` had zero callers, so loop detection's warn stage had never fired and any policy middleware a contributor added would have been silently inert. `after_llm_response` was never implemented or called and is removed.

**Cached tokens were billed at zero.** `cache_read`/`cache_write` were absent from the cost calculation entirely. OpenRouter's catalog already publishes the real per-model rates.

Smaller: `max_tokens` was an overflow substring, so a 400 naming the parameter entered a compaction loop that cannot fix it; `bash` and `code_execute` keep the tail of oversized output, where the error is; tool errors go through the truncator; `ToolContext.ask` defaults closed.

## On the review rounds

The first two rounds were verified inadequately and the later commits say so.

Round one was checked with `pytest tests/`, which overrides `testpaths` in `pyproject.toml` and skips `../evals/tests` — the only suite that drives the real agent loop. It reported green while every tool call raised `UnboundLocalError`. CI runs bare `pytest` and would have caught it.

Round two added tests that did not drive production code: the permission tests reimplemented both merge functions and asserted against the copies, and the ordering test built its exclusive tool with no delay, so awaiting it never yielded to the event loop and the race it was named for could not occur. Both fixes were revertible with the suite green.

Round three rewrote those to drive the real code and fixed what they had been hiding — a name collision that stored a dict where a `ToolAction` was declared, a loop warning that landed on the wrong tool call, completed tools recorded as cancelled, and a sibling-abort cascade that still could not fire because `ToolDefinition.__call__` swallows what tools raise.

Each of the eight fixes has since been individually reverted and confirmed to turn its test red.

## Verification

`1437 passed, 52 skipped` from `backend/` with the config's own `testpaths` (unit + evals), plus `test_code_execute.py`, which CI excludes.

## Deliberately not in scope

Prompt-cache prefix restructuring (moves mutable facts out of the system prompt; changes transcript shape and wants a fresh read of Anthropic's caching docs), spill-to-disk for oversized tool output, `bash` environment scrubbing (unsafe without an explicit forwarding mechanism — it would break `gh`, `aws`, `npm`, `docker`), reusing the session's system blocks for the compaction call, MCP auto-reconnect, and killable subprocesses.